### PR TITLE
Make sphinx dependencies development only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ rich>=4.2.1
 # for development only:
 # pytest
 # black
-# sphinx-rtd-theme
+# guzzle-sphinx-theme
 # recommonmark>=0.5.0


### PR DESCRIPTION
End users won't need to install the sphinx dependencies, so move them to the development-only section of requirements.txt.
