### PR TITLE
Add support for all TeX fonts, by @cobordism

### DIFF
--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -298,7 +298,11 @@ class SVGMobject(VMobject):
         all_childNodes_have_id = []
         if not isinstance(element, minidom.Element):
             return
-        if element.hasAttribute('id'):
+        if element.hasAttribute('id') and (
+                not element.tagName == "g"
+                and
+                not element.tagName == "defs"
+                ):             
             return [element]
         for e in element.childNodes:
             all_childNodes_have_id.append(self.get_all_childNodes_have_id(e))

--- a/manim/mobject/svg/tex_mobject.py
+++ b/manim/mobject/svg/tex_mobject.py
@@ -147,7 +147,9 @@ class TexMobject(SingleStringTexMobject):
         SingleStringTexMobject.__init__(
             self, self.arg_separator.join(tex_strings), **kwargs
         )
-        self.break_up_by_substrings()
+        config = dict(self.CONFIG)
+        config.update(kwargs)
+        self.break_up_by_substrings(config)
         self.set_color_by_tex_to_color_map(self.tex_to_color_map)
 
         if self.organize_left_to_right:
@@ -167,7 +169,7 @@ class TexMobject(SingleStringTexMobject):
         split_list = [s for s in split_list if s != '']
         return split_list
 
-    def break_up_by_substrings(self):
+    def break_up_by_substrings(self, config):
         """
         Reorganize existing submojects one layer
         deeper based on the structure of tex_strings (as a list
@@ -175,8 +177,9 @@ class TexMobject(SingleStringTexMobject):
         """
         new_submobjects = []
         curr_index = 0
-        config = dict(self.CONFIG)
-        config["alignment"] = ""
+        # config = dict(self.CONFIG)
+        # config.update(kwargs)
+        # config["alignment"] = ""
         for tex_string in self.tex_strings:
             sub_tex_mob = SingleStringTexMobject(tex_string, **config)
             num_submobs = len(sub_tex_mob.submobjects)

--- a/manim/mobject/svg/tex_mobject.py
+++ b/manim/mobject/svg/tex_mobject.py
@@ -31,6 +31,7 @@ class SingleStringTexMobject(SVGMobject):
         "organize_left_to_right": False,
         "alignment": "",
         "type": "tex",
+        "template": config['tex_template'],
     }
 
     def __init__(self, tex_string, **kwargs):
@@ -39,7 +40,8 @@ class SingleStringTexMobject(SVGMobject):
         self.tex_string = tex_string
         file_name = tex_to_svg_file(
             self.get_modified_expression(tex_string),
-            self.type
+            self.type,
+            tex_template=self.template
         )
         SVGMobject.__init__(self, file_name=file_name, **kwargs)
         if self.height is None:

--- a/manim/tex_font_example.py
+++ b/manim/tex_font_example.py
@@ -1,0 +1,50 @@
+from manim import (
+    BLACK, WHITE, UP, UL, ORIGIN, DOWN, LEFT, RIGHT, TextMobject,
+    ApplyMethod, AnimationGroup, VGroup, FadeIn, FadeOut, Transform,
+    FadeOutAndShift, FadeInFromDown, FadeOutAndShiftDown, Scene
+    )
+from manim.tex_font_templates import (TexTemplateFromFontConfig, TEX_FONT_CONFIGS, FontMobject)
+
+TEXT_COLOUR = WHITE
+BACKGROUND_COLOUR = BLACK
+
+
+class simple(Scene):
+    def makelabel(self, font):
+        return FontMobject(
+            "FontMobject(text, font=", font+ ")").to_edge(UL)
+    def maketext(self, font):
+        return FontMobject(
+            TEX_FONT_CONFIGS[font]["description"],
+            font=font
+            )
+    def construct(self):
+        self.label = TextMobject("Tex Font Profile Showcase").to_edge(UL)
+        first = True
+        font = "font"
+        self.text = TextMobject("Tex font Sample")
+        self.add(self.label)
+        self.add(self.text)
+        self.wait(1)
+        for font in TEX_FONT_CONFIGS:
+            self.nexttext = self.maketext(font)
+            transform = Transform(self.label, self.makelabel(font)) if first is True else \
+                        Transform(self.label[1], self.makelabel(font)[1])
+            self.play(FadeOutAndShift(self.text, direction=UP),
+                      transform,
+                      FadeInFromDown(self.nexttext)
+                      )
+            self.text = self.nexttext
+            first = False
+            self.wait(0.5)
+        self.wait(2)
+        self.nexttext = TextMobject("Thanks to\\\\ http://jf.burnol.free.fr/showcase.html")
+        self.play(FadeOutAndShift(self.text, direction=UP),
+                  FadeOut(self.label),
+                  FadeInFromDown(self.nexttext))
+        self.text = self.nexttext
+        self.wait(4)
+        self.nexttext = FontMobject("Code at \\\\gitlab.com/co-bordism/manim/-/tree/all\_tex\_fonts\_community", font="ecfaugieeg")
+        self.play(FadeOutAndShift(self.text, direction=UP),
+                  FadeInFromDown(self.nexttext))
+        self.wait(6)

--- a/manim/tex_font_template.tex
+++ b/manim/tex_font_template.tex
@@ -1,0 +1,13 @@
+\documentclass[preview]{standalone}
+
+\usepackage[english]{babel}
+\usepackage{amsmath}
+\usepackage{amssymb}
+
+%PackageConfig
+
+FontConfig
+
+YourTextHere
+
+\end{document}

--- a/manim/tex_font_templates.py
+++ b/manim/tex_font_templates.py
@@ -1,0 +1,587 @@
+import os
+from .utils.tex import TexTemplateFromFile
+from .mobject.svg.tex_mobject import TextMobject
+from .utils.config_ops import digest_config
+
+
+class TexTemplateFromFontConfig(TexTemplateFromFile):
+    def __init__(self, font, **kwargs):
+        digest_config(self, kwargs)
+        self.font=font
+        if "compiler" in TEX_FONT_CONFIGS[font]:
+            tex_command = TEX_FONT_CONFIGS[font]["compiler"]
+        else:
+            tex_command = "latex"
+        if "output" in TEX_FONT_CONFIGS[font]:
+            tex_output = TEX_FONT_CONFIGS[font]["output"]
+        else:
+            tex_output = ".dvi"
+        self.tex_compiler = {
+            "command": tex_command,
+            "output_format": tex_output,
+        }
+        self.rebuild_cache()
+
+    def rebuild_cache(self):
+        self.body = self.TexTemplateFileBodyFromFontConfig(self.font)
+
+    def TexTemplateFileBodyFromFontConfig(self, font_name):
+        template = open(
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "tex_font_template.tex",
+                ),
+            "r").read()
+        file_body = \
+            template.replace(
+                "FontConfig",
+                TEX_FONT_CONFIGS[font_name]["config"] + (
+                    "" if r"\begin{document}" in TEX_FONT_CONFIGS[font_name]["config"] else
+                    r"""
+                    \begin{document}
+                    """)
+            )
+        return file_body
+
+class FontMobject(TextMobject):
+    def __init__(self, *tex_strings, font=None, **kwargs):
+        if font is None: # default to TextMobject
+            super().__init__(*tex_strings, **kwargs)
+        else:
+            super().__init__(*tex_strings, template=TexTemplateFromFontConfig(font), **kwargs)
+
+# All the font examples from http://jf.burnol.free.fr/showcase.html
+
+TEX_FONT_CONFIGS = {
+    "lmtp" : {
+        "description": "Latin Modern Typewriter Proportional",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage[variablett]{lmodern}
+            \renewcommand{\rmdefault}{\ttdefault}
+            \usepackage[LGRgreek]{mathastext}
+            \MTgreekfont{lmtt} % no lgr lmvtt, so use lgr lmtt
+            \Mathastext
+            \let\varepsilon\epsilon % only \varsigma in LGR
+            """,
+        },
+    "fufug": {
+        "description": "Fourier Utopia (Fourier upright Greek)",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage[upright]{fourier}
+            \usepackage{mathastext}
+            """,
+        },
+    "droidserif": {
+        "description": "Droid Serif",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage[default]{droidserif}
+            \usepackage[LGRgreek]{mathastext}
+            \let\varepsilon\epsilon
+            """,
+        },
+    "droidsans": {
+        "description": "Droid Sans",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage[default]{droidsans}
+            \usepackage[LGRgreek]{mathastext}
+            \let\varepsilon\epsilon
+            """,
+        },
+    "ncssg": {
+        "description": "New Century Schoolbook (Symbol Greek)",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage{newcent}
+            \usepackage[symbolgreek]{mathastext}
+            \linespread{1.1}
+            """,
+        },
+    "fceg": {
+        "description": "French Cursive (Euler Greek)",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage[default]{frcursive}
+            \usepackage[eulergreek,noplusnominus,noequal,nohbar,%
+            nolessnomore,noasterisk]{mathastext}
+            """,
+        },
+    "aksg": {
+        "description": "Auriocus Kalligraphicus (Symbol Greek)",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage{aurical}
+            \renewcommand{\rmdefault}{AuriocusKalligraphicus}
+            \usepackage[symbolgreek]{mathastext}
+            """,
+        },
+    "ecfscmg": {
+        "description": "ECF Skeetch (CM Greek)",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage[T1]{fontenc}
+            \DeclareFontFamily{T1}{fsk}{}
+            \DeclareFontShape{T1}{fsk}{m}{n}{<->s*[1.315] fskmw8t}{}
+            \renewcommand\rmdefault{fsk}
+            \usepackage[noendash,defaultmathsizes,nohbar,defaultimath]{mathastext}
+            """,
+        },
+    "urwagsg": {
+        "description": "URW Avant Garde (Symbol Greek)",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage{avant}
+            \renewcommand{\familydefault}{\sfdefault}
+            \usepackage[symbolgreek,defaultmathsizes]{mathastext}
+            """,
+        },
+    "urwzccmg": {
+        "description": "URW Zapf Chancery (CM Greek)",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \DeclareFontFamily{T1}{pzc}{}
+            \DeclareFontShape{T1}{pzc}{mb}{it}{<->s*[1.2] pzcmi8t}{}
+            \DeclareFontShape{T1}{pzc}{m}{it}{<->ssub * pzc/mb/it}{}
+            \DeclareFontShape{T1}{pzc}{mb}{sl}{<->ssub * pzc/mb/it}{}
+            \DeclareFontShape{T1}{pzc}{m}{sl}{<->ssub * pzc/mb/sl}{}
+            \DeclareFontShape{T1}{pzc}{m}{n}{<->ssub * pzc/mb/it}{}
+            \usepackage{chancery}
+            \usepackage{mathastext}
+            \linespread{1.05}
+            \begin{document}\boldmath
+            """,
+        },
+    "gfsbodoni": {
+        "description": "GFS Bodoni",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \renewcommand{\rmdefault}{bodoni}
+            \usepackage[LGRgreek]{mathastext}
+            \let\varphi\phi
+            \linespread{1.06}
+            """,
+        },
+    "palatinosg": {
+        "description": "Palatino (Symbol Greek)",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage{palatino}
+            \usepackage[symbolmax,defaultmathsizes]{mathastext}
+            """,
+        },
+    "ncssgpxm": {
+        "description": "New Century Schoolbook (Symbol Greek, PX math symbols)",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage{pxfonts}
+            \usepackage{newcent}
+            \usepackage[symbolgreek,defaultmathsizes]{mathastext}
+            \linespread{1.06}
+            """,
+        },
+    "epigrafica": {
+        "description": "Epigrafica",
+        "config": r"""
+            \usepackage[LGR,OT1]{fontenc}
+            \usepackage{epigrafica}
+            \usepackage[basic,LGRgreek,defaultmathsizes]{mathastext}
+            \let\varphi\phi
+            \linespread{1.2}
+            """,
+        },
+    "gfsneohellenic": {
+        "description": "GFS NeoHellenic",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \renewcommand{\rmdefault}{neohellenic}
+            \usepackage[LGRgreek]{mathastext}
+            \let\varphi\phi
+            \linespread{1.06}
+            """,
+        },
+    "comfortaa": {
+        "description": "Comfortaa",
+        "config": r"""
+            \usepackage[default]{comfortaa}
+            \usepackage[LGRgreek,defaultmathsizes,noasterisk]{mathastext}
+            \let\varphi\phi
+            \linespread{1.06}
+            """,
+        },
+    "slitexeg": {
+        "description": "SliTeX (Euler Greek)",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage{tpslifonts}
+            \usepackage[eulergreek,defaultmathsizes]{mathastext}
+            \MTEulerScale{1.06}
+            \linespread{1.2}
+            """,
+        },
+    # "aptxgm": {
+    #     "description": "Antykwa Półtawskiego (TX Fonts for Greek and math symbols)",
+    #     "config": r"""
+    #         \usepackage[OT4,OT1]{fontenc}
+    #         \usepackage{txfonts}
+    #         \usepackage[upright]{txgreeks}
+    #         \usepackage{antpolt}
+    #         \usepackage[defaultmathsizes,nolessnomore]{mathastext}
+    #         """,
+    #     },
+    "baskervaldadff": {
+        "description": "Baskervald ADF with Fourier",
+        "config": r"""
+            \usepackage[upright]{fourier}
+            \usepackage{baskervald}
+            \usepackage[defaultmathsizes,noasterisk]{mathastext}
+            """,
+        },
+    "libertine": {
+        "description": "Libertine",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage{libertine}
+            \usepackage[greek=n]{libgreek}
+            \usepackage[noasterisk,defaultmathsizes]{mathastext}
+            """,
+        },
+    "biolinum": {
+        "description": "Biolinum",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage{libertine}
+            \renewcommand{\familydefault}{\sfdefault}
+            \usepackage[greek=n,biolinum]{libgreek}
+            \usepackage[noasterisk,defaultmathsizes]{mathastext}
+            """,
+        },
+    # "mpmptx": {
+    #     "description": "Minion Pro and Myriad Pro (and TX fonts symbols)",
+    #     "config": r"""
+    #         \usepackage{txfonts}
+    #         \usepackage[upright]{txgreeks}
+    #         \usepackage[no-math]{fontspec}
+    #         \setmainfont[Mapping=tex-text]{Minion Pro}
+    #         \setsansfont[Mapping=tex-text,Scale=MatchUppercase]{Myriad Pro}
+    #         \renewcommand\familydefault\sfdefault
+    #         \usepackage[defaultmathsizes]{mathastext}
+    #         \renewcommand\familydefault\rmdefault
+    #         """,
+    #     "compiler": "xelatex"
+    #     },
+    # "mptx": {
+    #     "description": "Minion Pro (and TX fonts symbols)",
+    #     "config": r"""
+    #         \usepackage{txfonts}
+    #         \usepackage[no-math]{fontspec}
+    #         \setmainfont[Mapping=tex-text]{Minion Pro}
+    #         \usepackage[defaultmathsizes]{mathastext}
+    #         """,
+    #     "compiler": "xelatex"
+    #     },
+    "gnufsfs": {
+        "description": "GNU FreeSerif and FreeSans",
+        "config": r"""
+            \usepackage[no-math]{fontspec}
+            \setmainfont[ExternalLocation,
+                         Mapping=tex-text,
+                         BoldFont=FreeSerifBold,
+                         ItalicFont=FreeSerifItalic,
+                         BoldItalicFont=FreeSerifBoldItalic]{FreeSerif}
+            \setsansfont[ExternalLocation,
+                         Mapping=tex-text,
+                         BoldFont=FreeSansBold,
+                         ItalicFont=FreeSansOblique,
+                         BoldItalicFont=FreeSansBoldOblique,
+                         Scale=MatchLowercase]{FreeSans}
+            \renewcommand{\familydefault}{lmss}
+            \usepackage[LGRgreek,defaultmathsizes,noasterisk]{mathastext}
+            \renewcommand{\familydefault}{\sfdefault}
+            \Mathastext
+            \let\varphi\phi % no `var' phi in LGR encoding
+            \renewcommand{\familydefault}{\rmdefault}
+            """,
+        "compiler": "xelatex",
+        "output": ".pdf"
+        },
+    "gnufstx": {
+        "description": "GNU FreeSerif (and TX fonts symbols)",
+        "config": r"""
+            \usepackage[no-math]{fontspec}
+            \usepackage{txfonts}  %\let\mathbb=\varmathbb
+            \setmainfont[ExternalLocation,
+                         Mapping=tex-text,
+                         BoldFont=FreeSerifBold,
+                         ItalicFont=FreeSerifItalic,
+                         BoldItalicFont=FreeSerifBoldItalic]{FreeSerif}
+            \usepackage[defaultmathsizes]{mathastext}
+            """,
+        "compiler": "xelatex",
+        "output": ".pdf"
+        },
+    "librisadff": {
+        "description": "Libris ADF with Fourier",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage[upright]{fourier}
+            \usepackage{libris}
+            \renewcommand{\familydefault}{\sfdefault}
+            \usepackage[noasterisk]{mathastext}
+            """,
+        },
+    # "vollkorntx": {
+    #     "description": "Vollkorn (TX fonts for Greek and math symbols)",
+    #     "config": r"""
+    #         \usepackage[T1]{fontenc}
+    #         \usepackage{txfonts}
+    #         \usepackage[upright]{txgreeks}
+    #         \usepackage{vollkorn}
+    #         \usepackage[defaultmathsizes]{mathastext}
+    #         """,
+    #     },
+    # "brushscriptxpx": {
+    #     "description": "BrushScriptX-Italic (PX math and Greek)",
+    #     "config": r"""
+    #         \usepackage[T1]{fontenc}
+    #         \usepackage{pxfonts}
+    #         %\usepackage{pbsi}
+    #         \renewcommand{\rmdefault}{pbsi}
+    #         \renewcommand{\mddefault}{xl}
+    #         \renewcommand{\bfdefault}{xl}
+    #         \usepackage[defaultmathsizes,noasterisk]{mathastext}
+    #         \begin{document}\boldmath
+    #         """,
+    #         "compiler": "xelatex"
+    #     },
+    "ecftallpaul": {
+        "description": "ECF Tall Paul (with Symbol font)",
+        "config": r"""
+            \DeclareFontFamily{T1}{ftp}{}
+            \DeclareFontShape{T1}{ftp}{m}{n}{
+               <->s*[1.4] ftpmw8t
+            }{} % increase size by factor 1.4
+            \renewcommand\familydefault{ftp} % emerald package
+            \usepackage[symbol]{mathastext}
+            \let\infty\inftypsy
+            """,
+        },
+    "ecfaugieeg": {
+        "description": "ECF Augie (Euler Greek)",
+        "config": r"""
+            \renewcommand\familydefault{fau} % emerald package
+            \usepackage[defaultmathsizes,eulergreek]{mathastext}
+            """,
+        },
+    "ecfjdtx": {
+        "description": "ECF JD (with TX fonts)",
+        "config": r"""
+            \usepackage{txfonts}
+            \usepackage[upright]{txgreeks}
+            \renewcommand\familydefault{fjd} % emerald package
+            \usepackage{mathastext}
+            \begin{document}\mathversion{bold}
+            """,
+        },
+    "ecfwebstertx": {
+        "description": "ECF Webster (with TX fonts)",
+        "config": r"""
+            \usepackage{txfonts}
+            \usepackage[upright]{txgreeks}
+            \renewcommand\familydefault{fwb} % emerald package
+            \usepackage{mathastext}
+            \renewcommand{\int}{\intop\limits}
+            \linespread{1.5}
+            \begin{document}\mathversion{bold}
+            """,
+        },
+    # "comicsansms": {
+    #     "description": "Comic Sans MS",
+    #     "config": r"""
+    #         \usepackage[no-math]{fontspec}
+    #         \setmainfont[Mapping=tex-text]{Comic Sans MS}
+    #         \usepackage[defaultmathsizes]{mathastext}
+    #         """,
+    #     "compiler": "xelatex",
+    #     },
+    "electrumadfcm": {
+        "description": "Electrum ADF (CM Greek)",
+        "config": r"""
+            \usepackage[T1]{fontenc}
+            \usepackage[LGRgreek,basic,defaultmathsizes]{mathastext}
+            \usepackage[lf]{electrum}
+            \Mathastext
+            \let\varphi\phi
+            """,
+        },
+    # "americantypewriter": {
+    #     "description": "American Typewriter",
+    #     "config": r"""
+    #         \usepackage[no-math]{fontspec}
+    #         \setmainfont[Mapping=tex-text]{American Typewriter}
+    #         \usepackage[defaultmathsizes]{mathastext}
+    #         """,
+    #     "compiler": "xelatex"
+    #     },
+    # "papyrus": {
+    #     "description": "Papyrus",
+    #     "config": r"""
+    #         \usepackage[no-math]{fontspec}
+    #         \setmainfont[Mapping=tex-text]{Papyrus}
+    #         \usepackage[defaultmathsizes]{mathastext}
+    #         """,
+    #     "compiler": "xelatex"
+    #     },
+    # "noteworthylight": {
+    #     "description": "Noteworthy Light",
+    #     "config": r"""
+    #         \usepackage[no-math]{fontspec}
+    #         \setmainfont[Mapping=tex-text]{Noteworthy Light}
+    #         \usepackage[defaultmathsizes]{mathastext}
+    #         """,
+    #     "compiler": "xelatex"
+    #     },
+    # "chalkboardse": {
+    #     "description": "Chalkboard SE",
+    #     "config": r"""
+    #         \usepackage[no-math]{fontspec}
+    #         \setmainfont[Mapping=tex-text]{Chalkboard SE}
+    #         \usepackage[defaultmathsizes]{mathastext}
+    #         """,
+    #     "compiler": "xelatex"
+    #     },
+    "chalkduster": {
+        "description": "Chalkduster",
+        "config": r"""
+            \usepackage[no-math]{fontspec}
+            \setmainfont[Mapping=tex-text]{Chalkduster}
+            \usepackage[defaultmathsizes]{mathastext}
+            """,
+        "compiler": "lualatex",
+        "output": ".pdf"
+        },
+    # # "applechancery": {
+    # #     "description": "Apple Chancery",
+    # #     "config": r"""
+    # #         \usepackage[no-math]{fontspec}
+    # #         \setmainfont[Mapping=tex-text]{Apple Chancery}
+    # #         \usepackage[defaultmathsizes]{mathastext}
+    # #         """,
+    # #     "compiler": "xelatex"
+    # #     },
+    # "zapfchancery": {
+    #     "description": "Zapf Chancery",
+    #     "config": r"""
+    #         \DeclareFontFamily{T1}{pzc}{}
+    #         \DeclareFontShape{T1}{pzc}{mb}{it}{<->s*[1.2] pzcmi8t}{}
+    #         \DeclareFontShape{T1}{pzc}{m}{it}{<->ssub * pzc/mb/it}{}
+    #         \usepackage{chancery} % = \renewcommand{\rmdefault}{pzc}
+    #         \renewcommand\shapedefault\itdefault
+    #         \renewcommand\bfdefault\mddefault
+    #         \usepackage[defaultmathsizes]{mathastext}
+    #         \linespread{1.05}
+    #         """,
+    #     },
+    # # "italicvollkornf": {
+    # #     "description": "Vollkorn with Fourier (Italic)",
+    # #     "config": r"""
+    # #         \usepackage{fourier}
+    # #         \usepackage{vollkorn}
+    # #         \usepackage[italic,nohbar]{mathastext}
+    # #         """,
+    # #     },
+    # "italiclmtpcm": {
+    #     "description": "Latin Modern Typewriter Proportional (CM Greek) (Italic)",
+    #     "config": r"""
+    #         \usepackage[T1]{fontenc}
+    #         \usepackage[variablett,nomath]{lmodern}
+    #         \renewcommand{\familydefault}{\ttdefault}
+    #         \usepackage[frenchmath]{mathastext}
+    #         \linespread{1.08}
+    #         """,
+    #     },
+    # "italictimesf": {
+    #     "description": "Times with Fourier (Italic)",
+    #     "config": r"""
+    #         \usepackage{fourier}
+    #         \renewcommand{\rmdefault}{ptm}
+    #         \usepackage[italic,defaultmathsizes,noasterisk]{mathastext}
+    #         """,
+    #     },
+    # "italichelveticaf": {
+    #     "description": "Helvetica with Fourier (Italic)",
+    #     "config": r"""
+    #         \usepackage[T1]{fontenc}
+    #         \usepackage[scaled]{helvet}
+    #         \usepackage{fourier}
+    #         \renewcommand{\rmdefault}{phv}
+    #         \usepackage[italic,defaultmathsizes,noasterisk]{mathastext}
+    #         """,
+    #     },
+    # "italicvanturisadff": {
+    #     "description": "Venturis ADF with Fourier (Italic)",
+    #     "config": r"""
+    #         \usepackage{fourier}
+    #         \usepackage[lf]{venturis}
+    #         \usepackage[italic,defaultmathsizes,noasterisk]{mathastext}
+    #         """,
+    #     },
+    # "italicromandeadff": {
+    #     "description": "Romande ADF with Fourier (Italic)",
+    #     "config": r"""
+    #         \usepackage[T1]{fontenc}
+    #         \usepackage{fourier}
+    #         \usepackage{romande}
+    #         \usepackage[italic,defaultmathsizes,noasterisk]{mathastext}
+    #         \renewcommand{\itshape}{\swashstyle}
+    #         """,
+    #     },
+    # "italicgfsdidot": {
+    #     "description": "GFS Didot (Italic)",
+    #     "config": r"""
+    #         \usepackage[T1]{fontenc}
+    #         \renewcommand\rmdefault{udidot}
+    #         \usepackage[LGRgreek,defaultmathsizes,italic]{mathastext}
+    #         \let\varphi\phi
+    #         """,
+    #     },
+    # "italicdroidserifpx": {
+    #     "description": "Droid Serif (PX math symbols) (Italic)",
+    #     "config": r"""
+    #         \usepackage[T1]{fontenc}
+    #         \usepackage{pxfonts}
+    #         \usepackage[default]{droidserif}
+    #         \usepackage[LGRgreek,defaultmathsizes,italic,basic]{mathastext}
+    #         \let\varphi\phi
+    #         """,
+    #     },
+    # "italicdroidsans": {
+    #     "description": "Droid Sans (Italic)",
+    #     "config": r"""
+    #         \usepackage[T1]{fontenc}
+    #         \usepackage[default]{droidsans}
+    #         \usepackage[LGRgreek,defaultmathsizes,italic]{mathastext}
+    #         \let\varphi\phi
+    #         """,
+    #     },
+    # "italicverdana": {
+    #     "description": "Verdana (Italic)",
+    #     "config": r"""
+    #         \usepackage[no-math]{fontspec}
+    #         \setmainfont[Mapping=tex-text]{Verdana}
+    #         \usepackage[defaultmathsizes,italic]{mathastext}
+    #         """,
+    #     "compiler": "xelatex"
+    #     },
+    # "italicbaskerville": {
+    #     "description": "Baskerville (Italic)",
+    #     "config": r"""
+    #         \usepackage[no-math]{fontspec}
+    #         \setmainfont[Mapping=tex-text]{Baskerville}
+    #         \usepackage[defaultmathsizes,italic]{mathastext}
+    #         """,
+    #     "compiler": "xelatex"
+    #     },
+}

--- a/manim/tex_font_templates.py
+++ b/manim/tex_font_templates.py
@@ -374,6 +374,8 @@ TEX_FONT_CONFIGS = {
             \renewcommand\familydefault{fau} % emerald package
             \usepackage[defaultmathsizes,eulergreek]{mathastext}
             """,
+        "compiler": "pdflatex",
+        "output": ".pdf"
         },
     "ecfjdtx": {
         "description": "ECF JD (with TX fonts)",
@@ -459,8 +461,8 @@ TEX_FONT_CONFIGS = {
             \setmainfont[Mapping=tex-text]{Chalkduster}
             \usepackage[defaultmathsizes]{mathastext}
             """,
-        "compiler": "lualatex",
-        "output": ".pdf"
+        "compiler": "xelatex",
+        "output": ".xdv"
         },
     # # "applechancery": {
     # #     "description": "Apple Chancery",

--- a/manim/utils/tex.py
+++ b/manim/utils/tex.py
@@ -9,6 +9,10 @@ class TexTemplateFromFile():
         "use_ctex": False,
         "filename" : "tex_template.tex",
         "text_to_replace": "YourTextHere",
+        "tex_compiler": {
+            "command": "latex",
+            "output_format": ".dvi",
+        },
     }
     body = ""
 

--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -15,11 +15,16 @@ def tex_hash(expression):
     return hasher.hexdigest()[:16]
 
 
-def tex_to_svg_file(expression, source_type):
-    tex_template = config['tex_template']
+def tex_to_svg_file(expression, source_type, tex_template=None):
+    if tex_template is None:
+        tex_template = config['tex_template']
     tex_file = generate_tex_file(expression, tex_template, source_type)
-    dvi_file = tex_to_dvi(tex_file, tex_template.use_ctex)
-    return dvi_to_svg(dvi_file, use_ctex=tex_template.use_ctex)
+    dvi_file = tex_to_dvi(tex_file,
+                          use_ctex=tex_template.use_ctex,
+                          tex_compiler=tex_template.tex_compiler)
+    return dvi_to_svg(dvi_file,
+                      use_ctex=tex_template.use_ctex,
+                      tex_compiler=tex_template.tex_compiler)
 
 
 def generate_tex_file(expression, tex_template, source_type):
@@ -40,24 +45,31 @@ def generate_tex_file(expression, tex_template, source_type):
             outfile.write(output)
     return result
 
-
-def tex_to_dvi(tex_file, use_ctex=False):
-    result = tex_file.replace(".tex", ".dvi" if not use_ctex else ".xdv")
-    result = Path(result).as_posix()
-    tex_file = Path(tex_file).as_posix()
-    tex_dir = Path(file_writer_config['tex_dir']).as_posix()
-    if not os.path.exists(result):
-        commands = [
-            "latex",
+def tex_compilation_command(compiler, tex_file, tex_dir): 
+    if compiler["command"] == "latex" or \
+       compiler["command"] == "pdflatex" or \
+       compiler["command"] == "luatex" or \
+       compiler["command"] == "lualatex":
+       commands = [
+            compiler["command"],
             "-interaction=batchmode",
+            "-output-format=\"" + compiler["output_format"][1:] + "\"",
             "-halt-on-error",
             "-output-directory=\"{}\"".format(tex_dir),
             "\"{}\"".format(tex_file),
             ">",
             os.devnull
-        ] if not use_ctex else [
+        ]
+    elif compiler["command"] == "xelatex":
+        if compiler["output_format"] == ".xdv":
+            outflag = "-no-pdf"
+        elif compiler["output_format"] == ".pdf":
+            outflag = ""
+        else:
+            raise Exception('xelatex output is either pdf or xdv')
+        commands = [
             "xelatex",
-            "-no-pdf",
+            outflag,
             "-interaction=batchmode",
             "-halt-on-error",
             "-output-directory=\"{}\"".format(tex_dir),
@@ -65,36 +77,54 @@ def tex_to_dvi(tex_file, use_ctex=False):
             ">",
             os.devnull
         ]
-        exit_code = os.system(" ".join(commands))
+    else:
+        raise Exception("Tex compiler " + compiler["command"] + " unknown.")
+
+    return " ".join(commands)
+
+def tex_to_dvi(tex_file, use_ctex=False, tex_compiler=None):
+    if tex_compiler is None: # use default latex/dvi or xelatex/xdv
+        tex_compiler = \
+            {"command": "xelatex", "output_format": ".xdv"} if use_ctex else \
+            {"command": "latex", "output_format": ".dvi"}
+    result = tex_file.replace(".tex", tex_compiler["output_format"])
+    result = Path(result).as_posix()
+    tex_file = Path(tex_file).as_posix()
+    tex_dir = Path(file_writer_config['tex_dir']).as_posix()
+    if not os.path.exists(result):
+        command = tex_compilation_command(tex_compiler, tex_file, tex_dir)
+        exit_code = os.system(command)
+
         if exit_code != 0:
             log_file = tex_file.replace(".tex", ".log")
             raise Exception(
-                ("LaTeX error converting to dvi. "
-                 if not use_ctex
-                 else "XeLaTeX error converting to xdv. ") +
-                f"See log output above or the log file: {log_file}")
+                tex_compiler["command"] +  " error error converting to "  
+                + tex_compiler["output_format"][1:] + ". "
+                + f"See log output above or the log file: {log_file}")
     return result
 
 
-def dvi_to_svg(dvi_file, use_ctex=False, regen_if_exists=False):
+def dvi_to_svg(dvi_file, use_ctex=False, tex_compiler=None,
+               regen_if_exists=False, page=1):
     """
-    Converts a dvi, which potentially has multiple slides, into a
-    directory full of enumerated pngs corresponding with these slides.
-    Returns a list of PIL Image objects for these images sorted as they
-    where in the dvi
+    Converts a dvi, xdv, or pdf into an svg using dvisvgm.
     """
-    result = dvi_file.replace(".dvi" if not use_ctex else ".xdv", ".svg")
+    if tex_compiler is None: # use default latex/dvi or xelatex/xdv
+        tex_compiler = \
+            {"command": "xelatex", "output_format": ".xdv"} if use_ctex else \
+            {"command": "latex", "output_format": ".dvi"}
+    result = dvi_file.replace(tex_compiler["output_format"], ".svg")    
     result = Path(result).as_posix()
     dvi_file = Path(dvi_file).as_posix()
     if not os.path.exists(result):
         commands = [
             "dvisvgm",
+            "--pdf" if tex_compiler["output_format"] == ".pdf" else "",
+            "-p " + str(page),
             "\"{}\"".format(dvi_file),
             "-n",
-            "-v",
-            "0",
-            "-o",
-            "\"{}\"".format(result),
+            "-v 0",
+            "-o " + "\"{}\"".format(result),
             ">",
             os.devnull
         ]


### PR DESCRIPTION
## List of Changes
- Allow for specifying a tex template when you create a TexMobject.
    - `TexMobject("text1", template=template1)` and `TexMobject("text2", template=template2)` can be used in the same scene.

- Allow end user to specify which LaTeX and output command is used.
    - End user can specify that a particular template should be compiled with lualatex with a pdf output.

- Added a collection of TeX fonts with maths support
    - All this font stuff is entirely contained in the two files tex_font_template.tex and tex_font_templates.py and can be removed, keeping the other changes.

- Fixes to SVG import to allow InkScape saved files.
    - The inkskape svg fix is a small fix and will be subsumed in the future in the revamp of the svg system.


## Motivation
Author's original motivation for all of this was to emulate chalk on a blackboard like so: https://vimeo.com/432852225
This could be extended to multiple different styles of text.

## Explanation for Changes
These changes allow the end user to select TexTemplates  even for individual Tex[t]Mobjects.

## Testing Status
I'm guessing @cobordism has tested this on their own machine.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

