### PR TITLE
Change pip3 installation instruction to community edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ If you have installed MacTeX and are comfortable with it, do not install BasicTe
 
 ### Installing Manim-Community itself
 
-Manim runs on Python 3.7+. If you'd like to just use the library, you can install it from PyPI via pip:
+Manim-Community runs on Python 3.6+. If you'd like to just use the library, you can install it from PyPI via pip:
 
 ```sh
-pip3 install manimlib
+pip3 install manimce
 ```
 
 However, if you'd like to contribute to and/or help develop


### PR DESCRIPTION
## List of Changes

- Change `pip3 install` instruction to use Community Edition of Manim
- Change minimum Python version from 3.7 to 3.6

## Motivation

- Package appeared to be listed incorrectly as `manimlib`
- `manimce` requires 3.6, as listed [here](https://pypi.org/project/manimce/)

## Further Comments

- The [pip listing](https://pypi.org/project/manimce/) for `manimce` links to this repo
- `manimlib` is listed in the [3b1b repo](https://github.com/3b1b/manim#Installation), so it's likely out of place here
- `manimce` runs the provided [example code](https://github.com/ManimCommunity/manim#usage) without issue in Python 3.6 *and* 3.7

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
