### PR TITLE
Added a VDict class with usage example

### DIFF
--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -151,22 +151,27 @@ class VDictTest(Scene):
         print(my_dict.get_all_submobjects())
 
         text = TextMobject("Some text").set_color(GREEN).next_to(square, DOWN)
-        my_dict.add(('t', text)) #add like a VGroup
+        my_dict.add(('t', text))                        #add like a VGroup
         self.wait()
         
+        rect = Rectangle().next_to(text, DOWN)
+        my_dict['r'] = rect                             # can also do key assignment like a python dict
         print(my_dict.get_all_submobjects())
 
-        my_dict['t'].set_color(PURPLE) # access submobjects like a python dict
+        my_dict['t'].set_color(PURPLE)                  # access submobjects like a python dict
         self.play(my_dict['t'].scale, 3)
         self.wait()
 
-        my_dict.remove('t') # remove submojects by key
+        my_dict.remove('t')                             # remove submojects by key
         self.wait()
 
         self.play(Uncreate(my_dict['s']))
         self.wait()
 
         self.play(FadeOut(my_dict['c']))
+        self.wait()
+
+        self.play(FadeOutAndShiftDown(my_dict['r']))
         self.wait()
 
 # See old_projects folder for many, many more

--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -151,18 +151,23 @@ class VDictTest(Scene):
         print(my_dict.get_all_submobjects())
 
         text = TextMobject("Some text").set_color(GREEN).next_to(square, DOWN)
-        my_dict.add(('t', text))                        #add like a VGroup
+
+        #add like a VGroup
+        my_dict.add(('t', text))                        
         self.wait()
         
         rect = Rectangle().next_to(text, DOWN)
-        my_dict['r'] = rect                             # can also do key assignment like a python dict
+        # can also do key assignment like a python dict
+        my_dict['r'] = rect                             
         print(my_dict.get_all_submobjects())
 
-        my_dict['t'].set_color(PURPLE)                  # access submobjects like a python dict
+        # access submobjects like a python dict
+        my_dict['t'].set_color(PURPLE)                  
         self.play(my_dict['t'].scale, 3)
         self.wait()
 
-        my_dict.remove('t')                             # remove submojects by key
+        # remove submojects by key
+        my_dict.remove('t')                             
         self.wait()
 
         self.play(Uncreate(my_dict['s']))
@@ -171,7 +176,12 @@ class VDictTest(Scene):
         self.play(FadeOut(my_dict['c']))
         self.wait()
 
-        self.play(FadeOutAndShiftDown(my_dict['r']))
+        self.play(FadeOutAndShift(my_dict['r'], DOWN))
         self.wait()
+
+        # iterate through all submobjects currently associated with my_dict
+        for submob in my_dict.get_all_submobjects():
+            self.play(ShowCreation(submob))
+            self.wait()
 
 # See old_projects folder for many, many more

--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -166,6 +166,10 @@ class VDictTest(Scene):
         self.play(my_dict['t'].scale, 3)
         self.wait()
 
+        # also supports python dict styled reassignment
+        my_dict['t'] = TextMobject("Some other text").set_color(BLUE)
+        self.wait()
+
         # remove submojects by key
         my_dict.remove('t')                             
         self.wait()

--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -133,7 +133,6 @@ class UpdatersExample(Scene):
         )
         self.wait()
 
-# See old_projects folder for many, many more
 class VDictTest(Scene):
     def construct(self):
         square = Square().set_color(RED)
@@ -151,7 +150,7 @@ class VDictTest(Scene):
 
         print(my_dict.get_all_submobjects())
 
-        text = TextMobject("Some text").set_color(GREEN)
+        text = TextMobject("Some text").set_color(GREEN).next_to(square, DOWN)
         my_dict.add(('t', text)) #add like a VGroup
         self.wait()
         
@@ -169,3 +168,5 @@ class VDictTest(Scene):
 
         self.play(FadeOut(my_dict['c']))
         self.wait()
+
+# See old_projects folder for many, many more

--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -134,3 +134,38 @@ class UpdatersExample(Scene):
         self.wait()
 
 # See old_projects folder for many, many more
+class VDictTest(Scene):
+    def construct(self):
+        square = Square().set_color(RED)
+        circle = Circle().set_color(YELLOW).next_to(square, UP)
+
+        # create dict from list of tuples each having key-mobject pair
+        pairs = [('s', square), ('c', circle)]
+        my_dict = VDict(*pairs, show_keys=True)
+
+        # display it just like a VGroup
+        self.play(
+            ShowCreation(my_dict)
+            )
+        self.wait()
+
+        print(my_dict.get_all_submobjects())
+
+        text = TextMobject("Some text").set_color(GREEN)
+        my_dict.add(('t', text)) #add like a VGroup
+        self.wait()
+        
+        print(my_dict.get_all_submobjects())
+
+        my_dict['t'].set_color(PURPLE) # access submobjects like a python dict
+        self.play(my_dict['t'].scale, 3)
+        self.wait()
+
+        my_dict.remove('t') # remove submojects by key
+        self.wait()
+
+        self.play(Uncreate(my_dict['s']))
+        self.wait()
+
+        self.play(FadeOut(my_dict['c']))
+        self.wait()

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1021,7 +1021,7 @@ class VDict(VMobject):
         
             Parameters
             ----------
-            key : any suitable type of a python `dict`
+            key : Hashable
                 The key of the submoject to be accessed
             
             Returns

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -907,7 +907,7 @@ class VGroup(VMobject):
         self.add(*vmobjects)
 
 class VDict(VMobject):
-    '''A VGroup-like class, also offering submobject access by
+    """A VGroup-like class, also offering submobject access by
     key, like a python dict
 
     Parameters
@@ -936,8 +936,7 @@ class VDict(VMobject):
     submob_dict : :class:`dict`
             Is the actual python dictionary that is used to bind
             the keys to the mobjects
-            
-    '''
+    """
 
     def __init__(self, *pairs, show_keys=False, **kwargs):
         if not all(isinstance(m[1], VMobject) for m in pairs):
@@ -949,30 +948,29 @@ class VDict(VMobject):
         
 
     def add(self, *pairs):
-        '''Adds the key-value pairs to the :class:`VDict` object.
+        """Adds the key-value pairs to the :class:`VDict` object.
 
-            Also, it internally adds the value to the `submobjects` :class:`list`
-            of :class:`~.Mobject`, which is responsible for actual on-screen display
-            
-            Parameters
-            ---------
-            pairs : Tuple[Hashable, :class:`~.VMobject`]
-                Each pair is a :class:`tuple` wherein the first 
-                element is the key for the mobject and the second
-                element is the actual mobject
+        Also, it internally adds the value to the `submobjects` :class:`list`
+        of :class:`~.Mobject`, which is responsible for actual on-screen display
 
-            Returns
-            -------
-            :class:`VDict`
-                Returns the :class:`VDict` object on which this method was called
+        Parameters
+        ---------
+        pairs : Tuple[Hashable, :class:`~.VMobject`]
+            Each pair is a :class:`tuple` wherein the first 
+            element is the key for the mobject and the second
+            element is the actual mobject
 
-            Examples
-            --------
-            Normal usage::
-                square_obj = Square()
-                my_dict.add(('s', square_obj))
-            
-        '''
+        Returns
+        -------
+        :class:`VDict`
+            Returns the :class:`VDict` object on which this method was called
+
+        Examples
+        --------
+        Normal usage::
+            square_obj = Square()
+            my_dict.add(('s', square_obj))
+        """
         for pair in pairs:
             key = pair[0]
             value = pair[1]
@@ -989,27 +987,26 @@ class VDict(VMobject):
         return self
 
     def remove(self, key):
-        '''Removes the mobject from the :class:`VDict` object having the key `key`
+        """Removes the mobject from the :class:`VDict` object having the key `key`
         
-            Also, it internally removes the mobject from the `submobjects` :class:`list`
-            of :class:`~.Mobject`, (which is responsible for removing it from the screen)
+        Also, it internally removes the mobject from the `submobjects` :class:`list`
+        of :class:`~.Mobject`, (which is responsible for removing it from the screen)
 
-            Parameters
-            ----------
-            key : Hashable
-                The key of the submoject to be removed
+        Parameters
+        ----------
+        key : Hashable
+            The key of the submoject to be removed
 
-            Returns
-            -------
-            :class:`VDict`
-                Returns the :class:`VDict` object on which this method was called
+        Returns
+        -------
+        :class:`VDict`
+            Returns the :class:`VDict` object on which this method was called
 
-            Examples
-            --------
-            Normal usage::
-                my_dict.remove('square')
-
-        '''
+        Examples
+        --------
+        Normal usage::
+            my_dict.remove('square')
+        """
         if key not in self.submob_dict:
             raise Exception("The given key '%s' is not present in the VDict" %str(key))
         super().remove(self.submob_dict[key])
@@ -1017,67 +1014,64 @@ class VDict(VMobject):
         return self
 
     def __getitem__(self, key):
-        '''Overriding the [] operator for getting submobject by key
+        """Overriding the [] operator for getting submobject by key
         
-            Parameters
-            ----------
-            key : Hashable
-                The key of the submoject to be accessed
+        Parameters
+        ----------
+        key : Hashable
+           The key of the submoject to be accessed
             
-            Returns
-            -------
-            :class:`VMobject`
-                The submobject corresponding to the key `key`
+        Returns
+        -------
+        :class:`VMobject`
+           The submobject corresponding to the key `key`
 
-            Examples
-            --------
-            Normal usage::
-                self.play(ShowCreation(my_dict['s']))
-
-        '''
+        Examples
+        --------
+        Normal usage::
+           self.play(ShowCreation(my_dict['s']))
+        """
         submob = self.submob_dict[key]
         return submob 
 
     def __setitem__(self, key, value):
-        '''Overriding the [] operator for assigning submobject like a python dict
+        """Overriding the [] operator for assigning submobject like a python dict
 
-            Parameters
-            ----------
-            key : Hashable
-                The key of the submoject to be assigned
-            value : :class:`VMobject`
-                The submobject to bind the key to
+        Parameters
+        ----------
+        key : Hashable
+            The key of the submoject to be assigned
+        value : :class:`VMobject`
+            The submobject to bind the key to
             
-            Returns
-            -------
-            None
+        Returns
+        -------
+        None
 
-            Examples
-            --------
-            Normal usage::
-                square_obj = Square()
-                my_dict['sq'] = square_obj
-        
-        '''
+        Examples
+        --------
+        Normal usage::
+            square_obj = Square()
+            my_dict['sq'] = square_obj
+        """
         if key in self.submob_dict:
             self.remove(key)
         self.add((key, value))
 
     def get_all_submobjects(self):
-        ''' To get all the submobjects associated with a particular :class:`VDict` object
+        """To get all the submobjects associated with a particular :class:`VDict` object
         
-            Returns
-            -------
-            :class:`dict_values`
-                All the submobjects associated with the :class:`VDict` object
+        Returns
+        -------
+        :class:`dict_values`
+            All the submobjects associated with the :class:`VDict` object
 
-            Examples
-            --------
-            Normal usage::
-                for submob in my_dict.get_all_submobjects():
-                    self.play(ShowCreation(submob))
-
-        '''
+        Examples
+        --------
+        Normal usage::
+            for submob in my_dict.get_all_submobjects():
+                self.play(ShowCreation(submob))
+        """
         submobjects = self.submob_dict.values()
         return submobjects
 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -932,7 +932,7 @@ class VDict(VMobject):
 
     def remove(self, key):
         if key not in self.submob_dict:
-            raise Exception("The given key '%s' is not present in the Dict" %str(key))
+            raise Exception("The given key '%s' is not present in the VDict" %str(key))
         super().remove(self.submob_dict[key])
         del self.submob_dict[key]
         return self

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -932,7 +932,7 @@ class VDict(VMobject):
             :class:`VDict`. When displayed, the key is towards
             the left of the mobject.
             Defaults to False
-    submob_dict : :class:`dict`:
+    submob_dict : :class:`dict`
             Is the actual python dictionary that is used to bind
             the keys to the mobjects
             

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -921,7 +921,8 @@ class VDict(VMobject):
             the mobject. This might be useful when debugging,
             especially when there are a lot of mobjects in the
             :class:`VDict`. Defaults to False
-    **kwargs : Keyword arguments
+    kwargs : Any
+            Other arguments to be passed to `Mobject` or the CONFIG.
 
     Attributes
     ----------

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1043,7 +1043,7 @@ class VDict(VMobject):
 
             Parameters
             ----------
-            key : any suitable type of a python `dict`
+            key : Hashable
                 The key of the submoject to be assigned
             value : :class:`VMobject`
                 The submobject to bind the key to

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -952,6 +952,9 @@ class VDict(VMobject):
     def __getitem__(self, key):
         return self.submob_dict[key]
 
+    def __setitem__(self, key, value):
+        self.add((key, value))
+
     def get_all_submobjects(self):
         return (self.submob_dict).values()
 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1068,7 +1068,7 @@ class VDict(VMobject):
         
             Returns
             -------
-            submobjects : :class:`dict_values`
+            :class:`dict_values`
                 All the submobjects associated with the :class:`VDict` object
 
             Examples

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -958,7 +958,7 @@ class VDict(VMobject):
             Also, it internally adds the value to the `submobjects` :class:`list`
             of :class:`~.Mobject`, which is responsible for actual on-screen display
             
-            Paramters
+            Parameters
             ---------
             *pairs : :class:`iterable`
                 Each pair is a :class:`tuple` wherein the first 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -996,7 +996,7 @@ class VDict(VMobject):
 
             Parameters
             ----------
-            key : 
+            key : Hashable
                 The key of the submoject to be removed
 
             Returns

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -911,12 +911,15 @@ class VDict(VMobject):
     A VGroup-like class, also offering submobject access by
     key, like a python dict
     '''
-    def __init__(self, *pairs, **kwargs):
+
+    def __init__(self, *pairs, show_keys=False, **kwargs):
         if not all([isinstance(m[1], VMobject) for m in pairs ]):
             raise Exception("All submobjects must be of type VMobject")
         VMobject.__init__(self, **kwargs)
+        self.show_keys = show_keys
         self.submob_dict = {}
         self.add(*pairs)
+        
 
     def add(self, *pairs):
         '''Adds the key-value pairs to self.submob_dict
@@ -926,7 +929,15 @@ class VDict(VMobject):
         for pair in pairs:
             key = pair[0]
             value = pair[1]
-            self.submob_dict[key] = value
+            
+            mob = value
+            if self.show_keys:
+                from ...mobject.svg.tex_mobject import TextMobject
+                # This import is here and not at the top to avoid circular import
+                key_text = TextMobject(str(key)).next_to(value, LEFT)
+                mob.add(key_text)
+            
+            self.submob_dict[key] = mob
             super().add(value)
         return self
 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1007,7 +1007,7 @@ class VDict(VMobject):
             Examples
             --------
             Normal usage::
-            my_dict.remove('square')
+                my_dict.remove('square')
 
         '''
         if key not in self.submob_dict:

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -906,6 +906,44 @@ class VGroup(VMobject):
         VMobject.__init__(self, **kwargs)
         self.add(*vmobjects)
 
+class VDict(VMobject):
+    ''' 
+    A VGroup-like class, also offering submobject access by
+    key, like a python dict
+    '''
+    def __init__(self, *pairs, **kwargs):
+        if not all([isinstance(m[1], VMobject) for m in pairs ]):
+            raise Exception("All submobjects must be of type VMobject")
+        VMobject.__init__(self, **kwargs)
+        self.submob_dict = {}
+        self.add(*pairs)
+
+    def add(self, *pairs):
+        '''Adds the key-value pairs to self.submob_dict
+            and the value to the 'submobjects' list of Mobject,
+            (which is responsible for actual on-screen display)
+        '''
+        for pair in pairs:
+            key = pair[0]
+            value = pair[1]
+            self.submob_dict[key] = value
+            super().add(value)
+        return self
+
+    def remove(self, key):
+        if key not in self.submob_dict:
+            raise Exception("The given key '%s' is not present in the Dict" %str(key))
+        super().remove(self.submob_dict[key])
+        del self.submob_dict[key]
+        return self
+
+    # overriding the [] operator for getting submobject by key
+    def __getitem__(self, key):
+        return self.submob_dict[key]
+
+    def get_all_submobjects(self):
+        return (self.submob_dict).values()
+
 
 class VectorizedPoint(VMobject):
     CONFIG = {

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -932,7 +932,6 @@ class VDict(VMobject):
             :class:`VDict`. When displayed, the key is towards
             the left of the mobject.
             Defaults to False
-    **kwargs : Keyword arguments
     submob_dict : :class:`dict`:
             Is the actual python dictionary that is used to bind
             the keys to the mobjects

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -912,7 +912,7 @@ class VDict(VMobject):
 
     Parameters
     ----------
-    *pairs : :class:`iterable`
+    pairs: Tuple[Hashable, :class:`~.VMobject`]
             Each pair is a 2-element :class:`tuple` wherein the first 
             element is the key for the mobject and the second
             element is the actual mobject

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -963,7 +963,7 @@ class VDict(VMobject):
 
             Returns
             -------
-            self : :class:`VDict`
+            :class:`VDict`
                 Returns the :class:`VDict` object on which this method was called
 
             Examples

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1001,7 +1001,7 @@ class VDict(VMobject):
 
             Returns
             -------
-            self : :class:`VDict`
+            :class:`VDict`
                 Returns the :class:`VDict` object on which this method was called
 
             Examples

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -925,10 +925,6 @@ class VDict(VMobject):
 
     Attributes
     ----------
-    *pairs : :class:`iterable`
-            Each pair is a :class:`tuple` wherein the first 
-            element is the key for the mobject and the second
-            element is the actual mobject
     show_keys : :class:`bool`, optional
             Whether to also display the key associated with 
             the mobject. This might be useful when debugging,

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -956,7 +956,7 @@ class VDict(VMobject):
             
             Parameters
             ---------
-            *pairs : :class:`iterable`
+            pairs : Tuple[Hashable, :class:`~.VMobject`]
                 Each pair is a :class:`tuple` wherein the first 
                 element is the key for the mobject and the second
                 element is the actual mobject

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1026,7 +1026,7 @@ class VDict(VMobject):
             
             Returns
             -------
-            submob : :class:`VMobject`
+            :class:`VMobject`
                 The submobject corresponding to the key `key`
 
             Examples

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1078,7 +1078,7 @@ class VDict(VMobject):
                     self.play(ShowCreation(submob))
 
         '''
-        submobjects = (self.submob_dict).values()
+        submobjects = self.submob_dict.values()
         return submobjects
 
 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -907,9 +907,40 @@ class VGroup(VMobject):
         self.add(*vmobjects)
 
 class VDict(VMobject):
-    ''' 
-    A VGroup-like class, also offering submobject access by
+    '''A VGroup-like class, also offering submobject access by
     key, like a python dict
+
+    Parameters
+    ----------
+    *pairs : :class:`iterable`
+            Each pair is a 2-element :class:`tuple` wherein the first 
+            element is the key for the mobject and the second
+            element is the actual mobject
+    show_keys : :class:`bool`, optional
+            Whether to also display the key associated with 
+            the mobject. This might be useful when debugging,
+            especially when there are a lot of mobjects in the
+            :class:`VDict`. Defaults to False
+    **kwargs : Keyword arguments
+
+    Attributes
+    ----------
+    *pairs : :class:`iterable`
+            Each pair is a :class:`tuple` wherein the first 
+            element is the key for the mobject and the second
+            element is the actual mobject
+    show_keys : :class:`bool`, optional
+            Whether to also display the key associated with 
+            the mobject. This might be useful when debugging,
+            especially when there are a lot of mobjects in the
+            :class:`VDict`. When displayed, the key is towards
+            the left of the mobject.
+            Defaults to False
+    **kwargs : Keyword arguments
+    submob_dict : :class:`dict`:
+            Is the actual python dictionary that is used to bind
+            the keys to the mobjects
+            
     '''
 
     def __init__(self, *pairs, show_keys=False, **kwargs):
@@ -922,9 +953,29 @@ class VDict(VMobject):
         
 
     def add(self, *pairs):
-        '''Adds the key-value pairs to self.submob_dict
-            and the value to the 'submobjects' list of Mobject,
-            (which is responsible for actual on-screen display)
+        '''Adds the key-value pairs to the :class:`VDict` object.
+
+            Also, it internally adds the value to the `submobjects` :class:`list`
+            of :class:`~.Mobject`, which is responsible for actual on-screen display
+            
+            Paramters
+            ---------
+            *pairs : :class:`iterable`
+                Each pair is a :class:`tuple` wherein the first 
+                element is the key for the mobject and the second
+                element is the actual mobject
+
+            Returns
+            -------
+            self : :class:`VDict`
+                Returns the :class:`VDict` object on which this method was called
+
+            Examples
+            --------
+            Normal usage::
+                square_obj = Square()
+                my_dict.add(('s', square_obj))
+            
         '''
         for pair in pairs:
             key = pair[0]
@@ -932,8 +983,8 @@ class VDict(VMobject):
             
             mob = value
             if self.show_keys:
-                from ...mobject.svg.tex_mobject import TextMobject
                 # This import is here and not at the top to avoid circular import
+                from ...mobject.svg.tex_mobject import TextMobject
                 key_text = TextMobject(str(key)).next_to(value, LEFT)
                 mob.add(key_text)
             
@@ -942,21 +993,95 @@ class VDict(VMobject):
         return self
 
     def remove(self, key):
+        '''Removes the mobject from the :class:`VDict` object having the key `key`
+        
+            Also, it internally removes the mobject from the `submobjects` :class:`list`
+            of :class:`~.Mobject`, (which is responsible for removing it from the screen)
+
+            Parameters
+            ----------
+            key : 
+                The key of the submoject to be removed
+
+            Returns
+            -------
+            self : :class:`VDict`
+                Returns the :class:`VDict` object on which this method was called
+
+            Examples
+            --------
+            Normal usage::
+            my_dict.remove('square')
+
+        '''
         if key not in self.submob_dict:
             raise Exception("The given key '%s' is not present in the VDict" %str(key))
         super().remove(self.submob_dict[key])
         del self.submob_dict[key]
         return self
 
-    # overriding the [] operator for getting submobject by key
     def __getitem__(self, key):
-        return self.submob_dict[key]
+        '''Overriding the [] operator for getting submobject by key
+        
+            Parameters
+            ----------
+            key : any suitable type of a python `dict`
+                The key of the submoject to be accessed
+            
+            Returns
+            -------
+            submob : :class:`VMobject`
+                The submobject corresponding to the key `key`
+
+            Examples
+            --------
+            Normal usage::
+                self.play(ShowCreation(my_dict['s']))
+
+        '''
+        submob = self.submob_dict[key]
+        return submob 
 
     def __setitem__(self, key, value):
+        '''Overriding the [] operator for assigning submobject like a python dict
+
+            Parameters
+            ----------
+            key : any suitable type of a python `dict`
+                The key of the submoject to be assigned
+            value : :class:`VMobject`
+                The submobject to bind the key to
+            
+            Returns
+            -------
+            None
+
+            Examples
+            --------
+            Normal usage::
+                square_obj = Square()
+                my_dict['sq'] = square_obj
+        
+        '''
         self.add((key, value))
 
     def get_all_submobjects(self):
-        return (self.submob_dict).values()
+        ''' To get all the submobjects associated with a particular :class:`VDict` object
+        
+            Returns
+            -------
+            submobjects : :class:`dict_values`
+                All the submobjects associated with the :class:`VDict` object
+
+            Examples
+            --------
+            Normal usage::
+                for submob in my_dict.get_all_submobjects():
+                    self.play(ShowCreation(submob))
+
+        '''
+        submobjects = (self.submob_dict).values()
+        return submobjects
 
 
 class VectorizedPoint(VMobject):

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -940,7 +940,7 @@ class VDict(VMobject):
     '''
 
     def __init__(self, *pairs, show_keys=False, **kwargs):
-        if not all([isinstance(m[1], VMobject) for m in pairs ]):
+        if not all(isinstance(m[1], VMobject) for m in pairs):
             raise Exception("All submobjects must be of type VMobject")
         VMobject.__init__(self, **kwargs)
         self.show_keys = show_keys

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -925,7 +925,7 @@ class VDict(VMobject):
 
     Attributes
     ----------
-    show_keys : :class:`bool`, optional
+    show_keys : :class:`bool`
             Whether to also display the key associated with 
             the mobject. This might be useful when debugging,
             especially when there are a lot of mobjects in the

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1063,6 +1063,8 @@ class VDict(VMobject):
                 my_dict['sq'] = square_obj
         
         '''
+        if key in self.submob_dict:
+            self.remove(key)
         self.add((key, value))
 
     def get_all_submobjects(self):


### PR DESCRIPTION
Thanks for contributing to manim!

**Please ensure that your pull request works with the latest version of manim.**
You should also include:

1. Linked issue: #186 
2. This is the code I used for testing:
```python
class VDictTest(Scene):
    def construct(self):
        square = Square().set_color(RED)
        circle = Circle().set_color(YELLOW).next_to(square, UP)

        # create dict from list of tuples each having key-mobject pair
        pairs = [('s', square), ('c', circle)]
        my_dict = VDict(*pairs, show_keys=True)

        # display it just like a VGroup
        self.play(
            ShowCreation(my_dict)
            )
        self.wait()

        print(my_dict.get_all_submobjects())

        text = TextMobject("Some text").set_color(GREEN).next_to(square, DOWN)

        #add like a VGroup
        my_dict.add(('t', text))                        
        self.wait()
        
        rect = Rectangle().next_to(text, DOWN)
        # can also do key assignment like a python dict
        my_dict['r'] = rect                             
        print(my_dict.get_all_submobjects())

        # access submobjects like a python dict
        my_dict['t'].set_color(PURPLE)                  
        self.play(my_dict['t'].scale, 3)
        self.wait()

        # also supports python dict styled reassignment
        my_dict['t'] = TextMobject("Some other text").set_color(BLUE)
        self.wait()

        # remove submojects by key
        my_dict.remove('t')                             
        self.wait()

        self.play(Uncreate(my_dict['s']))
        self.wait()

        self.play(FadeOut(my_dict['c']))
        self.wait()

        self.play(FadeOutAndShift(my_dict['r'], DOWN))
        self.wait()

        # iterate through all submobjects currently associated with my_dict
        for submob in my_dict.get_all_submobjects():
            self.play(ShowCreation(submob))
            self.wait()
```
![VDictTest](https://user-images.githubusercontent.com/45491806/87177533-6f68b600-c2f9-11ea-9bb7-5715ede590d4.gif)



