### PR TITLE
Add a way to pass a custom browser to docs builder.

### DIFF
--- a/scripts/make_and_open_docs.py
+++ b/scripts/make_and_open_docs.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 import os
+import sys
 import webbrowser
 
 path_makefile = Path(__file__).parents[1] / "docs"
 os.system(f"cd {path_makefile} && make html")
 
-website = path_makefile / "build" / "html" / "index.html"
-webbrowser.open_new_tab(f"{website}")
-#alternative to the upper line:
-# webbrowser.get('firefox').open_new_tab(f"{website}")
+website = "file://" + str(path_makefile / "build" / "html" / "index.html")
+try:  # Allows you to pass a custom browser if you want.
+    webbrowser.get(sys.argv[1]).open_new_tab(f"{website}")
+except IndexError:
+    webbrowser.open_new_tab(f"{website}")


### PR DESCRIPTION
You can now use `python make_and_open_docs.py <browser>` to open the docs in `<browser>`

## List of Changes
- Check if `sys.argv` has a valid browser name and use the browser if it exists.

## Motivation
Instead if having a part of the script commented, this allows for more flexibility.

## Testing Status
Manually tested.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
