### PR TITLE
Rename CustomTeX example scenes to be more specific.

### DIFF
--- a/example_scenes/customtex.py
+++ b/example_scenes/customtex.py
@@ -1,23 +1,23 @@
 from manim import *
 
-# Test cases:
-# 1. manim customtex.py ExampleFileScene -pl
-#       --> should fail, because \vv is not defined
-#
-# 2. manim customtex.py ExampleFileScene --tex_template custom_template.tex -pl
-#       --> should succeed as custom template includes package esvect (which defines \vv)
-#
-# 3. manim customtex.py ExampleClassScene -pl
-#       --> should succeed as the package esvect is included in template object
-
-class ExampleFileScene(Scene):
+class TexTemplateFromCLI(Scene):
+    """This scene uses a custom TexTemplate file.
+    The path of the TexTemplate _must_ be passed with the command line
+    argument `--tex_template <path to template>`.
+    For this scene, you can use the custom_template.tex file next to it.
+    This scene will fail to render if a tex_template.tex that doesn't
+    import esvect is passed, and will throw a LaTeX error in that case.
+    """
     def construct(self):
         text = TexMobject(r"\vv{vb}")
         #text=TextMobject(r"$\vv{vb}$")
         self.play(Write(text))
 
 
-class ExampleClassScene(Scene):
+class InCodeTexTemplate(Scene):
+    """This example scene demonstrates how to modify the tex template
+    for a particular scene from the code for the scene itself.
+    """
     def construct(self):
         tpl = TexTemplate()
         tpl.append_package(["esvect", ["f"]])


### PR DESCRIPTION
## List of Changes
- Rename `ExampleFileScene` to `TexTemplateFromCLI`
- Rename `ExampleClassScene` to `InCodeTexTemplate`
- Remove comments and rewrite them as docstrings for corresponding Scenes.

## Motivation
The "better" way of drawing the end users' attention to _how_ to use the custom TexTemplate related functions was discussed in #199 , and the conversation stopped with @leotrs suggesting that the instructions should probably go in the documentation instead of as comments in the file.

For clarity, `ExampleFileScene` has been renamed to `TexTemplateFromCLI` and `ExampleClassScene` has been renamed to `InCodeTexTemplate` to better reflect what they demonstrate.

## Testing Status
As this is only a name change in an example scene, it shouldn't really impact anything else.
The scenes themselves still work as intended.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
