### PR TITLE
Reference raw basic.py file in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,13 +207,13 @@ If you have installed MacTeX and are comfortable with it, do not install BasicTe
 
 ### Installing Manim-Community itself
 
-Manim-Community runs on Python 3.6+. If you'd like to just use the library, you can install it from PyPI via pip:
+1. Manim-Community runs on Python 3.6+. If you'd like to just use the library, you can install it from PyPI via pip:
 
 ```sh
 pip3 install manimce
 ```
 
-However, if you'd like to contribute to and/or help develop
+2. However, if you'd like to contribute to and/or help develop
 `manim-community`, you can clone this branch to your local device. To do
 this, first make sure you have `git` installed. Then, clone this repo by
 executing either
@@ -228,7 +228,7 @@ or
 git clone https://github.com/ManimCommunity/manim.git
 ```
 
-depending on whether you want to use HTTPS or SSH. Finally, run the
+depending on whether you want to use HTTPS or SSH. Finally, after having cloned this repo, run the
 following:
 
 ```sh
@@ -241,7 +241,12 @@ To run your first example Scene, you can run the following commands:
 
 ### For users:
 
-1. Download the `example_scenes/basic.py` file from [GitHub](https://github.com/ManimCommunity/manim/blob/master/example_scenes/basic.py)
+1. Download the `example_scenes/basic.py` file from [GitHub](https://raw.github.com/ManimCommunity/manim/blob/master/example_scenes/basic.py), or place it manually
+in your current working directory with
+```sh
+wget https://raw.github.com/ManimCommunity/manim/master/example_scenes/basic.py
+```
+
 2. Run the following command:
 ```sh
 manim example_scenes/basic.py SquareToCircle -pl


### PR DESCRIPTION
must reference "raw.github.com" to get the contents of `basic.py`, otherwise one gets the github file content page in HTML.

## Acknowledgement
- [X] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
