### PR TITLE
Update Scene.py to change a misleading Docstring.

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -178,23 +178,25 @@ class Scene(Container):
 
     def set_camera_pixel_array(self, pixel_array):
         """
-        Sets the camera to display a Pixel Array
-        
+        Sets the camera's pixel array to the passed pixel
+        array. Does not impact what the scene currently displays.
+
         Parameters
         ----------
         pixel_array: Union[np.ndarray,list,tuple]
-            Pixel array to set the camera to display
+            Pixel array
         """
         self.camera.set_pixel_array(pixel_array)
 
     def set_camera_background(self, background):
         """
         Sets the camera to display a Pixel Array
+        in the background.
         
         Parameters
         ----------
         background: Union[np.ndarray,list,tuple]
-            
+            The Pixel Array of the background.
         """
         self.camera.set_background(background)
 


### PR DESCRIPTION
Scene.set_camera_pixel_array() apparently does not change what the scene displays. According changes to the docstring have been made.

Thanks for contributing to manim!

**Please ensure that your pull request works with the latest version of manim.**
You should also include:

1. The motivation for making this change (or link the relevant issues)
2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) This is rather informal at the moment, but
the goal is to show us how you know the pull request works as intended.
