### PR TITLE
Fixes an old FRAME_HEIGHT reference

### DIFF
--- a/manim/camera/moving_camera.py
+++ b/manim/camera/moving_camera.py
@@ -36,7 +36,7 @@ class MovingCamera(Camera):
         """
         digest_config(self, kwargs)
         if frame is None:
-            frame = ScreenRectangle(height=FRAME_HEIGHT)
+            frame = ScreenRectangle(height=config['frame_height'])
             frame.set_stroke(
                 self.default_frame_stroke_color,
                 self.default_frame_stroke_width,


### PR DESCRIPTION
Just a single line fix to complement the config switch done by #98. A line in moving_camera.py used for ZoomedScene still used the old FRAME_HEIGHT, breaking that class and possible some others.