### PR TITLE
Pycairo install Made Easy Using single Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Before installing `manim-community`, there are some additional dependencies that
 6. Alternatively, Running the command below installs pycairo. This needs to be an elevated command prompt like Powershell.
 
    ```powershell
-   (Invoke-WebRequest -Uri https://gist.githubusercontent.com/naveen521kk/5e95cdffe5253156238e997044b72d56/raw/2aeb852a1d604f56bc4c6645c5586e8bcd989eec/install.py -UseBasicParsing).Content | python
+   (Invoke-WebRequest -Uri https://raw.githubusercontent.com/ManimCommunity/manim/master/scripts/pycairoInstall.py -UseBasicParsing).Content | python
    ```
 
    

--- a/README.md
+++ b/README.md
@@ -56,8 +56,18 @@ Before installing `manim-community`, there are some additional dependencies that
 > win_amd64 corresponds to 64-bit machines, win32 corresponds to 32-bit machines
 
 3. Open up your command prompt by hitting the Win key and typing `cmd`
+
 4. Enter the directory where you install cairo by typing `cd C:\path\to\cairo` with the path being where you downloaded the `.whl` file
+
 5. Finally, run `pip3 install (cairo-file).whl`, where the file the appropriate name of the `.whl` file.
+
+6. Alternatively, Running the command below installs pycairo. This needs to be an elevated command prompt like Powershell.
+
+   ```powershell
+   (Invoke-WebRequest -Uri https://gist.githubusercontent.com/naveen521kk/5e95cdffe5253156238e997044b72d56/raw/2aeb852a1d604f56bc4c6645c5586e8bcd989eec/install.py -UseBasicParsing).Content | python
+   ```
+
+   
 
 #### FFmpeg Installation
 1. To install `ffmpeg` and add it to your PATH, install [Chocolatey](https://chocolatey.org/) and run `choco install ffmpeg`

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Before installing `manim-community`, there are some additional dependencies that
 6. Alternatively, Running the command below installs pycairo. This needs to be an elevated command prompt like Powershell.
 
    ```powershell
-   (Invoke-WebRequest -Uri https://raw.githubusercontent.com/ManimCommunity/manim/master/scripts/pycairoInstall.py -UseBasicParsing).Content | python
+   (Invoke-WebRequest -Uri https://raw.githubusercontent.com/ManimCommunity/manim/master/scripts/pycairoInstall.py -UseBasicParsing).Content | py -3
    ```
 
    

--- a/Scripts/pycairoInstall.py
+++ b/Scripts/pycairoInstall.py
@@ -1,0 +1,45 @@
+#This script install pycairo.
+import platform
+import os
+import sys
+import urllib.request
+
+#python 3.7 32-bit
+#pycairo‑1.19.1‑cp37‑cp37m‑win32.whl
+if 'Windows' in platform.system():
+    if sys.version[:3]=='3.7' and platform.machine()=='x86':
+        urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp37-cp37m-win32.whl", "pycairo-1.19.1-cp37-cp37m-win32.whl")
+        print("Sucessfully downloaded Cairo for your system")
+        print("Installing Cairo")
+        os.system("pip install pycairo-1.19.1-cp37-cp37m-win32.whl")
+        os.remove("pycairo-1.19.1-cp37-cp37m-win32.whl")
+        print("Succesfully installed Cairo")
+
+    #python 3.7 AMD64(64-bit)
+    #pycairo-1.19.1-cp37-cp37m-win_amd64.whl
+    elif sys.version[:3]=='3.7' and platform.machine()=='AMD64':
+        urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp37-cp37m-win_amd64.whl", "pycairo-1.19.1-cp37-cp37m-win_amd64.whl")
+        print("Sucessfully downloaded Cairo for your system")
+        print("Installing Cairo")
+        os.system("pip3 install pycairo-1.19.1-cp37-cp37m-win_amd64.whl")
+        os.remove("pycairo-1.19.1-cp37-cp37m-win_amd64.whl")
+        print("Succesfully installed Cairo")
+        
+    #python 3.8 32-bit
+    #pycairo-1.19.1-cp38-cp38-win32.whl
+    elif sys.version[:3]=='3.8' and platform.machine()=='x86':
+        urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp38-cp38-win32.whl", "pycairo-1.19.1-cp38-cp38-win32.whl")
+        print("Sucessfully downloaded Cairo for your system")
+        print("Installing Cairo")
+        os.system("pip3 install pycairo-1.19.1-cp38-cp38-win32.whl")
+        os.remove("pycairo-1.19.1-cp38-cp38-win32.whl")
+        print("Succesfully installed Cairo")   
+    #python 3.8 AMD64
+    #pycairo-1.19.1-cp38-cp38-win_amd64.whl
+    elif sys.version[:3]=='3.8' and platform.machine()=='AMD64':
+        urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp38-cp38-win_amd64.whl", "pycairo-1.19.1-cp38-cp38-win_amd64.whl")
+        print("Sucessfully downloaded Cairo for your system")
+        print("Installing Cairo")
+        os.system("pip install pycairo-1.19.1-cp38-cp38-win_amd64.whl")
+        os.remove("pycairo-1.19.1-cp38-cp38-win_amd64.whl")
+        print("Succesfully installed Cairo")       

--- a/Scripts/pycairoInstall.py
+++ b/Scripts/pycairoInstall.py
@@ -1,13 +1,25 @@
-#This script install pycairo.
-
 import platform
 import os
 import sys
 import urllib.request
 
 if 'Windows' in platform.system():
+    #In case the python version is 3.6 and the system is 32-bit, try pycairo‑1.19.1‑cp37‑cp37m‑win32.whl version of cairo
+    if sys.version[:3]=='3.6' and platform.machine()=='x86':
+        urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp36-cp36m-win32.whl", "pycairo-1.19.1-cp36-cp36m-win32.whl")
+        os.system("pip install pycairo-1.19.1-cp36-cp36m-win32.whl")
+        os.remove("pycairo-1.19.1-cp37-cp37m-win32.whl")
+
+    #In case the python version is 3.6 and the system is 64-bit, try pycairo‑1.19.1‑cp37‑cp37m‑win32.whl version of cairo
+    elif sys.version[:3]=='3.6' and platform.machine()=='AMD64':
+        urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp36-cp36m-win_amd64.whl", "pycairo-1.19.1-cp36-cp36m-win_amd64.whl")
+        print("Sucessfully downloaded Cairo for your system")
+        print("Installing Cairo")
+        os.system("pip install pycairo-1.19.1-cp36-cp36m-win_amd64.whl")
+        os.remove("pycairo-1.19.1-cp36-cp36m-win_amd64.whl")
+    
     #In case the python version is 3.7 and the system is 32-bit, try pycairo‑1.19.1‑cp37‑cp37m‑win32.whl version of cairo
-    if sys.version[:3]=='3.7' and platform.machine()=='x86':
+    elif sys.version[:3]=='3.7' and platform.machine()=='x86':
         urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp37-cp37m-win32.whl", "pycairo-1.19.1-cp37-cp37m-win32.whl")
         print("Sucessfully downloaded Cairo for your system")
         print("Installing Cairo")
@@ -36,4 +48,4 @@ if 'Windows' in platform.system():
         print("Sucessfully downloaded Cairo for your system")
         print("Installing Cairo")
         os.system("pip install pycairo-1.19.1-cp38-cp38-win_amd64.whl")
-        os.remove("pycairo-1.19.1-cp38-cp38-win_amd64.whl")     
+        os.remove("pycairo-1.19.1-cp38-cp38-win_amd64.whl")   

--- a/Scripts/pycairoInstall.py
+++ b/Scripts/pycairoInstall.py
@@ -1,12 +1,12 @@
 #This script install pycairo.
+
 import platform
 import os
 import sys
 import urllib.request
 
-#python 3.7 32-bit
-#pycairo‑1.19.1‑cp37‑cp37m‑win32.whl
 if 'Windows' in platform.system():
+    #In case the python version is 3.7 and the system is 32-bit, try pycairo‑1.19.1‑cp37‑cp37m‑win32.whl version of cairo
     if sys.version[:3]=='3.7' and platform.machine()=='x86':
         urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp37-cp37m-win32.whl", "pycairo-1.19.1-cp37-cp37m-win32.whl")
         print("Sucessfully downloaded Cairo for your system")
@@ -15,8 +15,7 @@ if 'Windows' in platform.system():
         os.remove("pycairo-1.19.1-cp37-cp37m-win32.whl")
         print("Succesfully installed Cairo")
 
-    #python 3.7 AMD64(64-bit)
-    #pycairo-1.19.1-cp37-cp37m-win_amd64.whl
+    #In case the python version is 3.7 and the system is AMD64, try pycairo-1.19.1-cp37-cp37m-win_amd64.whl version of cairo
     elif sys.version[:3]=='3.7' and platform.machine()=='AMD64':
         urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp37-cp37m-win_amd64.whl", "pycairo-1.19.1-cp37-cp37m-win_amd64.whl")
         print("Sucessfully downloaded Cairo for your system")
@@ -25,17 +24,16 @@ if 'Windows' in platform.system():
         os.remove("pycairo-1.19.1-cp37-cp37m-win_amd64.whl")
         print("Succesfully installed Cairo")
         
-    #python 3.8 32-bit
-    #pycairo-1.19.1-cp38-cp38-win32.whl
+    #In case the python version is 3.8 and the system is 32-bit, try pycairo-1.19.1-cp38-cp38-win32.whl version of cairo
     elif sys.version[:3]=='3.8' and platform.machine()=='x86':
         urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp38-cp38-win32.whl", "pycairo-1.19.1-cp38-cp38-win32.whl")
         print("Sucessfully downloaded Cairo for your system")
         print("Installing Cairo")
         os.system("pip3 install pycairo-1.19.1-cp38-cp38-win32.whl")
         os.remove("pycairo-1.19.1-cp38-cp38-win32.whl")
-        print("Succesfully installed Cairo")   
-    #python 3.8 AMD64
-    #pycairo-1.19.1-cp38-cp38-win_amd64.whl
+        print("Succesfully installed Cairo")
+        
+    #In case the python version is 3.8 and the system is AMD64, try pycairo-1.19.1-cp38-cp38-win_amd64.whl version of cairo
     elif sys.version[:3]=='3.8' and platform.machine()=='AMD64':
         urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp38-cp38-win_amd64.whl", "pycairo-1.19.1-cp38-cp38-win_amd64.whl")
         print("Sucessfully downloaded Cairo for your system")

--- a/Scripts/pycairoInstall.py
+++ b/Scripts/pycairoInstall.py
@@ -20,7 +20,7 @@ if 'Windows' in platform.system():
         urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp37-cp37m-win_amd64.whl", "pycairo-1.19.1-cp37-cp37m-win_amd64.whl")
         print("Sucessfully downloaded Cairo for your system")
         print("Installing Cairo")
-        os.system("pip3 install pycairo-1.19.1-cp37-cp37m-win_amd64.whl")
+        os.system("pip install pycairo-1.19.1-cp37-cp37m-win_amd64.whl")
         os.remove("pycairo-1.19.1-cp37-cp37m-win_amd64.whl")
         print("Succesfully installed Cairo")
         
@@ -29,7 +29,7 @@ if 'Windows' in platform.system():
         urllib.request.urlretrieve("https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/pycairo-1.19.1-cp38-cp38-win32.whl", "pycairo-1.19.1-cp38-cp38-win32.whl")
         print("Sucessfully downloaded Cairo for your system")
         print("Installing Cairo")
-        os.system("pip3 install pycairo-1.19.1-cp38-cp38-win32.whl")
+        os.system("pip install pycairo-1.19.1-cp38-cp38-win32.whl")
         os.remove("pycairo-1.19.1-cp38-cp38-win32.whl")
         print("Succesfully installed Cairo")
         

--- a/Scripts/pycairoInstall.py
+++ b/Scripts/pycairoInstall.py
@@ -13,7 +13,6 @@ if 'Windows' in platform.system():
         print("Installing Cairo")
         os.system("pip install pycairo-1.19.1-cp37-cp37m-win32.whl")
         os.remove("pycairo-1.19.1-cp37-cp37m-win32.whl")
-        print("Succesfully installed Cairo")
 
     #In case the python version is 3.7 and the system is AMD64, try pycairo-1.19.1-cp37-cp37m-win_amd64.whl version of cairo
     elif sys.version[:3]=='3.7' and platform.machine()=='AMD64':
@@ -22,7 +21,6 @@ if 'Windows' in platform.system():
         print("Installing Cairo")
         os.system("pip install pycairo-1.19.1-cp37-cp37m-win_amd64.whl")
         os.remove("pycairo-1.19.1-cp37-cp37m-win_amd64.whl")
-        print("Succesfully installed Cairo")
         
     #In case the python version is 3.8 and the system is 32-bit, try pycairo-1.19.1-cp38-cp38-win32.whl version of cairo
     elif sys.version[:3]=='3.8' and platform.machine()=='x86':
@@ -31,7 +29,6 @@ if 'Windows' in platform.system():
         print("Installing Cairo")
         os.system("pip install pycairo-1.19.1-cp38-cp38-win32.whl")
         os.remove("pycairo-1.19.1-cp38-cp38-win32.whl")
-        print("Succesfully installed Cairo")
         
     #In case the python version is 3.8 and the system is AMD64, try pycairo-1.19.1-cp38-cp38-win_amd64.whl version of cairo
     elif sys.version[:3]=='3.8' and platform.machine()=='AMD64':
@@ -39,5 +36,4 @@ if 'Windows' in platform.system():
         print("Sucessfully downloaded Cairo for your system")
         print("Installing Cairo")
         os.system("pip install pycairo-1.19.1-cp38-cp38-win_amd64.whl")
-        os.remove("pycairo-1.19.1-cp38-cp38-win_amd64.whl")
-        print("Succesfully installed Cairo")       
+        os.remove("pycairo-1.19.1-cp38-cp38-win_amd64.whl")     

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
         ]
     },
     install_requires=[
-        "colour",
         "argparse",
         "colour",
         "numpy",


### PR DESCRIPTION
Fixed Pycairo installation for windows user.
```powershell
(Invoke-WebRequest -Uri https://gist.githubusercontent.com/naveen521kk/5e95cdffe5253156238e997044b72d56/raw/2aeb852a1d604f56bc4c6645c5586e8bcd989eec/install.py -UseBasicParsing).Content | python
```
Running above command installs `pycairo`. Supports Windows7+ with elevated Command Prompt like Powershell. Further it supports, python 3.7 and 3.8 and x86 PC and AMD64 PC. 
Fix #14 .