### PR TITLE
specify minimal required version of rich

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pycairo
 pydub
 pygments
 pyreadline; sys_platform == 'win32'
-rich
+rich>=4.2.1
 # pytest (for development only)
 # black (for development only)


### PR DESCRIPTION
## List of Changes
- Set minimum requirement for version of `rich` in `requirements.txt`


## Motivation
Resolves #245 


## Explanation for Changes
See https://github.com/ManimCommunity/manim/issues/245#issuecomment-668498765 and the related issue https://github.com/willmcgugan/rich/issues/190


## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))


