### PR TITLE
fixed -f flag on windows

### DIFF
--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -36,7 +36,7 @@ def open_file_if_needed(file_writer):
 
         for file_path in file_paths:
             if current_os == "Windows":
-                os.startfile(file_path)
+                os.startfile(os.path.dirname(file_path))
             else:
                 commands = []
                 if current_os == "Linux":


### PR DESCRIPTION
## List of Changes
- Fixed -f flag on windows. (- f flag will show the video output file in file explorer (on windows))

## Motivation
It was broken and as less bug = more fun I had to fix it. fixes #234 

## Explanation for Changes
I added `os.dirname `to the `os.startfile `(otherwise it would start the file with video viewer and not the directory with file explorer)

## Testing Status
This won't come with tests now as we don't have correct implementation of CLI tests now. see #227 .
Furthermore, I don't see how to test that.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

