### PR TITLE
Add install instructions for pip3 for Ubuntu users under WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ sudo apt install texlive texlive-latex-extra texlive-fonts-extra texlive-latex-r
 > Note: this installation may take up a lot of space. The developers are working on providing a simpler, lighter LaTeX package for you to install
 2. You can check you did it right by running `latex`
 
-#### Pip3 Installation
+#### `pip3` Installation
 1. Install `pip3` in the `python3-pip` package with your package manager: `sudo apt-get install python3-pip`
 2. You can check you did it right by running `pip3`
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ sudo apt install texlive texlive-latex-extra texlive-fonts-extra texlive-latex-r
 > Note: this installation may take up a lot of space. The developers are working on providing a simpler, lighter LaTeX package for you to install
 2. You can check you did it right by running `latex`
 
+#### Pip3 Installation
+1. Install `pip3` in the `python3-pip` package with your package manager: `sudo apt-get install python3-pip`
+2. You can check you did it right by running `pip3`
+
 ### Arch/Manjaro
 
 Before installing `manim-community`, there are some additional dependencies that you must have installed:


### PR DESCRIPTION
installation on Ubuntu definitely depends on pip3 being installed. it wasn't on my system (neither was the indicated packages of texlive)

## List of Changes
- Ensure `pip3` is installed by providing installation instruction in the preliminaries section (prerequisites)

## Motivation
- Dependency without which the next section of installation instruction cannot be accomplished

## Acknowledgement
- [X] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
