### PR TITLE
Fix failing tests

### DIFF
--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from ..constants import *
+from ..config import config
 from ..animation.animation import Animation
 from ..animation.movement import Homotopy
 from ..animation.composition import AnimationGroup
@@ -45,7 +46,7 @@ class FocusOn(Transform):
 
     def create_starting_mobject(self):
         return Dot(
-            radius=FRAME_X_RADIUS + FRAME_Y_RADIUS,
+            radius=config['frame_x_radius'] + config['frame_y_radius'],
             stroke_width=0,
             fill_color=self.color,
             fill_opacity=0,

--- a/manim/config.py
+++ b/manim/config.py
@@ -177,7 +177,7 @@ def _parse_file_writer_config(config_parser, args):
 def _parse_cli(arg_list, input=True):
     parser = argparse.ArgumentParser(
         description='Animation engine for explanatory math videos',
-        epilog='Made with ❤ by the manim community devs'
+        epilog='Made with <3 by the manim community devs'
     )
     if input:
         parser.add_argument(

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -16,7 +16,7 @@ def capture(command):
 def test_help(python_version):
     command = [python_version, "-m", "manim", "--help"]
     out, err, exitcode = capture(command)
-    assert exitcode == 0, f"Manim has been installed incorrectly. Please refer to the troubleshooting section on the wiki. Error:\n{err}"
+    assert exitcode == 0, f"Manim has been installed incorrectly. Please refer to the troubleshooting section on the wiki. Error:\n{err.decode()}"
 
 
 @pytest.mark.skip_end_to_end

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -22,7 +22,7 @@ def test_help(python_version):
 @pytest.mark.skip_end_to_end
 def test_basicScene(python_version):
     """ Simulate SquareToCircle. The cache will be saved in tests_caches/media_temp (temporary directory). This is mainly intended to test the partial-movies process. """
-    path_basic_scene = os.path.join("tests_data", "basic_scenes.py")
+    path_basic_scene = os.path.join("tests", "tests_data", "basic_scenes.py")
     path_output = os.path.join("tests_cache", "media_temp")
     command = [python_version, "-m", "manim", path_basic_scene,
                "SquareToCircle", "-l", "--media_dir", path_output]
@@ -35,7 +35,7 @@ def test_basicScene(python_version):
 @pytest.mark.skip_end_to_end
 def test_WriteStuff(python_version):
     """This is mainly intended to test the caching process of the tex objects"""
-    path_basic_scene = os.path.join("tests_data", "basic_scenes.py")
+    path_basic_scene = os.path.join("tests", "tests_data", "basic_scenes.py")
     path_output = os.path.join("tests_cache", "media_temp")
     command = [python_version, "-m", "manim", path_basic_scene,
                "WriteStuff", "-l", "--media_dir", path_output]

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -126,29 +126,11 @@ def set_test_scene(scene_object, module_name):
         set_test_scene(DotTest, "geometry")
     """
 
-    CONFIG_TEST = {
-        'camera_config': {
-            'frame_rate': 15,
-            'pixel_height': 480,
-            'pixel_width': 854
-        },
-        'end_at_animation_number': None,
-        'file_writer_config': {
-            'file_name': None,
-            'input_file_path': 'test.py',
-            'movie_file_extension': '.mp4',
-            'png_mode': 'RGB',
-            'save_as_gif': False,
-            'save_last_frame': False,
-            'save_pngs': False,
-            'write_to_movie': False
-        },
-        'leave_progress_bars': False,
-        'skip_animations': True,
-        'start_at_animation_number': None
-    }
+    config['pixel_height'] = 480
+    config['pixel_width'] = 854
+    config['frame_rate'] = 15
 
-    scene = scene_object(**CONFIG_TEST)
+    scene = scene_object()
     data = scene.get_frame()
     path = os.path.join("manim", "tests", "tests_data",
                         "{}".format(module_name))

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -125,7 +125,7 @@ def set_test_scene(scene_object, module_name):
     Normal usage::
         set_test_scene(DotTest, "geometry")
     """
-
+    file_writer_config['skip_animations'] = True
     config['pixel_height'] = 480
     config['pixel_width'] = 854
     config['frame_rate'] = 15

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -6,7 +6,7 @@ import logging
 import pytest
 
 from manim import logger
-from manim import config
+from manim import config, file_writer_config
 
 
 class SceneTester:
@@ -34,8 +34,8 @@ class SceneTester:
     def __init__(self, scene_object, module_tested, caching_needed=False):
         # Disable the the logs, (--quiet is broken) TODO
         logging.disable(logging.CRITICAL)
-        self.path_tests_medias_cache = os.path.join('tests_cache', module_tested)
-        self.path_tests_data = os.path.join('tests_data', module_tested)
+        self.path_tests_medias_cache = os.path.join('tests', 'tests_cache', module_tested)
+        self.path_tests_data = os.path.join('tests', 'tests_data', module_tested)
 
         if caching_needed:
             config['text_dir'] = os.path.join(
@@ -43,6 +43,7 @@ class SceneTester:
             config['tex_dir'] = os.path.join(
                 self.path_tests_medias_cache, scene_object.__name__, 'Tex')
 
+        file_writer_config['skip_animations'] = True
         config['pixel_height'] = 480
         config['pixel_width'] = 854
         config['frame_rate'] = 15

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -40,7 +40,7 @@ class SceneTester:
         if caching_needed:
             config['text_dir'] = os.path.join(
                 self.path_tests_medias_cache, scene_object.__name__, 'Text')
-            config['tex_dir'] = os.path.join(
+            file_writer_config['tex_dir'] = os.path.join(
                 self.path_tests_medias_cache, scene_object.__name__, 'Tex')
 
         file_writer_config['skip_animations'] = True


### PR DESCRIPTION
There are three issues that I fixed  :

### 1 : pytest rootdir 
The first issue was a quick one, as the rootdir of pytest was set as manim/, the .npy files could not be found as their path was set to tests_data/etc and not tests/tests_data/etc. 
I think that this was an inteniontal move by @leotrs, who wanted the tests to use a custom `manim.cfg`. Sadly, we can't currently use one when not rendering a scene not from command lines. See #184.
### 2 : `skip_animation` not enabled for tests : a t values issue.
The second issue the these failing tests undercovered was an issue with t values. 
@leotrs changed a little bit the config that the tests use when they are running, he basically didn't add -s flag. I agree, this should not be a problem as the last frame should be the same if we skip the rendering process of the animations or not, but they are different. See #183 TLDR : This is a problem with the t values, when doing `-s`, there is only one t value generated by manim wich is 1.0 (the time when the animation ends), and when the skip_animations is False, there are, let's say, 15 values of t generated (as 15 fps) which go from 0 to not 1 but .93333. In other terms, the animation stops at 93%). I fixed THE TESTS  (not this issue) by simply adding to testing_utils.py `file_write_config['skip_animations'] = True`.

### 3 : frame_width slightly changed
I didn't have to fix this, I will explain.
`frame_width` is computed l62 config.py : 
```python
    config['frame_width'] = (config['frame_height']
                             * config['pixel_width']
                             / config['pixel_height'])
```
Because of how Python handles float, this value may differ depending how what is the value of  `config['pixel_width'] and config['pixel_height']`
If config['pixel_width'] is not set in a `manim.cfg`, (as it is done in the tests, see testing_utils.py, l.48), default value of pixel_width will be taken. 
There is the problem,  `config['frame_width']` should be the same in both cases (set in manim.cdg and not set) (as default values and values used in the tests have the same ratio),  they slightly differ (something like 14.211111111111 and 14.23333333).
That's why there is a slightly pixel related difference. 
As we don't use a manim.cfg for the tests rn, it is ok. But when we will do so, we will have to render a new set of tests_data.

## Issues to be fixed : 

- `NameError: name 'FRAME_X_RADIUS' is not defined`  
Not sure how to fix that. The king @leotrs surely knows.
**FIXED**

- `UnicodeEncodeError: 'charmap' codec can't encode character '\u2764' in position 2905: character maps to <undefined>`
This has been recently added in the -h flag  : "Made with ❤ by the manim community dev". 
Sadly, '\u2764' (the heart) is seems to not be suported by the decoding of `subprocess`. 
To quicly fix this major issue, we could do the biggest change in manim's history : changing ❤ by <3.  
**FIXED**