### PR TITLE
Restore --save_pngs

### DIFF
--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -6,6 +6,7 @@ import os
 import _thread as thread
 from time import sleep
 import datetime
+from PIL import Image
 
 import manimlib.constants as consts
 from manimlib.constants import FFMPEG_BIN
@@ -37,7 +38,6 @@ class SceneFileWriter(object):
     """
     CONFIG = {
         "write_to_movie": False,
-        # TODO, save_pngs is doing nothing
         "save_pngs": False,
         "png_mode": "RGBA",
         "save_last_frame": False,
@@ -56,6 +56,7 @@ class SceneFileWriter(object):
         self.stream_lock = False
         self.init_output_directories()
         self.init_audio()
+        self.frame_count = 0
 
     # Output directories and files
     def init_output_directories(self):
@@ -66,7 +67,7 @@ class SceneFileWriter(object):
         """
         module_directory = self.output_directory or self.get_default_module_directory()
         scene_name = self.file_name or self.get_default_scene_name()
-        if self.save_last_frame:
+        if self.save_last_frame or self.save_pngs:
             if consts.VIDEO_DIR != "":
                 image_dir = guarantee_existence(os.path.join(
                     consts.VIDEO_DIR,
@@ -334,6 +335,10 @@ class SceneFileWriter(object):
         """
         if self.write_to_movie:
             self.writing_process.stdin.write(frame.tostring())
+        if self.save_pngs:
+            path, extension = os.path.splitext(self.image_file_path)
+            Image.fromarray(frame).save(f'{path}{self.frame_count}{extension}')
+            self.frame_count += 1
 
     def save_final_image(self, image):
         """


### PR DESCRIPTION
Causes `--save_pngs` to save frames to `/media/videos/<module name>/images/<scene name><frame number>.png`. The paths here are a mess, but they can't really be improved on effectively until  we make some progress on #12.