### PR TITLE
removed keywords from -r flag

### DIFF
--- a/manim/config.py
+++ b/manim/config.py
@@ -209,16 +209,7 @@ def get_camera_configuration(args):
 
     # If the resolution was passed in via -r
     if args.resolution:
-        if args.resolution.lower() == "low":
-            camera_config.update(constants.LOW_QUALITY_CAMERA_CONFIG)
-        elif args.resolution.lower() == "medium":
-            camera_config.update(constants.MEDIUM_QUALITY_CAMERA_CONFIG)
-        elif args.resolution.lower() == "high":
-            camera_config.update(constants.HIGH_QUALITY_CAMERA_CONFIG)
-        elif args.resolution.lower() == "4K":
-            camera_config.update(constants.FOURK_CAMERA_CONFIG)
-
-        elif "," in args.resolution:
+        if  "," in args.resolution:
             height_str, width_str = args.resolution.split(",")
             height = int(height_str)
             width = int(width_str)


### PR DESCRIPTION
I removed the possibility to add keywords like "`medium`", "`low`" etc... from the `-r` flag since you can do exactly the same but with for example `-l` for `"low"` or `--high_quality`.