### PR TITLE
ArcBetweenPoints fix/enhancement

### DIFF
--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -214,6 +214,7 @@ class Arc(TipableVMobject):
     def __init__(self, start_angle=0, angle=TAU / 4, **kwargs):
         self.start_angle = start_angle
         self.angle = angle
+        self.failed_to_get_center=False
         VMobject.__init__(self, **kwargs)
 
     def generate_points(self):
@@ -259,7 +260,6 @@ class Arc(TipableVMobject):
         # Normals
         n1 = rotate_vector(t1, TAU / 4)
         n2 = rotate_vector(t2, TAU / 4)
-        self.failed_to_get_center=False
         try:
             return line_intersection(
                 line1=(a1, a1 + n1),

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -214,7 +214,7 @@ class Arc(TipableVMobject):
     def __init__(self, start_angle=0, angle=TAU / 4, **kwargs):
         self.start_angle = start_angle
         self.angle = angle
-        self.failed_to_get_center=False
+        self._failed_to_get_center=False
         VMobject.__init__(self, **kwargs)
 
     def generate_points(self):
@@ -268,7 +268,7 @@ class Arc(TipableVMobject):
         except Exception:
             if warning:
                 warnings.warn("Can't find Arc center, using ORIGIN instead")
-            self.failed_to_get_center=True
+            self._failed_to_get_center=True
             return np.array(ORIGIN)
 
     def move_arc_center_to(self, point):
@@ -311,7 +311,7 @@ class ArcBetweenPoints(Arc):
         
         if radius is None:
             center=self.get_arc_center(warning=False)
-            if not self.failed_to_get_center:
+            if not self._failed_to_get_center:
                 self.radius=np.linalg.norm(np.array(start) - np.array(center))
             else:
                 self.radius=math.inf

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -286,7 +286,7 @@ class ArcBetweenPoints(Arc):
     Inherits from Arc and additionally takes 2 points between which the arc is spanned.
     """
     def __init__(self, start, end, angle=TAU / 4, radius=None, **kwargs):
-        if radius!=None:
+        if radius is not None:
             self.radius=radius
             if radius < 0:
                 sign=-2
@@ -309,7 +309,7 @@ class ArcBetweenPoints(Arc):
             self.set_points_as_corners([LEFT, RIGHT])
         self.put_start_and_end_on(start, end)
         
-        if radius==None:
+        if radius is None:
             center=self.get_arc_center(warning=False)
             if not self.failed_to_get_center:
                 self.radius=np.linalg.norm(np.array(start) - np.array(center))

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -550,7 +550,7 @@ class Mobject(Container):
         curr_vect = curr_end - curr_start
         if np.all(curr_vect == 0):
             raise Exception("Cannot position endpoints of closed loop")
-        target_vect = end - start
+        target_vect = np.array(end) - np.array(start)
         self.scale(
             get_norm(target_vect) / get_norm(curr_vect),
             about_point=curr_start,


### PR DESCRIPTION
1. The motivation for making this change (#40)
mobject.py has been slightly changed to fix an issue where points that weren't passed into ArcBetweenPoints as np.array caused manim to fail.
geometry.py had ArcBetweenPoints adjusted to also support radius instead of just angle. Small changes to Arc were necessary to facilitate that .radius returns correct values at all times.

2. How you tested the new behavior:

```python
class Test(Scene):
    def construct(self):
        a = Arc(radius=-1)
        print(a.radius)
        b = Arc(radius=1)
        print(b.radius)
        c = Arc(angle=2)
        print(c.radius)
        d = Arc(angle=1)
        print(d.radius)
        e = ArcBetweenPoints([-1,0,0],[1,0,0],radius=-2)
        print(e.radius)
        f = ArcBetweenPoints([-1,0,0],[1,0,0],radius=1)
        print(f.radius)
        g = ArcBetweenPoints([-1,0,0],[1,0,0],angle=0.1)
        print(g.radius)
        h = ArcBetweenPoints([-1,0,0],[1,0,0],angle=0)
        print(h.radius)

        self.play(Write(VGroup(a,b,c,d,e,f,g,h).arrange(RIGHT)));self.wait(2)
```