### PR TITLE
Add rendered scene name to render end message

### DIFF
--- a/manim/logger.py
+++ b/manim/logger.py
@@ -63,6 +63,7 @@ RichHandler.KEYWORDS = [
     "module",
     "File",
     "Rendering",
+    "Rendered"
 ]
 logging.basicConfig(
     level="NOTSET",

--- a/manim/logger.py
+++ b/manim/logger.py
@@ -63,7 +63,7 @@ RichHandler.KEYWORDS = [
     "module",
     "File",
     "Rendering",
-    "Rendered"
+    "Rendered",
 ]
 logging.basicConfig(
     level="NOTSET",

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -104,9 +104,11 @@ class Scene(Container):
     def print_end_message(self):
         """
         Used internally to print the number of
-        animations played after the scene ends.
+        animations played after the scene ends, 
+        as well as the name of the scene rendered 
+        (useful when using the `-a` option).
         """
-        logger.info("Played {} animations".format(self.num_plays))
+        logger.info(f"Render complete for {self.__str__()}.\nPlayed {self.num_plays} animations")
 
     def set_variables_as_attrs(self, *objects, **newly_named_objects):
         """

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -108,7 +108,7 @@ class Scene(Container):
         as well as the name of the scene rendered 
         (useful when using the `-a` option).
         """
-        logger.info(f"Rendered {self.__str__()}\nPlayed {self.num_plays} animations")
+        logger.info(f"Rendered {str(self)}\nPlayed {self.num_plays} animations")
 
     def set_variables_as_attrs(self, *objects, **newly_named_objects):
         """

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -108,7 +108,7 @@ class Scene(Container):
         as well as the name of the scene rendered 
         (useful when using the `-a` option).
         """
-        logger.info(f"Render complete for {self.__str__()}.\nPlayed {self.num_plays} animations")
+        logger.info(f"Rendered {self.__str__()}\nPlayed {self.num_plays} animations")
 
     def set_variables_as_attrs(self, *objects, **newly_named_objects):
         """


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
<!-- List out your changes one by one like this:
- Change 1
- Change 2
- and so on..
-->
- Added `Rendered` as a keyword to `RichHandler.KEYWORDS` (manim/logger.py, e8965ff)
- Modify end message a bit. (manim/scene/scene.py, 
401577c)
- Replaced usage of `str.format()` with f-string in manim/scene/scene.py

## Motivation
<!-- Why you feel your changes are required. -->
To close #232

## Explanation for Changes
<!-- How do your changes solve aforementioned problems? -->
Adds the scene name to the end message.

## Testing Status
<!-- Optional, but recommended, your computer specs and what tests you ran with their results, if any -->
Works on WIndows 10:
![image](https://user-images.githubusercontent.com/65204531/89121708-cfa8dd00-d4de-11ea-8304-88c7a89db56a.png)
(command: `manim example_scenes/basic.py -as`)

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
