### PR TITLE
Small improvements to Matrix mobject

### DIFF
--- a/manimlib/mobject/matrix.py
+++ b/manimlib/mobject/matrix.py
@@ -128,10 +128,12 @@ class Matrix(VMobject):
         return self
 
     def get_rows(self):
-        """
-        Return rows of the matrix as VGroups
-        parameters: none
-        return value: array of VGroups, each VGroup containing a row 
+        """Return rows of the matrix as VGroups
+        
+        Returns
+        --------
+        List[:class:`~.VGroup`]
+            Each VGroup contains a row of the matrix.
         """
         return VGroup(*[
             VGroup(*self.mob_matrix[i, :])
@@ -139,10 +141,17 @@ class Matrix(VMobject):
         ])
 
     def set_row_colors(self, *colors):
-        """
-        Set individual colors for each row of the matrix
-        parameters: list of colors, one color per row
-        return value: matrix object itself
+        """Set individual colors for each row of the matrix
+        
+        Parameters
+        ----------
+        colors : str
+            The list of colors; each color specified corresponds to a row.
+        
+        Returns
+        -------
+        :class:`Matrix`
+            The current matrix object (self).
         """
         rows = self.get_rows()
         for color, row in zip(colors, rows):

--- a/manimlib/mobject/matrix.py
+++ b/manimlib/mobject/matrix.py
@@ -128,12 +128,18 @@ class Matrix(VMobject):
         return self
 
     def get_rows(self):
+        """
+        Return rows of the matrix as VGroups
+        """
         return VGroup(*[
             VGroup(*self.mob_matrix[i, :])
             for i in range(self.mob_matrix.shape[1])
         ])
 
     def set_row_colors(self, *colors):
+        """
+        Set individual colors for each row of the matrix
+        """
         rows = self.get_rows()
         for color, row in zip(colors, rows):
             row.set_color(color)

--- a/manimlib/mobject/matrix.py
+++ b/manimlib/mobject/matrix.py
@@ -63,6 +63,8 @@ class Matrix(VMobject):
         "element_to_mobject": TexMobject,
         "element_to_mobject_config": {},
         "element_alignment_corner": DR,
+        "left_bracket": "\\big[",
+        "right_bracket": "\\big]",
     }
 
     def __init__(self, matrix, **kwargs):
@@ -76,7 +78,7 @@ class Matrix(VMobject):
         self.organize_mob_matrix(mob_matrix)
         self.elements = VGroup(*mob_matrix.flatten())
         self.add(self.elements)
-        self.add_brackets()
+        self.add_brackets(self.left_bracket,self.right_bracket)
         self.center()
         self.mob_matrix = mob_matrix
         if self.add_background_rectangles_to_entries:
@@ -100,8 +102,8 @@ class Matrix(VMobject):
                 )
         return self
 
-    def add_brackets(self):
-        bracket_pair = TexMobject("\\big[", "\\big]")
+    def add_brackets(self, left, right):
+        bracket_pair = TexMobject(left, right)
         bracket_pair.scale(2)
         bracket_pair.stretch_to_fit_height(
             self.get_height() + 2 * self.bracket_v_buff

--- a/manimlib/mobject/matrix.py
+++ b/manimlib/mobject/matrix.py
@@ -102,7 +102,7 @@ class Matrix(VMobject):
                 )
         return self
 
-    def add_brackets(self, left, right):
+    def add_brackets(self, left = "\\big[", right = "\\big]"):
         bracket_pair = TexMobject(left, right)
         bracket_pair.scale(2)
         bracket_pair.stretch_to_fit_height(

--- a/manimlib/mobject/matrix.py
+++ b/manimlib/mobject/matrix.py
@@ -130,6 +130,8 @@ class Matrix(VMobject):
     def get_rows(self):
         """
         Return rows of the matrix as VGroups
+        parameters: none
+        return value: array of VGroups, each VGroup containing a row 
         """
         return VGroup(*[
             VGroup(*self.mob_matrix[i, :])
@@ -139,6 +141,8 @@ class Matrix(VMobject):
     def set_row_colors(self, *colors):
         """
         Set individual colors for each row of the matrix
+        parameters: list of colors, one color per row
+        return value: matrix object itself
         """
         rows = self.get_rows()
         for color, row in zip(colors, rows):

--- a/manimlib/mobject/matrix.py
+++ b/manimlib/mobject/matrix.py
@@ -145,7 +145,7 @@ class Matrix(VMobject):
         
         Parameters
         ----------
-        colors : str
+        colors : :class:`str`
             The list of colors; each color specified corresponds to a row.
         
         Returns

--- a/manimlib/mobject/matrix.py
+++ b/manimlib/mobject/matrix.py
@@ -127,6 +127,18 @@ class Matrix(VMobject):
             column.set_color(color)
         return self
 
+    def get_rows(self):
+        return VGroup(*[
+            VGroup(*self.mob_matrix[i, :])
+            for i in range(self.mob_matrix.shape[1])
+        ])
+
+    def set_row_colors(self, *colors):
+        rows = self.get_rows()
+        for color, row in zip(colors, rows):
+            row.set_color(color)
+        return self
+
     def add_background_to_entries(self):
         for mob in self.get_entries():
             mob.add_background_rectangle()


### PR DESCRIPTION
easy customization of the left and right bracket of a matrix
- added attributes `left_bracket` and `right_bracket` to `Matrix` class, default is to use old hard-coded brackets
- changed `add_brackets()` to accept parameters specifying left and right bracket to use
- changed `__init__()` in order to call `add_brackets` with the newly introduced parameters

set row colors to a matrix mobject, similar function exists for columns
- added method `get_rows()` similar to `get_columns()`, returning the rows of a matrix as a `VGroup`
- added method `set_row_colors()` similiar to `set_column_colors()`
