### PR TITLE
remove_stray_braces quickfix

### DIFF
--- a/manim/mobject/svg/tex_mobject.py
+++ b/manim/mobject/svg/tex_mobject.py
@@ -105,8 +105,8 @@ class SingleStringTexMobject(SVGMobject):
         Makes TexMobject resiliant to unmatched { at start
         """
         # "\{" does not count (it's a brace literal), but "\\{" counts (it's a new line and then brace)
-        num_lefts = tex.count('{')-tex.count('\\{')+tex.count('\\\\{')
-        num_rights = tex.count('}')-tex.count('\\}')+tex.count('\\\\}')
+        num_lefts = tex.count("{")-tex.count("\\{")+tex.count("\\\\{")
+        num_rights = tex.count("}")-tex.count("\\}")+tex.count("\\\\}")
         while num_rights > num_lefts:
             tex = "{" + tex
             num_lefts += 1

--- a/manim/mobject/svg/tex_mobject.py
+++ b/manim/mobject/svg/tex_mobject.py
@@ -105,8 +105,8 @@ class SingleStringTexMobject(SVGMobject):
         Makes TexMobject resiliant to unmatched { at start
         """
         # "\{" does not count (it's a brace literal), but "\\{" counts (it's a new line and then brace)
-        num_lefts = tex.count("{")-tex.count("\\{")+tex.count("\\\\{")
-        num_rights = tex.count("}")-tex.count("\\}")+tex.count("\\\\}")
+        num_lefts = tex.count("{") - tex.count("\\{") + tex.count("\\\\{")
+        num_rights = tex.count("}") - tex.count("\\}") + tex.count("\\\\}")
         while num_rights > num_lefts:
             tex = "{" + tex
             num_lefts += 1

--- a/manim/mobject/svg/tex_mobject.py
+++ b/manim/mobject/svg/tex_mobject.py
@@ -104,7 +104,9 @@ class SingleStringTexMobject(SVGMobject):
         """
         Makes TexMobject resiliant to unmatched { at start
         """
-        num_lefts, num_rights = [tex.count(char) for char in "{}"]
+        # "\{" does not count (it's a brace literal), but "\\{" counts (it's a new line and then brace)
+        num_lefts = tex.count('{')-tex.count('\\{')+tex.count('\\\\{')
+        num_rights = tex.count('}')-tex.count('\\}')+tex.count('\\\\}')
         while num_rights > num_lefts:
             tex = "{" + tex
             num_lefts += 1


### PR DESCRIPTION
## List of Changes
Fixing  #225. (In short, `TexMobject("\\{")` is giving a LaTeX error.)

## Motivation
To make compound TexMobjects consisting of literal braces, e.g. set-builder notation: `TexMobject("\\{,"x","\mid","x>2","\\}")` 

## Explanation for Changes
It's just a one-line fix, that substracts `\\{` and `\\}` from the count. (It also adds back `\\\\{` and `\\\\}` because those are not literal braces)

## Testing Status
As this is just a one-line fix, I only provide the minimal example that didn't work

```
class LiteralBraceTest(Scene):
    def construct(self):
        a = TexMobject("\\{")
        self.add(a)
```
![LiteralBraceTest](https://user-images.githubusercontent.com/20141904/89134815-706fba80-d528-11ea-93ca-f2f80d303f3c.png)
:


## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
