### PR TITLE
Check for add in VGroup

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -845,7 +845,6 @@ class VMobject(Mobject):
 
 
 class VGroup(VMobject):
-
     def __init__(self, *vmobjects, **kwargs):
         VMobject.__init__(self, **kwargs)
         self.add(*vmobjects)

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -854,7 +854,7 @@ class VGroup(VMobject):
 
         Parameters
         ----------
-        vmobjects :
+        vmobjects : :class:`~.VMobject`
             List of VMobject to add
 
         Returns

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -845,11 +845,31 @@ class VMobject(Mobject):
 
 
 class VGroup(VMobject):
+
     def __init__(self, *vmobjects, **kwargs):
-        if not all([isinstance(m, VMobject) for m in vmobjects]):
-            raise Exception("All submobjects must be of type VMobject")
         VMobject.__init__(self, **kwargs)
         self.add(*vmobjects)
+
+    def add(self, *vmobjects):
+        """Checks if all passed elements are an instance of VMobject and then add them to submobjects
+
+        Parameters
+        ----------
+        vmobjects :
+            List of VMobject to add
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        Exception
+            If one element of the list is not an instance of VMobject
+        """
+        if not all([isinstance(m, VMobject) for m in vmobjects]):
+            raise Exception("All submobjects must be of type VMobject")
+        super().add(*vmobjects)
 
 
 class VDict(VMobject):

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -866,7 +866,7 @@ class VGroup(VMobject):
         TypeError
             If one element of the list is not an instance of VMobject
         """
-        if not all([isinstance(m, VMobject) for m in vmobjects]):
+        if not all(isinstance(m, VMobject) for m in vmobjects):
             raise TypeError("All submobjects must be of type VMobject")
         super().add(*vmobjects)
 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -863,11 +863,11 @@ class VGroup(VMobject):
 
         Raises
         ------
-        Exception
+        TypeError
             If one element of the list is not an instance of VMobject
         """
         if not all([isinstance(m, VMobject) for m in vmobjects]):
-            raise Exception("All submobjects must be of type VMobject")
+            raise TypeError("All submobjects must be of type VMobject")
         super().add(*vmobjects)
 
 

--- a/tests/test_vectorized_mobject.py
+++ b/tests/test_vectorized_mobject.py
@@ -1,0 +1,31 @@
+import pytest
+from manim import Mobject, VMobject, VGroup
+
+
+def test_vgroup_init():
+    """Test the VGroup instantiation."""
+    VGroup()
+    VGroup(VMobject())
+    VGroup(VMobject(), VMobject())
+    with pytest.raises(TypeError):
+        VGroup(Mobject())
+    with pytest.raises(TypeError):
+        VGroup(Mobject(), Mobject())
+
+
+def test_vgroup_add():
+    """Test the VGroup add method."""
+    obj = VGroup()
+    assert len(obj.submobjects) == 0
+    obj.add(VMobject())
+    assert len(obj.submobjects) == 1
+    with pytest.raises(TypeError):
+        obj.add(Mobject())
+    assert len(obj.submobjects) == 1
+    with pytest.raises(TypeError):
+        # If only one of the added object is not an instance of VMobject, none of them should be added
+        obj.add(VMobject(), Mobject())
+    assert len(obj.submobjects) == 1
+    with pytest.raises(Exception):  # TODO change this to ValueError once #307 is merged
+        # a Mobject cannot contain itself
+        obj.add(obj)


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

Solves #284 as suggested in the issue by checking if every submobject is an instance of `VMobject` in the `add` function instead of doing it only at initialization.

## Acknowledgement
- [X] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
