### PR TITLE
More descriptive error for INVALID_NUMBER_MESSAGE

### DIFF
--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -108,7 +108,7 @@ CHOOSE_NUMBER_MESSAGE = """
 Choose number corresponding to desired scene/arguments.
 (Use comma separated list for multiple entries)
 Choice(s): """
-INVALID_NUMBER_MESSAGE = "Fine then, if you don't want to give a valid number I'll just quit"
+INVALID_NUMBER_MESSAGE = "Invalid scene numbers have been specified. Aborting."
 
 NO_SCENE_MESSAGE = """
    There are no scenes inside that module


### PR DESCRIPTION
A more descriptive error for INVALID_NUMBER_MESSAGE so that people who are new to manim aren't confused.