### PR TITLE
fixed -f flag (fix introduced bug by #235)

### DIFF
--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -36,7 +36,10 @@ def open_file_if_needed(file_writer):
 
         for file_path in file_paths:
             if current_os == "Windows":
-                os.startfile(os.path.dirname(file_path))
+                if file_writer_config["preview"]:
+                    os.startfile(file_path)
+                if file_writer_config["show_file_in_finder"]:
+                    os.startfile(os.path.dirname(file_path))
             else:
                 commands = []
                 if current_os == "Linux":


### PR DESCRIPTION
I would like to deeply apologize for that. My last PR #235 broke `-p` flag on windows. The bug was that -p would open the file in the file explorer rather than preview it. #235 didn't fix -f flag on windows as there was no -f flag on windows.

Here is the quick fix. Now `-f` flag works on windows as well as `-p` flag 

Once again, sorry for that.

