### PR TITLE
Fixed bug that broke some Windows CLIs

### DIFF
--- a/manim/utils/config_utils.py
+++ b/manim/utils/config_utils.py
@@ -435,9 +435,11 @@ def _init_dirs(config):
 def _from_command_line():
     """Determine if manim was called from the command line."""
     # Manim can be called from the command line in three different
-    # ways.  The first two involve using the manim or manimcm commands
+    # ways.  The first two involve using the manim or manimcm commands.
+    # Note that some Windows CLIs replace those commands with the path
+    # to their executables, so we must check for this as well
     prog = os.path.split(sys.argv[0])[-1]
-    from_cli_command = prog in ["manim", "manimcm"]
+    from_cli_command = prog in ["manim", "manim.exe", "manimcm", "manimcm.exe"]
 
     # The third way involves using `python -m manim ...`.  In this
     # case, the CLI arguments passed to manim do not include 'manim',


### PR DESCRIPTION
## Motivation
In some Windows CLIs, the command 

`manim file.py ...`

will generate the argv

`C:\\path\\to\\manim.exe file.py ...`

This would cause `_from_command_line()` to misleadingly return False, which completely prevents users from calling manim from the command line, as certain key fields like `input_file` would not be populated.

## Explanation for Changes
The problem is fixed simply by adding checks for "manim.exe" and "manimcm.exe" to `_from_command_line()`.

## Testing Status
The issue was first noticed while running `manim` from the terminal on PyCharm Community 2019.2.6 with Python 3.8. Before patching, the command returned a `FileNotFoundError`; after patching, the command worked as documented.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

