### PR TITLE
# Changes in camera.py to fix fixed frame option in 3D

### DIFF
--- a/manim/camera/camera.py
+++ b/manim/camera/camera.py
@@ -414,9 +414,8 @@ class Camera(object):
         else:
             method = Mobject.get_family
         if self.use_z_index:
-            mobjects.sort(key=lambda m: m.z_index)
+            mobjects = sorted(mobjects,key=lambda m: m.z_index)
         return remove_list_redundancies(list(it.chain(*[method(m) for m in mobjects])))
-
     def get_mobjects_to_display(
         self, mobjects, include_submobjects=True, excluded_mobjects=None
     ):

--- a/manim/camera/camera.py
+++ b/manim/camera/camera.py
@@ -414,8 +414,9 @@ class Camera(object):
         else:
             method = Mobject.get_family
         if self.use_z_index:
-            mobjects = sorted(mobjects,key=lambda m: m.z_index)
+            mobjects = sorted(mobjects, key=lambda m: m.z_index)
         return remove_list_redundancies(list(it.chain(*[method(m) for m in mobjects])))
+
     def get_mobjects_to_display(
         self, mobjects, include_submobjects=True, excluded_mobjects=None
     ):
@@ -438,7 +439,7 @@ class Camera(object):
         """
         if include_submobjects:
             mobjects = self.extract_mobject_family_members(
-                mobjects, only_those_with_points=True,
+                mobjects, only_those_with_points=True
             )
             if excluded_mobjects:
                 all_excluded = self.extract_mobject_family_members(excluded_mobjects)
@@ -973,9 +974,7 @@ class Camera(object):
         new_array : np.array
             The new pixel array to overlay.
         """
-        self.overlay_PIL_image(
-            pixel_array, self.get_image(new_array),
-        )
+        self.overlay_PIL_image(pixel_array, self.get_image(new_array))
 
     def overlay_PIL_image(self, pixel_array, image):
         """Overlays a PIL image on the passed pixel array.
@@ -1091,9 +1090,9 @@ class Camera(object):
         """
         # TODO: This seems...unsystematic
         big_sum = op.add(
-            camera_config["default_pixel_height"], camera_config["default_pixel_width"],
+            camera_config["default_pixel_height"], camera_config["default_pixel_width"]
         )
-        this_sum = op.add(self.get_pixel_height(), self.get_pixel_width(),)
+        this_sum = op.add(self.get_pixel_height(), self.get_pixel_width())
         factor = fdiv(big_sum, this_sum)
         return 1 + (thickness - 1) / factor
 


### PR DESCRIPTION
There was an issue with z_index and add_fixed_in_frame_mobjects (#264). This change will fix it.
Can be tested with 
```python
from manim import *
class Text3D(ThreeDScene):
    def construct(self):
        axes = ThreeDAxes()
        self.set_camera_orientation(phi=75 * DEGREES,theta=-45*DEGREES)
        text=TextMobject("This is a 3D text")
        self.add_fixed_in_frame_mobjects(text.to_corner(UL))
        self.add(axes)
        self.add(text)
        self.wait()

from pathlib import Path
if __name__ == "__main__":
    script = f"{Path(__file__).resolve()}"
    os.system(f"manim  -p -s  " + script )
```