### PR TITLE
Allow the user to type manim code when using - as filename.

### DIFF
--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -124,7 +124,7 @@ def get_scene_classes_from_module(module):
 def get_module(file_name):
     if file_name == "-":
         module = types.ModuleType("input_scenes")
-        logger.info("Enter the animation's code & end with an EOF (CTRL+D or CTRL+Z on Windows):")
+        logger.info("Enter the animation's code & end with an EOF (CTRL+D on Linux/Unix, CTRL+Z on Windows):")
         code = sys.stdin.read()
         if not code.startswith("from manim import"):
             logger.warn("Didn't find an import statement for Manim. Importing automatically...")

--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -124,8 +124,11 @@ def get_scene_classes_from_module(module):
 def get_module(file_name):
     if file_name == "-":
         module = types.ModuleType("input_scenes")
-        logger.info("Enter the code for your animation and end with an EOF (usually CTRL+D):")
+        logger.info("Enter the animation's code & end with an EOF (CTRL+D or CTRL+Z on Windows):")
         code = sys.stdin.read()
+        if not code.startswith("from manim import"):
+            logger.warn("Didn't find an import statement for Manim. Importing automatically...")
+            code="from manim import *\n"+code
         logger.info("Rendering animation from typed code...")
         try:
             exec(code, module.__dict__)

--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -6,6 +6,7 @@ import sys
 import re
 import traceback
 import importlib.util
+import types
 
 from .config import file_writer_config
 from .scene.scene import Scene
@@ -123,7 +124,9 @@ def get_scene_classes_from_module(module):
 def get_module(file_name):
     if file_name == "-":
         module = types.ModuleType("input_scenes")
+        logger.info("Enter the code for your animation and end with an EOF (usually CTRL+D):")
         code = sys.stdin.read()
+        logger.info("Rendering animation from typed code...")
         try:
             exec(code, module.__dict__)
             return module

--- a/tests/test_cli/dash_test_script.txt
+++ b/tests/test_cli/dash_test_script.txt
@@ -1,0 +1,5 @@
+# from manim import *
+class Dash_Test(Scene):
+        def construct(self):
+                self.play(ReplacementTransform(Square(),Circle()))
+                self.wait(2)

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -4,10 +4,11 @@ from shutil import rmtree
 import pytest
 
 
-def capture(command):
+def capture(command,instream=None):
     proc = subprocess.Popen(command,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
+                            stdin=instream
                             )
     out, err = proc.communicate()
     return out, err, proc.returncode
@@ -43,4 +44,18 @@ def test_WriteStuff(python_version):
     assert exitcode == 0, err
     assert os.path.exists(os.path.join(
         path_output, "videos", "basic_scenes", "480p15", "WriteStuff.mp4")), err
+    rmtree(path_output)
+
+@pytest.mark.skip_end_to_end
+def test_dash_as_name(python_version):
+    """Simulate using - as a filename. Intended to test the feature that allows end users to type manim code on the spot."""
+    path_output = os.path.join("tests_cache", "media_temp")
+    command = [python_version, "-m", "manim", "-", "-l", "--media_dir", path_output]
+    out, err, exitcode = capture(
+        command,
+        open(os.path.join(os.path.dirname(__file__), "dash_test_script.txt"))
+        )
+    assert exitcode == 0, err
+    assert os.path.exists(os.path.join(
+        path_output, "videos", "-", "480p15", "Dash_Test.mp4")), err
     rmtree(path_output)


### PR DESCRIPTION
Fixes the manim feature that allowed end users to enter manim code on the spot if they ran the `manim` command with `-` as the argument.

We just needed to import `types`, a built-in module, and the rest just fell into place.

I have added some log statements that make it clearer as to exactly what the end user had to do.

This is related to #75 which talks about removing it entirely since it didn't work as intended. Since this fixes it, will this close #75 ?
