### PR TITLE
Fix missing spaces and capitalize some words in usage message

### DIFF
--- a/manim/config.py
+++ b/manim/config.py
@@ -16,7 +16,7 @@ def parse_cli():
         parser = argparse.ArgumentParser()
         parser.add_argument(
             "file",
-            help="path to file holding the python code for the scene",
+            help="Path to file holding the python code for the scene",
         )
         parser.add_argument(
             "scene_names",
@@ -96,14 +96,14 @@ def parse_cli():
         parser.add_argument(
             "-o", "--file_name",
             help="Specify the name of the output file, if"
-                 "it should be different from the scene class name",
+                 " it should be different from the scene class name",
         )
         parser.add_argument(
             "-n", "--start_at_animation_number",
             help="Start rendering not from the first animation, but"
-                 "from another, specified by its index.  If you pass"
-                 "in two comma separated values, e.g. \"3,6\", it will end"
-                 "the rendering at the second value",
+                 " from another, specified by its index.  If you pass"
+                 " in two comma separated values, e.g. \"3,6\", it will end"
+                 " the rendering at the second value",
         )
         parser.add_argument(
             "-r", "--resolution",
@@ -125,20 +125,20 @@ def parse_cli():
         )
         parser.add_argument(
             "--media_dir",
-            help="directory to write media",
+            help="Directory to write media",
         )
         video_group = parser.add_mutually_exclusive_group()
         video_group.add_argument(
             "--video_dir",
-            help="directory to write file tree for video",
+            help="Directory to write file tree for video",
         )
         parser.add_argument(
             "--tex_dir",
-            help="directory to write tex",
+            help="Directory to write tex",
         )
         parser.add_argument(
             "--text_dir",
-            help="directory to write text",
+            help="Directory to write text",
         )
         return parser.parse_args()
     except argparse.ArgumentError as err:


### PR DESCRIPTION
Hey, this is a really simple PR but this was bothering me. There were some missing spaces between words in the usage message because someone wrote some of them using string concatenation but didn't include the space. Also, some of the help descriptions were capitalized where others were not, so I added some capitals.