### PR TITLE
Change user-wide config file location for MacOS.

### DIFF
--- a/manim/utils/config_utils.py
+++ b/manim/utils/config_utils.py
@@ -468,7 +468,7 @@ def _paths_config_file():
         )
     elif sys.platform.startswith("darwin"):
         user_wide = os.path.expanduser(
-            os.path.join("~", "Library", "Application Support", "Manim", "manim.cfg")
+            os.path.join("~", ".config", "Manim", "manim.cfg")
         )
     elif sys.platform.startswith("win32"):
         user_wide = os.path.expanduser(


### PR DESCRIPTION
## List of Changes
- Change user-wide MacOS config file path to `~/.config/Manim/manim.cfg` from `~/Library/Application Support/Manim/manim.cfg`

## Motivation
I mentioned in #179 that putting the user-wide config file for MacOS in a hidden directory such as `~/Library` may cause some discomfort for  new programmers (such as those manim often attracts). @PgBiel suggested that it could be moved to `~/.config/Manim/manim.cfg`, as `~/.config/` is a common directory for such config files to be placed.

## Testing Status
Pytest exited with 0 errors.
Manually using `manim cfg write --level user` writes to the new location.
Rendering a scene takes into consideration the new location of the config file.


## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
