### PR TITLE
Fix  #125 by adding custom .interpolate method for ValueTracker

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1088,17 +1088,6 @@ class Mobject(Container):
     def interpolate_color(self, mobject1, mobject2, alpha):
         raise NotImplementedError('Please override in a child class.')
 
-    def become_partial(self, mobject, a, b):
-        """
-        Set points in such a way as to become only
-        part of mobject.
-        Inputs 0 <= a < b <= 1 determine what portion
-        of mobject to become.
-        """
-        raise NotImplementedError('Please override in a child class.')
-
-        # TODO, color?
-
     def pointwise_become_partial(self, mobject, a, b):
         raise NotImplementedError('Please override in a child class.')
 
@@ -1120,7 +1109,7 @@ class Mobject(Container):
                       "for a Mobject with no points"
             caller_name = sys._getframe(1).f_code.co_name
             raise Exception(message.format(caller_name))
-    
+
     # About z-index
     def set_z_index(self, z_index_value):
         """Sets the mobject's :attr:`z_index` to the value specified in `z_index_value`.
@@ -1129,7 +1118,7 @@ class Mobject(Container):
         ----------
         z_index_value : Union[:class:`int`, :class:`float`]
             The new value of :attr:`z_index` set.
-        
+
         Returns
         -------
         :class:`Mobject`
@@ -1137,10 +1126,10 @@ class Mobject(Container):
         """
         self.z_index = z_index_value
         return self
-    
+
     def set_z_index_by_z_coordinate(self):
         """Sets the mobject's z coordinate to the value of :attr:`z_index`.
-        
+
         Returns
         -------
         :class:`Mobject`

--- a/manim/mobject/value_tracker.py
+++ b/manim/mobject/value_tracker.py
@@ -1,11 +1,12 @@
 import numpy as np
 
+from ..utils.paths import straight_path
 from ..mobject.mobject import Mobject
 
 
 class ValueTracker(Mobject):
     """
-    Note meant to be displayed.  Instead the position encodes some
+    Not meant to be displayed.  Instead the position encodes some
     number, often one which another animation or continual_animation
     uses for its update function, and by treating it as a mobject it can
     still be animated and manipulated just like anything else.
@@ -25,6 +26,17 @@ class ValueTracker(Mobject):
 
     def increment_value(self, d_value):
         self.set_value(self.get_value() + d_value)
+
+    def interpolate(self, mobject1, mobject2,
+                    alpha, path_func=straight_path):
+        """
+        Turns self into an interpolation between mobject1
+        and mobject2.
+        """
+        self.points = path_func(
+            mobject1.points, mobject2.points, alpha
+        )
+        return self
 
 
 class ExponentialValueTracker(ValueTracker):


### PR DESCRIPTION
Added custom .interpolate method for ValueTracker

Removed unused .become_partial method from Mobject

Removed Trailing Spaces from ValueTracker and Mobject.

Fixes #125 

Commit 62050bb had changed the pass statements of some of the methods of Mobject() into NotImplementedError s. 
The method interpolate_color was one such method.

ThreeDCamera uses ValueTracker Mobjects in order to store the positions of the camera.

When ThreeDScene.move_camera() is called, the interpolate mobject of the ValueTracker is called. 
This method then calls interpolate_color, and since ValueTracker does not have a custom interpolate_color method, it uses the one in Mobject which it inherits from.

The interpolate_color method of Mobject only raises a NotImplementedError, and this results in ThreeDScene.move_camera() failing.

This PR adds a custom interpolate method for ValueTracker, as suggested by @Tony031218. This custom method does not call interpolate_color and hence fixes the issue.

Also, the .become_partial method was not mentioned anywhere outside of its definition, which itself simply raised a NotImplementedError, and hence was removed.