### PR TITLE
Add config entries for `default_pixel_width` and `default_pixel_height`

### DIFF
--- a/manim/camera/camera.py
+++ b/manim/camera/camera.py
@@ -1092,8 +1092,7 @@ class Camera(object):
         """
         # TODO: This seems...unsystematic
         big_sum = op.add(
-            camera_config["default_pixel_height"],
-            camera_config["default_pixel_width"],
+            camera_config["default_pixel_height"], camera_config["default_pixel_width"],
         )
         this_sum = op.add(self.get_pixel_height(), self.get_pixel_width(),)
         factor = fdiv(big_sum, this_sum)

--- a/manim/camera/camera.py
+++ b/manim/camera/camera.py
@@ -10,7 +10,7 @@ import cairo
 import numpy as np
 
 from ..constants import *
-from ..config import config
+from ..config import config, camera_config
 from ..logger import logger
 from ..mobject.types.image_mobject import AbstractImageMobject
 from ..mobject.mobject import Mobject
@@ -1092,8 +1092,8 @@ class Camera(object):
         """
         # TODO: This seems...unsystematic
         big_sum = op.add(
-            PRODUCTION_QUALITY_CAMERA_CONFIG["pixel_height"],
-            PRODUCTION_QUALITY_CAMERA_CONFIG["pixel_width"],
+            camera_config["default_pixel_height"],
+            camera_config["default_pixel_width"],
         )
         this_sum = op.add(self.get_pixel_height(), self.get_pixel_width(),)
         factor = fdiv(big_sum, this_sum)

--- a/manim/config.py
+++ b/manim/config.py
@@ -34,6 +34,8 @@ def _parse_config(config_parser, args):
         section = config_parser["CLI"]
     config = {opt: section.getint(opt) for opt in config_parser[flag]}
 
+    config["default_pixel_height"] = default.getint("pixel_height")
+    config["default_pixel_width"] = default.getint("pixel_width")
     # The -r, --resolution flag overrides the *_quality flags
     if args.resolution is not None:
         if "," in args.resolution:


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
- Add a new entry `config["default_pixel_height"]` and set it to the default value from the config files' CLI section.
- Add a new entry `config["default_pixel_width"]` and set it to the default value from the config files' CLI section.
- Make `Camera.adjusted_thickness` use `camera_config["default_pixel_height"]` and  `camera_config["default_pixel_width"]` instead of values from the nonexistent `PRODUCTION_QUALITY_CAMERA_CONFIG`

## Motivation
This will fix #228 .

## Explanation for Changes
With the new config revamp, `PRODUCTION_QUALITY_CAMERA_CONFIG` has been removed. A suitable replacement for the only places it is used (which is in `Camera.adjusted_thickness`) would be to add `default_pixel_height` and `default_pixel_width` entries to `config`, and make `Camera.adjusted_thickness` use those values instead. 

## Testing Status
Pytest exited with 0 errors.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
