### PR TITLE
Use an emoji heart only for MacOS and Linux

### DIFF
--- a/manim/config.py
+++ b/manim/config.py
@@ -176,8 +176,9 @@ def _parse_file_writer_config(config_parser, args):
 
 def _parse_cli(arg_list, input=True):
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description='Animation engine for explanatory math videos',
-        epilog='Made with <3 by the manim community devs'
+        epilog=f"Made with {'<3' if os.name == 'nt' else '❤ '} by the manim community devs"
     )
     if input:
         parser.add_argument(


### PR DESCRIPTION
Unicode isn't as scary as you might think. It's used by default in the rich and yarn clis and has been standardized for almost two decades. Windows uses some nonstandard encoding by default, so we have to add `encoding="utf-8"` manually.