### PR TITLE
Use file_writer_config instead of config to get text_dir for Text()

### DIFF
--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -5,7 +5,7 @@ import hashlib
 import cairo
 
 from ...constants import *
-from ...config import config
+from ...config import config,file_writer_config
 from ...container.container import Container
 from ...logger import logger
 from ...mobject.geometry import Dot, Rectangle
@@ -96,7 +96,7 @@ class Text(SVGMobject):
     def get_space_width(self):
         size = self.size * 10
 
-        dir_name = config['text_dir']
+        dir_name = file_writer_config['text_dir']
         file_name = os.path.join(dir_name, "space") + '.svg'
 
         surface = cairo.SVGSurface(file_name, 600, 400)
@@ -291,8 +291,7 @@ class Text(SVGMobject):
         if self.font == '':
             if NOT_SETTING_FONT_MSG != '':
                 logger.warning(NOT_SETTING_FONT_MSG)
-
-        dir_name = config['text_dir']
+        dir_name = file_writer_config['text_dir']
         hash_name = self.text2hash()
         file_name = os.path.join(dir_name, hash_name)+'.svg'
         if os.path.exists(file_name):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -38,7 +38,7 @@ class SceneTester:
         self.path_tests_data = os.path.join('tests', 'tests_data', module_tested)
 
         if caching_needed:
-            config['text_dir'] = os.path.join(
+            file_writer_config['text_dir'] = os.path.join(
                 self.path_tests_medias_cache, scene_object.__name__, 'Text')
             file_writer_config['tex_dir'] = os.path.join(
                 self.path_tests_medias_cache, scene_object.__name__, 'Tex')


### PR DESCRIPTION
Fixes a bug where a KeyError would be thrown when rendering a `Text()` mobject.

## List of Changes
- Import file_writer_config from config.py
- Use `file_writer_config['text_dir']` to obtain `text_dir` instead of `config['text_dir']`

## Motivation
Without this fix, you will be unable to render `Text()` objects, like, at _all_.

## Explanation for Changes
`config` does not contain `text_dir`, but `file_writer_config` does. Hence, replacing `config` with `file_writer_config` will ensure that the `text_dir` is obtained when required.

## Testing Status
We should probably edit the test `test_writing` to ensure that it picks up on stuff like this.
Mentioning @huguesdevimeux for his thoughts.

EDIT: huguesdevimeux has provided the necessary solution and it has been committed in this PR.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
