### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ As this is a Fork of [Manim by 3b1b](https://github.com/3b1b/manim), contributin
 
 4. After that, you can make your changes to the repo's files (the code is in the `manim` directory). Then, you can commit said changes.
 
+> Note: if your Pull Request doesn't change any of the actual code, please add `[skip ci]` to your commit message for Travis to ignore it.
+
 5. Finally, instead of  typing in `git push`, enter the command below.
 
    ```sh


### PR DESCRIPTION
Add in the fact that users who aren't editing any of the actual code can add `[skip ci]` to their commit message to avoid Travis from testing it. This could reduce the amount of builds that need to be done if we get to a point where there are a lot of PRs (and some of them don't involve editing the actual code).

Edit: Yes, I know, I forgot to add `[skip ci]` to this ↓ commit :/