### PR TITLE
Update code_mobject.py

### DIFF
--- a/manim/mobject/svg/code_mobject.py
+++ b/manim/mobject/svg/code_mobject.py
@@ -1,4 +1,5 @@
 import html
+import os
 from ...constants import *
 from ...container import Container
 from ...mobject.geometry import RoundedRectangle


### PR DESCRIPTION
Added the import for the os package, as I tried using this class with a simple example, Python 3.8.5 would return "NameError: name 'os' is not defined". After adding import os to the file, the video compiled sucessfully.

<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
<!-- List out your changes one by one like this:
- Change 1
- Change 2
- and so on..
-->

## Motivation
<!-- Why you feel your changes are required. -->

## Explanation for Changes
<!-- How do your changes solve aforementioned problems? -->

## Testing Status
<!-- Optional, but recommended, your computer specs and what tests you ran with their results, if any -->

## Further Comments
<!-- Optional, any edits/updates should preferably be written here. -->

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
