### PR TITLE
Properly parse the file path to get the module containing the Scenes

### DIFF
--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -135,6 +135,8 @@ def get_module(file_name):
             sys.exit(2)
     else:
         if os.path.exists(file_name):
+            if file_name[-3:] != ".py":
+                raise Exception(f"{file_name} is not a valid Manim python script.")
             module_name = file_name[:-3].replace(os.sep, '.').split('.')[-1]
             spec = importlib.util.spec_from_file_location(module_name, file_name)
             module = importlib.util.module_from_spec(spec)

--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -135,7 +135,7 @@ def get_module(file_name):
             sys.exit(2)
     else:
         if os.path.exists(file_name):
-            module_name = re.sub(r"\..+$", "", file_name.replace(os.sep, "."))
+            module_name = file_name[:-3].replace(os.sep, '.').split('.')[-1]
             spec = importlib.util.spec_from_file_location(module_name, file_name)
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)


### PR DESCRIPTION
This PR will close #171 .

The lines/file concerned are:

https://github.com/ManimCommunity/manim/blob/ea79842b17ccb7e0a5eb33be5edc5abb4ce60b50/manim/__main__.py#L137-L139

The issue was that the regex based approach would fail when there was a `.` in the path and end up importing all scenes in the library instead of those that were needed.

The pattern `"\..+$"` matches all characters after a `.` , and makes sure that the matched characters end with a newline, and replaces them with an empty string.

The pattern works fine when the only characters to the right of the `.` is `py`, but fails when you are leading in from another path.

For `./basic.py`, the `file_name.replace(os.sep,".")` makes the string into `..basic.py`, and the regex sees that the first character is a `.` and sees that the line ends with that string, and matches `..basic,py` entirely, and replaces it with an empty string.

`./basic.py` --> .replace(..) --> `..basic.py` --> regex --> ""

And then this empty string gets passed to `importlib`, which imports all the scenes that exist in the entire repo since it didn't receive a proper module to import.

This has been solved by using string slicing and splitting at appropriate places to extract the module name.

`module_name = file_name[:-3].replace(os.sep, '.').split('.')[-1]`

The string is first sliced to get rid of the `.py`, then the separators are replaced with `.`s. The resulting string is split at every `.` and the last element of that list, which _should_ be the module name, is taken.

I have tested this from multiple locations, with multiple file names. 

The only issue that this approach might face is that it will completely fail when there's a `.` in the name of the file containing the module, like `my.module.py`, but the original approach would fail in that case too, so, no net loss ;)