### PR TITLE
Make GraphScene more customizable

### DIFF
--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -35,8 +35,8 @@ class NumberLine(Line):
         "include_tip": False,
         "tip_width": 0.25,
         "tip_height": 0.25,
-        "add_start": 0,
-        "add_end": 0,
+        "add_start": 0, # extend number line by this amount at its starting point
+        "add_end": 0,   # extend number line by this amount at its end point
         "decimal_number_config": {
             "num_decimal_places": 0,
         },

--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -35,8 +35,8 @@ class NumberLine(Line):
         "include_tip": False,
         "tip_width": 0.25,
         "tip_height": 0.25,
-        "add_start": 0, # extend number line by this amount at its starting point
-        "add_end": 0,   # extend number line by this amount at its end point
+        "add_start": 0,  # extend number line by this amount at its starting point
+        "add_end": 0,    # extend number line by this amount at its end point
         "decimal_number_config": {
             "num_decimal_places": 0,
         },

--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -35,6 +35,8 @@ class NumberLine(Line):
         "include_tip": False,
         "tip_width": 0.25,
         "tip_height": 0.25,
+        "add_start": 0,
+        "add_end": 0,
         "decimal_number_config": {
             "num_decimal_places": 0,
         },
@@ -45,7 +47,7 @@ class NumberLine(Line):
         digest_config(self, kwargs)
         start = self.unit_size * self.x_min * RIGHT
         end = self.unit_size * self.x_max * RIGHT
-        Line.__init__(self, start, end, **kwargs)
+        Line.__init__(self, start-self.add_start*RIGHT, end+self.add_end*RIGHT, **kwargs)
         self.shift(-self.number_to_point(self.number_at_center))
 
         self.init_leftmost_tick()
@@ -95,7 +97,7 @@ class NumberLine(Line):
         )
 
     def get_tick_numbers(self):
-        u = -1 if self.include_tip else 1
+        u = -1 if self.include_tip and self.add_end==0 else 1
         return np.arange(
             self.leftmost_tick,
             self.x_max + u * self.tick_frequency / 2,
@@ -105,7 +107,7 @@ class NumberLine(Line):
     def number_to_point(self, number):
         alpha = float(number - self.x_min) / (self.x_max - self.x_min)
         return interpolate(
-            self.get_start(), self.get_end(), alpha
+            self.get_start()+self.add_start*RIGHT, self.get_end()-self.add_end*RIGHT, alpha
         )
 
     def point_to_number(self, point):

--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -47,7 +47,12 @@ class NumberLine(Line):
         digest_config(self, kwargs)
         start = self.unit_size * self.x_min * RIGHT
         end = self.unit_size * self.x_max * RIGHT
-        Line.__init__(self, start-self.add_start*RIGHT, end+self.add_end*RIGHT, **kwargs)
+        Line.__init__(
+            self,
+            start - self.add_start * RIGHT,
+            end + self.add_end * RIGHT,
+            **kwargs
+        )
         self.shift(-self.number_to_point(self.number_at_center))
 
         self.init_leftmost_tick()

--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -107,7 +107,9 @@ class NumberLine(Line):
     def number_to_point(self, number):
         alpha = float(number - self.x_min) / (self.x_max - self.x_min)
         return interpolate(
-            self.get_start()+self.add_start*RIGHT, self.get_end()-self.add_end*RIGHT, alpha
+            self.get_start() + self.add_start * RIGHT,
+            self.get_end() - self.add_end * RIGHT,
+            alpha
         )
 
     def point_to_number(self, point):

--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -97,7 +97,7 @@ class NumberLine(Line):
         )
 
     def get_tick_numbers(self):
-        u = -1 if self.include_tip and self.add_end==0 else 1
+        u = -1 if self.include_tip and self.add_end == 0 else 1
         return np.arange(
             self.leftmost_tick,
             self.x_max + u * self.tick_frequency / 2,

--- a/manim/scene/graph_scene.py
+++ b/manim/scene/graph_scene.py
@@ -51,15 +51,15 @@ class GraphScene(Scene):
         "default_riemann_end_color": GREEN,
         "area_opacity": 0.8,
         "num_rects": 50,
-        "include_tip": False,
-        "x_axis_visibility": True,
-        "y_axis_visibility": True,
-        "x_label_position": UP+RIGHT,
-        "y_label_position": UP+RIGHT,
-        "x_add_start": 0,
-        "x_add_end": 0,
-        "y_add_start": 0,
-        "y_add_end": 0,
+        "include_tip": False,          # add tip at the end of the axes
+        "x_axis_visibility": True,     # show or hide the x axis
+        "y_axis_visibility": True,     # show or hide the y axis
+        "x_label_position": UP+RIGHT,  # where to place the label of the x axis
+        "y_label_position": UP+RIGHT,  # where to place the label of the y axis
+        "x_add_start": 0,              # extend the x axis to the left
+        "x_add_end": 0,                # extend the x axis to the right
+        "y_add_start": 0,              # extend the y axis to the bottom
+        "y_add_end": 0,                # extend the y axis to the top
     }
 
     def setup(self):

--- a/manim/scene/graph_scene.py
+++ b/manim/scene/graph_scene.py
@@ -160,21 +160,16 @@ class GraphScene(Scene):
             y_axis.add(y_label)
             self.y_axis_label_mob = y_label
 
-        if self.x_axis_visibility and self.y_axis_visibility:
-            if animate:
-                self.play(Write(VGroup(x_axis, y_axis)))
-            else:
-                self.add(x_axis, y_axis)
-        elif self.x_axis_visibility:
-            if animate:
-                self.play(Write(x_axis))
-            else:
-                self.add(x_axis)
-        elif self.y_axis_visibility:
-            if animate:
-                self.play(Write(y_axis))
-            else:
-                self.add(y_axis)
+        axes = []
+        if self.x_axis_visibility:
+            axes.append(x_axis)
+        if self.y_axis_visibility:
+            axes.append(y_axis)
+
+        if animate:
+            self.play(Write(VGroup(*axes)))
+        else:
+            self.add(*axes)
         self.x_axis, self.y_axis = self.axes = VGroup(x_axis, y_axis)
         self.default_graph_colors = it.cycle(self.default_graph_colors)
 

--- a/manim/scene/graph_scene.py
+++ b/manim/scene/graph_scene.py
@@ -109,16 +109,11 @@ class GraphScene(Scene):
             x_axis.add_numbers(*self.x_labeled_nums)
         if self.x_axis_label:
             x_label = TextMobject(self.x_axis_label)
-            if self.include_tip:
-                x_label.next_to(
-                    x_axis.get_tips(), self.x_label_position,
-                    buff=SMALL_BUFF
-                )
-            else:
-                x_label.next_to(
-                    x_axis.get_tick_marks(), self.x_label_position,
-                    buff=SMALL_BUFF
-                )
+            x_label.next_to(
+                x_axis.get_tips() if self.include_tip else x_axis.get_tick_marks(),
+                self.x_label_position,
+                buff=SMALL_BUFF
+            )
             x_label.shift_onto_screen()
             x_axis.add(x_label)
             self.x_axis_label_mob = x_label

--- a/manim/scene/graph_scene.py
+++ b/manim/scene/graph_scene.py
@@ -51,6 +51,15 @@ class GraphScene(Scene):
         "default_riemann_end_color": GREEN,
         "area_opacity": 0.8,
         "num_rects": 50,
+        "include_tip": False,
+        "x_axis_visibility": True,
+        "y_axis_visibility": True,
+        "x_label_position": UP+RIGHT,
+        "y_label_position": UP+RIGHT,
+        "x_add_start": 0,
+        "x_add_end": 0,
+        "y_add_start": 0,
+        "y_add_end": 0,
     }
 
     def setup(self):
@@ -88,7 +97,10 @@ class GraphScene(Scene):
             tick_frequency=self.x_tick_frequency,
             leftmost_tick=self.x_leftmost_tick,
             numbers_with_elongated_ticks=self.x_labeled_nums,
-            color=self.axes_color
+            color=self.axes_color,
+            include_tip=self.include_tip,
+            add_start=self.x_add_start,
+            add_end=self.x_add_end
         )
         x_axis.shift(self.graph_origin - x_axis.number_to_point(0))
         if len(self.x_labeled_nums) > 0:
@@ -97,10 +109,16 @@ class GraphScene(Scene):
             x_axis.add_numbers(*self.x_labeled_nums)
         if self.x_axis_label:
             x_label = TextMobject(self.x_axis_label)
-            x_label.next_to(
-                x_axis.get_tick_marks(), UP + RIGHT,
-                buff=SMALL_BUFF
-            )
+            if self.include_tip:
+                x_label.next_to(
+                    x_axis.get_tips(), self.x_label_position,
+                    buff=SMALL_BUFF
+                )
+            else:
+                x_label.next_to(
+                    x_axis.get_tick_marks(), self.x_label_position,
+                    buff=SMALL_BUFF
+                )
             x_label.shift_onto_screen()
             x_axis.add(x_label)
             self.x_axis_label_mob = x_label
@@ -122,6 +140,9 @@ class GraphScene(Scene):
             color=self.axes_color,
             line_to_number_vect=LEFT,
             label_direction=LEFT,
+            include_tip=self.include_tip,
+            add_start=self.y_add_start,
+            add_end=self.y_add_end
         )
         y_axis.shift(self.graph_origin - y_axis.number_to_point(0))
         y_axis.rotate(np.pi / 2, about_point=y_axis.number_to_point(0))
@@ -132,17 +153,28 @@ class GraphScene(Scene):
         if self.y_axis_label:
             y_label = TextMobject(self.y_axis_label)
             y_label.next_to(
-                y_axis.get_corner(UP + RIGHT), UP + RIGHT,
+                y_axis.get_corner(self.y_label_position), self.y_label_position,
                 buff=SMALL_BUFF
             )
             y_label.shift_onto_screen()
             y_axis.add(y_label)
             self.y_axis_label_mob = y_label
 
-        if animate:
-            self.play(Write(VGroup(x_axis, y_axis)))
-        else:
-            self.add(x_axis, y_axis)
+        if self.x_axis_visibility and self.y_axis_visibility:
+            if animate:
+                self.play(Write(VGroup(x_axis, y_axis)))
+            else:
+                self.add(x_axis, y_axis)
+        elif self.x_axis_visibility:
+            if animate:
+                self.play(Write(x_axis))
+            else:
+                self.add(x_axis)
+        elif self.y_axis_visibility:
+            if animate:
+                self.play(Write(y_axis))
+            else:
+                self.add(y_axis)
         self.x_axis, self.y_axis = self.axes = VGroup(x_axis, y_axis)
         self.default_graph_colors = it.cycle(self.default_graph_colors)
 


### PR DESCRIPTION
When it comes to drawing coordinate systems, there are different conventions, especially at the high school level. In my country, most textbooks draw axes with arrow tips at the right / upper end. 
Also I prefer to have the first and final tick not at the very start or end of the axis.

Furthermore, I often prefer to have the axis label aligned with the axis line, e.g. the `x` label to the right of the axis and not above-right. I added this functionality as well.

As a last thing, I realized that we **must** call `setup_axes` in order for the `GraphScene` to function properly (e.g. `coords_to_point` or `point_to_coords`). However, sometimes you might not want the axes to be shown, either because you do not need any axes or because you want to draw custom axes yourself. So I added parameters `x_axis_visibility` and `y_axis_visibility` that allow to set up the axes without actually drawing them.

I have tested the new code in a project of mine. The changes are entirely backwards compatible.