### PR TITLE
Remove unnecessary packages from tex_template.tex

### DIFF
--- a/manim/tex_template.tex
+++ b/manim/tex_template.tex
@@ -13,6 +13,7 @@
 \usepackage{calligra}
 \usepackage{wasysym}
 \usepackage{ragged2e}
+\usepackage{physics}
 \usepackage{microtype}
 \DisableLigatures{encoding = *, family = * }
 %\usepackage[UTF8]{ctex}

--- a/manim/tex_template.tex
+++ b/manim/tex_template.tex
@@ -13,7 +13,6 @@
 \usepackage{calligra}
 \usepackage{wasysym}
 \usepackage{ragged2e}
-\usepackage{xcolor}
 \usepackage{microtype}
 \DisableLigatures{encoding = *, family = * }
 %\usepackage[UTF8]{ctex}

--- a/manim/tex_template.tex
+++ b/manim/tex_template.tex
@@ -5,7 +5,6 @@
 \usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \usepackage{amssymb}
-\usepackage{dsfont}
 \usepackage{setspace}
 \usepackage{tipa}
 \usepackage{relsize}
@@ -14,7 +13,6 @@
 \usepackage{calligra}
 \usepackage{wasysym}
 \usepackage{ragged2e}
-\usepackage{physics}
 \usepackage{xcolor}
 \usepackage{microtype}
 \DisableLigatures{encoding = *, family = * }


### PR DESCRIPTION
With these modifications we avoid having to install the `texlive-fonts-extra` package.