### PR TITLE
Use Cacheing in Github Actions

### DIFF
--- a/.github/manimdependency.json
+++ b/.github/manimdependency.json
@@ -1,6 +1,6 @@
 {
     "windows": {
-        "sox": "sox-14.4.2-win32.zip",
-        "ffmpeg": "ffmpeg-4.3.1-win64-static.zip"
+        "sox": "sox-14.4.2-win32",
+        "ffmpeg": "ffmpeg-4.3.1-win64-static"
     }
 }

--- a/.github/manimdependency.json
+++ b/.github/manimdependency.json
@@ -1,0 +1,6 @@
+{
+    "windows": {
+        "sox": "sox-14.4.2-win32.zip",
+        "ffmpeg": "ffmpeg-4.3.1-win64-static.zip"
+    }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,21 +70,20 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/cache@v2
         with:
-         path: |
-           $($env:APPDATA)\ManimCache
-         key: ${{ runner.os }}-dependencies
+         path: ${{ github.workspace }}\ManimCache
+         key: ${{ runner.os }}-dependencies-ffmpeg-sox-tinytex
       - name: Download system dependencies (Windows)
         if: runner.os == 'Windows' && steps.cache-windows.outputs.cache-hit != 'true'
         run: |
           Invoke-WebRequest "https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019" -O "$($env:TMP)\TinyTex.zip"
-          Expand-Archive -LiteralPath "$($env:TMP)\TinyTex.zip" -DestinationPath "$($env:APPDATA)\ManimCache\LatexWindows"
-          $env:Path += ";" + "$env:APPDATA\ManimCache\LatexWindows\TinyTeX\bin\win32"
+          Expand-Archive -LiteralPath "$($env:TMP)\TinyTex.zip" -DestinationPath "$($PWD)\ManimCache\LatexWindows"
+          $env:Path += ";" + "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\win32"
           tlmgr install standalone preview doublestroke ms setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english
           echo "Completed Latex Install Sox"
           Invoke-WebRequest https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip -SkipCertificateCheck -UserAgent "pwsh" -O "$($env:TMP)\SoX.zip"
-          7z x "$($env:TMP)\SoX.zip" -o"$env:APPDATA\ManimCache\SoX"
+          7z x "$($env:TMP)\SoX.zip" -o"$($PWD)\ManimCache\SoX"
           Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3.1-win64-static.zip -O "$($env:TMP)\ffmpeg-4.3.1-win64-static.zip"
-          7z x "$($env:TMP)\ffmpeg-4.3.1-win64-static.zip" -o"$env:APPDATA\ManimCache\FFmpeg"
+          7z x "$($env:TMP)\ffmpeg-4.3.1-win64-static.zip" -o"$($PWD)\ManimCache\FFmpeg"
       - name: Add Windows dependecies to path
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,15 @@ jobs:
       - name: Download system dependencies (Windows)
         if: runner.os == 'Windows' && steps.cache-windows.outputs.cache-hit != 'true'
         run: |
-          Invoke-WebRequest "https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019" -O "$($env:TMP)\TinyTex\TinyTex.zip"
-          Expand-Archive -LiteralPath "$($env:TMP)\TinyTex\TinyTex.zip" -DestinationPath "$($env:APPDATA)\ManimCache\LatexWindows"
+          Invoke-WebRequest "https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019" -O "$($env:TMP)\TinyTex.zip"
+          Expand-Archive -LiteralPath "$($env:TMP)\TinyTex.zip" -DestinationPath "$($env:APPDATA)\ManimCache\LatexWindows"
           $env:Path += ";" + "$env:APPDATA\ManimCache\LatexWindows\TinyTeX\bin\win32"
           tlmgr install standalone preview doublestroke ms setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english
           echo "Completed Latex Install Sox"
-          Invoke-WebRequest https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip -SkipCertificateCheck -UserAgent "pwsh" -O "$($env:TMP)\ManimCache\SoX.zip"
-          7z x "$($env:TMP)\ManimCache\SoX.zip" -o"$env:APPDATA\ManimCache\SoX"
-          Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3.1-win64-static.zip -O "$($env:TMP)\ManimCache\ffmpeg-4.3.1-win64-static.zip"
-          7z x "$($env:TMP)\ManimCache\ffmpeg-4.3.1-win64-static.zip" -o"$env:APPDATA\ManimCache\FFmpeg"
+          Invoke-WebRequest https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip -SkipCertificateCheck -UserAgent "pwsh" -O "$($env:TMP)\SoX.zip"
+          7z x "$($env:TMP)\SoX.zip" -o"$env:APPDATA\ManimCache\SoX"
+          Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3.1-win64-static.zip -O "$($env:TMP)\ffmpeg-4.3.1-win64-static.zip"
+          7z x "$($env:TMP)\ffmpeg-4.3.1-win64-static.zip" -o"$env:APPDATA\ManimCache\FFmpeg"
       - name: Add Windows dependecies to path
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+
       - name: Get pip cache dir
         shell: bash
         id: pip-cache-and-time
@@ -58,6 +59,7 @@ jobs:
         with:
           path: ${{ steps.pip-cache-and-time.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ matrix.python }}-${{ steps.pip-cache-and-time.outputs.date }}
+
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -82,6 +84,7 @@ jobs:
         with:
          path: ${{ github.workspace }}\ManimCache
          key: ${{ runner.os }}-dependencies-ffmpeg-sox-tinytex-${{ hashFiles('.github/manimdependency.json') }}-${{ steps.pip-cache-and-time.outputs.date }}
+
       - name: Download system dependencies (Windows)
         if: runner.os == 'Windows' && steps.cache-windows.outputs.cache-hit != 'true'
         run: |
@@ -90,22 +93,20 @@ jobs:
           $ffmpegVersion = python -c "import json;print(json.load(open('.github/manimdependency.json'))['windows']['ffmpeg'])"
           $ffmpegVersionNumber = python -c "import json;print(json.load(open('.github/manimdependency.json'))['windows']['ffmpeg'].split('-')[1])"
           $OriPath = $env:PATH
-          
           echo "Install Tinytex"
           Invoke-WebRequest "https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019" -O "$($env:TMP)\TinyTex.zip"
           Expand-Archive -LiteralPath "$($env:TMP)\TinyTex.zip" -DestinationPath "$($PWD)\ManimCache\LatexWindows"
           $env:Path = "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\win32;$($env:PATH)"
           tlmgr install standalone preview doublestroke ms setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english
           $env:PATH=$OriPath
-          
           echo "Completed Latex Install Sox"
           Invoke-WebRequest "https://downloads.sourceforge.net/project/sox/sox/$($soxVersionNumber)/$($soxVersion).zip" -UserAgent "wget" -O "$($env:TMP)\SoX.zip"
           7z x "$($env:TMP)\SoX.zip" -o"$($PWD)\ManimCache"
           Move-Item "ManimCache\sox-*" "ManimCache\SoX"
-          
           Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/$($ffmpegVersion).zip -O "$($env:TMP)\$($ffmpegVersion).zip"
           7z x "$($env:TMP)\$($ffmpegVersion).zip" -o"$($PWD)\ManimCache"
           Move-Item "ManimCache\ffmpeg-*" "ManimCache\FFmpeg"
+
       - name: Add Windows dependecies to path
         if: runner.os == 'Windows'
         run: |
@@ -113,6 +114,7 @@ jobs:
           $env:Path += ";" + "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\win32"
           $env:Path += ";" + "$($PWD)\ManimCache\SoX"
           echo "::set-env name=Path::$env:Path"
+
       - name: Install Pycairo (Non-Windows)
         if: runner.os == 'macOS' || runner.os == 'Linux'
         run: pip install pycairo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,15 @@ jobs:
       - name: Download system dependencies (Windows)
         if: runner.os == 'Windows' && steps.cache-windows.outputs.cache-hit != 'true'
         run: |
-          Invoke-WebRequest https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019 -O "$($TEMP)\TinyTex\TinyTex.zip"
-          Expand-Archive -LiteralPath "$($TEMP)\TinyTex\TinyTex.zip" -DestinationPath "$($env:APPDATA)\ManimCache\LatexWindows"
+          Invoke-WebRequest "https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019" -O "$($TMP)\TinyTex\TinyTex.zip"
+          Expand-Archive -LiteralPath "$($TMP)\TinyTex\TinyTex.zip" -DestinationPath "$($env:APPDATA)\ManimCache\LatexWindows"
           $env:Path += ";" + "$env:APPDATA\ManimCache\LatexWindows\TinyTeX\bin\win32"
           tlmgr install standalone preview doublestroke ms setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english
           echo "Completed Latex Install Sox"
-          Invoke-WebRequest https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip -SkipCertificateCheck -UserAgent "pwsh" -O "$($TEMP)\ManimCache\SoX.zip"
-          7z x "$($TEMP)\ManimCache\SoX.zip" -o"$env:APPDATA\ManimCache\SoX"
-          Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3.1-win64-static.zip -O "$($TEMP)\ManimCache\ffmpeg-4.3.1-win64-static.zip"
-          7z x "$($TEMP)\ManimCache\ffmpeg-4.3.1-win64-static.zip" -o"$env:APPDATA\ManimCache\FFmpeg"
+          Invoke-WebRequest https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip -SkipCertificateCheck -UserAgent "pwsh" -O "$($TMP)\ManimCache\SoX.zip"
+          7z x "$($TMP)\ManimCache\SoX.zip" -o"$env:APPDATA\ManimCache\SoX"
+          Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3.1-win64-static.zip -O "$($TMP)\ManimCache\ffmpeg-4.3.1-win64-static.zip"
+          7z x "$($TMP)\ManimCache\ffmpeg-4.3.1-win64-static.zip" -o"$env:APPDATA\ManimCache\FFmpeg"
       - name: Add Windows dependecies to path
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         id: pip-cache-and-time
         run: |
            echo "::set-output name=dir::$(pip cache dir)"
-           echo "::set-output name=date::$(python -c "import time; print(time.localtime().tm_mon,time.localtime().tm_year,sep='')")
+           echo "::set-output name=date::$(python -c `"import time; print(time.localtime().tm_mon,time.localtime().tm_year,sep='')`")"
 
       - name: pip cache
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           $env:Path += ";" + "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\win32"
           tlmgr install standalone preview doublestroke ms setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english
           echo "Completed Latex Install Sox"
-          Invoke-WebRequest https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip -SkipCertificateCheck -UserAgent "pwsh" -O "$($env:TMP)\SoX.zip"
+          Invoke-WebRequest https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip -UserAgent "wget" -O "$($env:TMP)\SoX.zip"
           7z x "$($env:TMP)\SoX.zip" -o"$($PWD)\ManimCache\SoX"
           Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3.1-win64-static.zip -O "$($env:TMP)\ffmpeg-4.3.1-win64-static.zip"
           7z x "$($env:TMP)\ffmpeg-4.3.1-win64-static.zip" -o"$($PWD)\ManimCache\FFmpeg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
         with:
           path: ${{ steps.pip-cache-and-time.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ matrix.python }}-${{ steps.pip-cache-and-time.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,25 +82,33 @@ jobs:
         uses: actions/cache@v2
         with:
          path: ${{ github.workspace }}\ManimCache
-         key: ${{ runner.os }}-dependencies-ffmpeg-sox-tinytex-${{ steps.pip-cache-and-time.outputs.date }}
+         key: ${{ runner.os }}-dependencies-ffmpeg-sox-tinytex-${{ hashFiles('.github/manimdependency.json') }}-${{ steps.pip-cache-and-time.outputs.date }}
       - name: Download system dependencies (Windows)
         if: runner.os == 'Windows' && steps.cache-windows.outputs.cache-hit != 'true'
         run: |
+          $soxVersion = python -c "import json;print(json.load(open('.github/manimdependency.json'))['windows']['sox'])"
+          $ffmpegVersion = python -c "import json;print(json.load(open('.github/manimdependency.json'))['windows']['ffmpeg'])"
+          
+          echo "Install Tinytex"
           Invoke-WebRequest "https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019" -O "$($env:TMP)\TinyTex.zip"
           Expand-Archive -LiteralPath "$($env:TMP)\TinyTex.zip" -DestinationPath "$($PWD)\ManimCache\LatexWindows"
           $env:Path += ";" + "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\win32"
           tlmgr install standalone preview doublestroke ms setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english
+          
           echo "Completed Latex Install Sox"
-          Invoke-WebRequest https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip -UserAgent "wget" -O "$($env:TMP)\SoX.zip"
-          7z x "$($env:TMP)\SoX.zip" -o"$($PWD)\ManimCache\SoX"
-          Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3.1-win64-static.zip -O "$($env:TMP)\ffmpeg-4.3.1-win64-static.zip"
-          7z x "$($env:TMP)\ffmpeg-4.3.1-win64-static.zip" -o"$($PWD)\ManimCache\FFmpeg"
+          Invoke-WebRequest "https://downloads.sourceforge.net/project/sox/sox/$((Get-Version $soxVersion).Version.toString())/$($soxVersion).zip" -UserAgent "wget" -O "$($env:TMP)\SoX.zip"
+          7z x "$($env:TMP)\SoX.zip" -o"$($PWD)\ManimCache"
+          Move-Item "ManimCache\sox-*" "ManimCache\SoX"
+          
+          Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/$($ffmpegVersion).zip -O "$($env:TMP)\$($ffmpegVersion).zip"
+          7z x "$($env:TMP)\$($ffmpegVersion).zip" -o"$($PWD)\ManimCache"
+          Move-Item "ManimCache\ffmpeg-*" "ManimCache\FFmpeg"
       - name: Add Windows dependecies to path
         if: runner.os == 'Windows'
         run: |
-          $env:Path += ";" + "$($PWD)\ManimCache\FFmpeg\ffmpeg-4.3.1-win64-static\bin"
+          $env:Path += ";" + "$($PWD)\ManimCache\FFmpeg\bin"
           $env:Path += ";" + "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\win32"
-          $env:Path += ";" + "$($PWD)\ManimCache\SoX\sox-14.4.2"
+          $env:Path += ";" + "$($PWD)\ManimCache\SoX"
           echo "::set-env name=Path::$env:Path"
       - name: Install Pycairo (Non-Windows)
         if: runner.os == 'macOS' || runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
            $($env:APPDATA)\ManimCache
          key: ${{ runner.os }}-dependencies
       - name: Download system dependencies (Windows)
-        if: runner.os == 'Windows' and steps.cache-windows.outputs.cache-hit != 'true'
+        if: runner.os == 'Windows' && steps.cache-windows.outputs.cache-hit != 'true'
         run: |
           Invoke-WebRequest https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019 -O "$($TEMP)\TinyTex\TinyTex.zip"
           Expand-Archive -LiteralPath "$($TEMP)\TinyTex\TinyTex.zip" -DestinationPath "$($env:APPDATA)\ManimCache\LatexWindows"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,15 +48,16 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Get pip cache dir
-        id: pip-cache
+        id: pip-cache-and-time
         run: |
            echo "::set-output name=dir::$(pip cache dir)"
+           echo "::set-output name=date::$(python -c "import time; print(time.localtime().tm_mon,time.localtime().tm_year,sep='')")
 
       - name: pip cache
         uses: actions/cache@v2
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ matrix.python }}
+          path: ${{ steps.pip-cache-and-time.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ matrix.python }}-${{ steps.pip-cache-and-time.outputs.date }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Install system dependencies (Linux)
@@ -82,7 +83,7 @@ jobs:
         uses: actions/cache@v2
         with:
          path: ${{ github.workspace }}\ManimCache
-         key: ${{ runner.os }}-dependencies-ffmpeg-sox-tinytex
+         key: ${{ runner.os }}-dependencies-ffmpeg-sox-tinytex-${{ steps.pip-cache-and-time.outputs.date }}
       - name: Download system dependencies (Windows)
         if: runner.os == 'Windows' && steps.cache-windows.outputs.cache-hit != 'true'
         run: |
@@ -111,7 +112,7 @@ jobs:
         run: python ./scripts/pycairoinstall.py
 
       - name: Install manim
-        run: pip install . pytest
+        run: pip install . pytest wheel
 
       - name: Run tests
         run: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,9 @@ jobs:
         run: python ./scripts/pycairoinstall.py
 
       - name: Install manim
-        run: pip install . pytest wheel
+        run: |
+          pip install wheel
+          pip install . pytest
 
       - name: Run tests
         run: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   push:
       branches:
         - master
-        - patch-2
   pull_request:
       branches:
         - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,18 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+           echo "::set-output name=dir::$(pip cache dir)"
 
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ matrix.python }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,14 @@ jobs:
         run: |
           $soxVersion = python -c "import json;print(json.load(open('.github/manimdependency.json'))['windows']['sox'])"
           $ffmpegVersion = python -c "import json;print(json.load(open('.github/manimdependency.json'))['windows']['ffmpeg'])"
+          $OriPath = $env:PATH
           
           echo "Install Tinytex"
           Invoke-WebRequest "https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019" -O "$($env:TMP)\TinyTex.zip"
           Expand-Archive -LiteralPath "$($env:TMP)\TinyTex.zip" -DestinationPath "$($PWD)\ManimCache\LatexWindows"
           $env:Path = "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\win32;$($env:PATH)"
           tlmgr install standalone preview doublestroke ms setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english
+          $env:PATH=$OriPath
           
           echo "Completed Latex Install Sox"
           Invoke-WebRequest "https://downloads.sourceforge.net/project/sox/sox/$((Get-Version $soxVersion).Version.toString())/$($soxVersion).zip" -UserAgent "wget" -O "$($env:TMP)\SoX.zip"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Get pip cache dir
+        shell: bash
         id: pip-cache-and-time
         run: |
            echo "::set-output name=dir::$(pip cache dir)"
-           echo "::set-output name=date::$(python -c `"import time; print(time.localtime().tm_mon,time.localtime().tm_year,sep='')`")"
+           echo "::set-output name=date::$(/bin/date -u "+%m%Y")"
 
       - name: pip cache
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           echo "Install Tinytex"
           Invoke-WebRequest "https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019" -O "$($env:TMP)\TinyTex.zip"
           Expand-Archive -LiteralPath "$($env:TMP)\TinyTex.zip" -DestinationPath "$($PWD)\ManimCache\LatexWindows"
-          $env:Path += ";" + "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\win32"
+          $env:Path = "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\win32;$($env:PATH)"
           tlmgr install standalone preview doublestroke ms setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english
           
           echo "Completed Latex Install Sox"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,9 @@ jobs:
       - name: Add Windows dependecies to path
         if: runner.os == 'Windows'
         run: |
-          $env:Path += ";" + "$env:APPDATA\ManimCache\FFmpeg\ffmpeg-4.3.1-win64-static\bin"
-          $env:Path += ";" + "$env:APPDATA\ManimCache\LatexWindows\TinyTeX\bin\win32"
-          $env:Path += ";" + "$env:APPDATA\ManimCache\SoX\sox-14.4.2"
+          $env:Path += ";" + "$($PWD)\ManimCache\FFmpeg\ffmpeg-4.3.1-win64-static\bin"
+          $env:Path += ";" + "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\win32"
+          $env:Path += ";" + "$($PWD)\ManimCache\SoX\sox-14.4.2"
           echo "::set-env name=Path::$env:Path"
       - name: Install Pycairo (Non-Windows)
         if: runner.os == 'macOS' || runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,15 @@ jobs:
       - name: Download system dependencies (Windows)
         if: runner.os == 'Windows' && steps.cache-windows.outputs.cache-hit != 'true'
         run: |
-          Invoke-WebRequest "https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019" -O "$($TMP)\TinyTex\TinyTex.zip"
-          Expand-Archive -LiteralPath "$($TMP)\TinyTex\TinyTex.zip" -DestinationPath "$($env:APPDATA)\ManimCache\LatexWindows"
+          Invoke-WebRequest "https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019" -O "$($env:TMP)\TinyTex\TinyTex.zip"
+          Expand-Archive -LiteralPath "$($env:TMP)\TinyTex\TinyTex.zip" -DestinationPath "$($env:APPDATA)\ManimCache\LatexWindows"
           $env:Path += ";" + "$env:APPDATA\ManimCache\LatexWindows\TinyTeX\bin\win32"
           tlmgr install standalone preview doublestroke ms setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english
           echo "Completed Latex Install Sox"
-          Invoke-WebRequest https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip -SkipCertificateCheck -UserAgent "pwsh" -O "$($TMP)\ManimCache\SoX.zip"
-          7z x "$($TMP)\ManimCache\SoX.zip" -o"$env:APPDATA\ManimCache\SoX"
-          Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3.1-win64-static.zip -O "$($TMP)\ManimCache\ffmpeg-4.3.1-win64-static.zip"
-          7z x "$($TMP)\ManimCache\ffmpeg-4.3.1-win64-static.zip" -o"$env:APPDATA\ManimCache\FFmpeg"
+          Invoke-WebRequest https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip -SkipCertificateCheck -UserAgent "pwsh" -O "$($env:TMP)\ManimCache\SoX.zip"
+          7z x "$($env:TMP)\ManimCache\SoX.zip" -o"$env:APPDATA\ManimCache\SoX"
+          Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3.1-win64-static.zip -O "$($env:TMP)\ManimCache\ffmpeg-4.3.1-win64-static.zip"
+          7z x "$($env:TMP)\ManimCache\ffmpeg-4.3.1-win64-static.zip" -o"$env:APPDATA\ManimCache\FFmpeg"
       - name: Add Windows dependecies to path
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
       branches:
         - master
+        - patch-2
   pull_request:
       branches:
         - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,9 @@ jobs:
         if: runner.os == 'Windows' && steps.cache-windows.outputs.cache-hit != 'true'
         run: |
           $soxVersion = python -c "import json;print(json.load(open('.github/manimdependency.json'))['windows']['sox'])"
+          $soxVersionNumber = python -c "import json;print(json.load(open('.github/manimdependency.json'))['windows']['sox'].split('-')[1])"
           $ffmpegVersion = python -c "import json;print(json.load(open('.github/manimdependency.json'))['windows']['ffmpeg'])"
+          $ffmpegVersionNumber = python -c "import json;print(json.load(open('.github/manimdependency.json'))['windows']['ffmpeg'].split('-')[1])"
           $OriPath = $env:PATH
           
           echo "Install Tinytex"
@@ -98,7 +100,7 @@ jobs:
           $env:PATH=$OriPath
           
           echo "Completed Latex Install Sox"
-          Invoke-WebRequest "https://downloads.sourceforge.net/project/sox/sox/$((Get-Version $soxVersion).Version.toString())/$($soxVersion).zip" -UserAgent "wget" -O "$($env:TMP)\SoX.zip"
+          Invoke-WebRequest "https://downloads.sourceforge.net/project/sox/sox/$($soxVersionNumber)/$($soxVersion).zip" -UserAgent "wget" -O "$($env:TMP)\SoX.zip"
           7z x "$($env:TMP)\SoX.zip" -o"$($PWD)\ManimCache"
           Move-Item "ManimCache\sox-*" "ManimCache\SoX"
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,22 +64,33 @@ jobs:
           sudo tlmgr install standalone preview doublestroke relsize fundus-calligra wasysym physics dvisvgm.x86_64-darwin dvisvgm rsfs wasy cm-super
           echo "::set-env name=PATH::$PATH"
 
-      - name: Install system dependencies (Windows)
+      - name: Cache Windows
+        id: cache-windows
         if: runner.os == 'Windows'
+        uses: actions/cache@v2
+        with:
+         path: |
+           $($env:APPDATA)\ManimCache
+         key: ${{ runner.os }}-dependencies
+      - name: Download system dependencies (Windows)
+        if: runner.os == 'Windows' and steps.cache-windows.outputs.cache-hit != 'true'
         run: |
-          Invoke-WebRequest https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019 -O TinyTex.zip
-          Expand-Archive -LiteralPath "$PWD\TinyTex.zip" -DestinationPath "$env:APPDATA\LatexWindows"
-          $env:Path += ";" + "$env:APPDATA\LatexWindows\TinyTeX\bin\win32"
+          Invoke-WebRequest https://ci.appveyor.com/api/projects/yihui/tinytex/artifacts/TinyTeX.zip?job=image:%20Visual%20Studio%202019 -O "$($TEMP)\TinyTex\TinyTex.zip"
+          Expand-Archive -LiteralPath "$($TEMP)\TinyTex\TinyTex.zip" -DestinationPath "$($env:APPDATA)\ManimCache\LatexWindows"
+          $env:Path += ";" + "$env:APPDATA\ManimCache\LatexWindows\TinyTeX\bin\win32"
           tlmgr install standalone preview doublestroke ms setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english
           echo "Completed Latex Install Sox"
-          Invoke-WebRequest https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip -SkipCertificateCheck -UserAgent "pwsh" -O SoX.zip
-          7z x "$PWD\SoX.zip" -o"$env:APPDATA\SoX"
-          $env:Path += ";" + "$env:APPDATA\SoX\sox-14.4.2"
-          Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3.1-win64-static.zip -O ffmpeg-4.3.1-win64-static.zip
-          7z x "$PWD\ffmpeg-4.3.1-win64-static.zip" -o"$env:APPDATA\FFmpeg"
-          $env:Path += ";" + "$env:APPDATA\FFmpeg\ffmpeg-4.3.1-win64-static\bin"
+          Invoke-WebRequest https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip -SkipCertificateCheck -UserAgent "pwsh" -O "$($TEMP)\ManimCache\SoX.zip"
+          7z x "$($TEMP)\ManimCache\SoX.zip" -o"$env:APPDATA\ManimCache\SoX"
+          Invoke-WebRequest https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3.1-win64-static.zip -O "$($TEMP)\ManimCache\ffmpeg-4.3.1-win64-static.zip"
+          7z x "$($TEMP)\ManimCache\ffmpeg-4.3.1-win64-static.zip" -o"$env:APPDATA\ManimCache\FFmpeg"
+      - name: Add Windows dependecies to path
+        if: runner.os == 'Windows'
+        run: |
+          $env:Path += ";" + "$env:APPDATA\ManimCache\FFmpeg\ffmpeg-4.3.1-win64-static\bin"
+          $env:Path += ";" + "$env:APPDATA\ManimCache\LatexWindows\TinyTeX\bin\win32"
+          $env:Path += ";" + "$env:APPDATA\ManimCache\SoX\sox-14.4.2"
           echo "::set-env name=Path::$env:Path"
-
       - name: Install Pycairo (Non-Windows)
         if: runner.os == 'macOS' || runner.os == 'Linux'
         run: pip install pycairo


### PR DESCRIPTION
## List of Changes
- First, using [action/cache](https://github.com/actions/cache) actions to cache windows dependencies and pip. I don't know about others.
- Add a file called `manimdependency.json` which can be used to upgrade dependencies(Only for windows now.)
- The cache is purged every month.

## Motivation
Makes the tests faster and prevents fails.


## Testing Status
Tested in my fork. https://github.com/naveen521kk/manim/actions


## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
