### PR TITLE
Remove a reference to Travis in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,6 @@ As this is a Fork of [Manim by 3b1b](https://github.com/3b1b/manim), contributin
 
 > As stated in the General Contribution Guidelines, make sure to test your changes against the example scenes in the `example_scenes` directory and test scenes in the `tests` directory, and add a new test in the `tests` directory for your new feature if you've made one.
 
-> Note: if your Pull Request doesn't change any of the actual code, please add `[skip ci]` to your commit message for Travis to ignore it.
-
 5. Finally, instead of  typing in `git push`, enter the command below.
 
    ```sh


### PR DESCRIPTION
There was a note asking the contributor to add `[skip ci]` to their commit if they did not modify any code that will be run.
Since we're not using Travis anymore, it's pointless to have this note in here.

## List of Changes
- Remove reference to Travis CI in `CONTRIBUTING.md`

## Motivation
Since we're not using Travis anymore, it's pointless to have this note in here.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
