### PR TITLE
Set MacOS's Config File path to '~/.config/manim/manim.cfg'

### DIFF
--- a/manim/utils/config_utils.py
+++ b/manim/utils/config_utils.py
@@ -462,15 +462,7 @@ def _paths_config_file():
     library_wide = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "..", "default.cfg")
     )
-    if sys.platform.startswith("linux"):
-        user_wide = os.path.expanduser(
-            os.path.join("~", ".config", "manim", "manim.cfg")
-        )
-    elif sys.platform.startswith("darwin"):
-        user_wide = os.path.expanduser(
-            os.path.join("~", ".config", "Manim", "manim.cfg")
-        )
-    elif sys.platform.startswith("win32"):
+    if sys.platform.startswith("win32"):
         user_wide = os.path.expanduser(
             os.path.join("~", "AppData", "Roaming", "Manim", "manim.cfg")
         )


### PR DESCRIPTION
## List of Changes
<!-- List out your changes one by one like this:
- Remove condition that checks if OS is Linux before setting config file path in `config_utils`
- Remove condition that checks if OS is MacOS before setting config file path in `config_utils`
- Set user config file path to `~/.config/manim/manim.cfg` if OS is not Windows.
-->

## Motivation
@PgBiel recommended in PR #276 that the config file location should be `~/.config/manim/manim.cfg` and not `~/.config/Manim/manim.cfg`, in order to follow convention.

This PR changes that.

## Testing Status
Pytest exited with 0 errors, manually using `manim cfg write --level user` writes to the proper place.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))