### PR TITLE
If -i flag is passed, only export .gif file.

### DIFF
--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -24,7 +24,7 @@ def open_file_if_needed(file_writer):
         sys.stdout = open(os.devnull, "w")
 
     open_file = any(
-        [file_writer_config["preview"], file_writer_config["show_file_in_finder"]]
+        [file_writer_config["preview"], file_writer_config["show_in_file_browser"]]
     )
     if open_file:
         current_os = platform.system()
@@ -41,7 +41,7 @@ def open_file_if_needed(file_writer):
             file_paths.append(file_writer.gif_file_path)
 
         for file_path in file_paths:
-            open_media_file(file_path, file_writer_config["show_file_in_finder"])
+            open_media_file(file_path, file_writer_config["show_in_file_browser"])
 
     if file_writer_config["verbose"] != "DEBUG":
         sys.stdout.close()

--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -13,6 +13,7 @@ from .utils import cfg_subcmds
 from .scene.scene import Scene
 from .utils.sounds import play_error_sound
 from .utils.sounds import play_finish_sound
+from .utils.file_ops import open_file as open_media_file
 from . import constants
 from .logger import logger, console
 
@@ -31,33 +32,16 @@ def open_file_if_needed(file_writer):
 
         if file_writer_config["save_last_frame"]:
             file_paths.append(file_writer.get_image_file_path())
-        if file_writer_config["write_to_movie"]:
+        if (
+            file_writer_config["write_to_movie"]
+            and not file_writer_config["save_as_gif"]
+        ):
             file_paths.append(file_writer.get_movie_file_path())
+        if file_writer_config["save_as_gif"]:
+            file_paths.append(file_writer.gif_file_path)
 
         for file_path in file_paths:
-            if current_os == "Windows":
-                if file_writer_config["preview"]:
-                    os.startfile(file_path)
-                if file_writer_config["show_file_in_finder"]:
-                    os.startfile(os.path.dirname(file_path))
-            else:
-                commands = []
-                if current_os == "Linux":
-                    commands.append("xdg-open")
-                elif current_os.startswith("CYGWIN"):
-                    commands.append("cygstart")
-                else:  # Assume macOS
-                    commands.append("open")
-
-                if file_writer_config["show_file_in_finder"]:
-                    commands.append("-R")
-
-                commands.append(file_path)
-
-                # commands.append("-g")
-                FNULL = open(os.devnull, "w")
-                sp.call(commands, stdout=FNULL, stderr=sp.STDOUT)
-                FNULL.close()
+            open_media_file(file_path, file_writer_config["show_file_in_finder"])
 
     if file_writer_config["verbose"] != "DEBUG":
         sys.stdout.close()

--- a/manim/default.cfg
+++ b/manim/default.cfg
@@ -33,8 +33,8 @@ save_as_gif = False
 # -p, --preview
 preview = False
 
-# -f, --show_file_in_finder
-show_file_in_finder = False
+# -f, --show_in_file_browser
+show_in_file_browser = False
 
 # -v, --verbose
 verbose = INFO

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -497,11 +497,12 @@ class SceneFileWriter(object):
             file_writer_config["ffmpeg_loglevel"],
         ]
 
-        if self.write_to_movie:
+        if self.write_to_movie and not self.save_as_gif:
             commands += ["-c", "copy", movie_file_path]
 
         if self.save_as_gif:
             commands += [self.gif_file_path]
+
         if not self.includes_sound:
             commands.insert(-1, "-an")
 
@@ -546,7 +547,9 @@ class SceneFileWriter(object):
             shutil.move(temp_file_path, movie_file_path)
             os.remove(sound_file_path)
 
-        self.print_file_ready_message(movie_file_path)
+        self.print_file_ready_message(
+            self.gif_file_path if self.save_as_gif else movie_file_path
+        )
         if file_writer_config["write_to_movie"]:
             for file_path in partial_movie_files:
                 # We have to modify the accessed time so if we have to clean the cache we remove the one used the longest.

--- a/manim/utils/config_utils.py
+++ b/manim/utils/config_utils.py
@@ -51,7 +51,7 @@ def _parse_file_writer_config(config_parser, args):
     # in batches, depending on their type: booleans and strings
     for boolean_opt in [
         "preview",
-        "show_file_in_finder",
+        "show_in_file_browser",
         "sound",
         "leave_progress_bars",
         "write_to_movie",
@@ -223,10 +223,10 @@ def _parse_cli(arg_list, input=True):
     )
     parser.add_argument(
         "-f",
-        "--show_file_in_finder",
+        "--show_in_file_browser",
         action="store_const",
         const=True,
-        help="Show the output file in finder",
+        help="Show the output file in the File Browser",
     )
     parser.add_argument(
         "--sound",

--- a/manim/utils/file_ops.py
+++ b/manim/utils/file_ops.py
@@ -42,17 +42,19 @@ def modify_atime(file_path):
     os.utime(file_path, times=(time.time(), os.path.getmtime(file_path)))
 
 
-def open_file(file_path):
+def open_file(file_path, in_browser=False):
     current_os = platform.system()
     if current_os == "Windows":
-        os.startfile(file_path)
+        os.startfile(file_path if not in_browser else os.path.dirname(file_path))
     else:
         if current_os == "Linux":
             commands = ["xdg-open"]
+            file_path = file_path if not in_browser else os.path.dirname(file_path)
         elif current_os.startswith("CYGWIN"):
             commands = ["cygstart"]
+            file_path = file_path if not in_browser else os.path.dirname(file_path)
         elif current_os == "Darwin":
-            commands = ["open"]
+            commands = ["open"] if not in_browser else ["open", "-R"]
         else:
             raise OSError("Unable to identify your operating system...")
         commands.append(file_path)


### PR DESCRIPTION
## List of Changes
- Add an option to the `open_file` method in `file_ops` which allows it to show the passed file in the OS's file explorer. 
- Make `SceneFileWriter` only export final video file if `write_to_movie` is True and  `save_as_gif` is False.
- Made the end "File Ready at:" message display the proper file path.
- Made `open_file_if_needed` in `__main__.py` only open "movie" files if `save_as_gif` is False and `write_to_movie` is True.
- Made `open_file_if_needed` in `__main__.py` use the `open_file` method in `file_ops`.

## Motivation
Fixes #267 

## Testing Status
Pytest exited with 0 errors.
Manually testing the flags yielded the required results.

## Further Comments
Currently, the option which makes manim open the file in the user's file explorer is named `-f` for `finder`. However, using it on a non-MacOS system will still work.
The current name might cause some confusion among end users, leading them to believe `-f` only works on MacOS.

Should the name of the flag be changed?

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
