### PR TITLE
Simplified folder Structure

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -68,7 +68,7 @@ class SceneFileWriter(object):
         """
         module_directory = self.output_directory or self.get_default_module_directory()
         scene_name = self.file_name or self.get_default_scene_name()
-        if self.save_last_frame:
+        if self.save_last_frame or self.save_pngs:
             image_dir = guarantee_existence(os.path.join(
                 dirs.VIDEO_DIR
             ))

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -68,26 +68,18 @@ class SceneFileWriter(object):
         """
         module_directory = self.output_directory or self.get_default_module_directory()
         scene_name = self.file_name or self.get_default_scene_name()
-        #print("1")
-        #print(dirs.MEDIA_DIR)
-        if self.save_last_frame or self.save_pngs:
-            if dirs.MEDIA_DIR != "":
-                image_dir = guarantee_existence(os.path.join(
-                    dirs.MEDIA_DIR,
-                    "images",
-                    module_directory,
-                ))
+        if self.save_last_frame:
+            image_dir = guarantee_existence(os.path.join(
+                dirs.VIDEO_DIR
+            ))
             self.image_file_path = os.path.join(
                 image_dir,
                 add_extension_if_not_present(scene_name, ".png")
             )
         if self.write_to_movie:
-            if dirs.VIDEO_DIR != "":
-                movie_dir = guarantee_existence(os.path.join(
-                    dirs.VIDEO_DIR,
-                    module_directory,
-                    self.get_resolution_directory(),
-                ))
+            movie_dir = guarantee_existence(os.path.join(
+                dirs.VIDEO_DIR
+            ))
             self.movie_file_path = os.path.join(
                 movie_dir,
                 add_extension_if_not_present(


### PR DESCRIPTION
In regard of #66 this pull request removes the nested folder stucture in the output.
Tested with:
```py
from manim import *

class Test(Scene):
    def construct(self):
        dot = Dot()
        self.add(dot)
        self.wait(1)
        self.play(Transform(dot, Circle()))
        self.wait()

from pathlib import Path
if __name__ == "__main__":
    script = f"{Path(__file__).resolve()}"
    os.system(f"manim  -l -p -c 'BLACK' --video_dir ~/Downloads/ " + script )
```
When the argument ` --video_dir ~/Downloads/ "` is defined.