### PR TITLE
fix links to basic.py, custom_template.tex and customtex.py in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ To run your first example Scenes, you can run the following commands:
 
 ### For users:
 
-1. Download the `example_scenes/basic.py` file from [GitHub](https://raw.github.com/ManimCommunity/manim/blob/master/example_scenes/basic.py), or place it manually
+1. Download the `example_scenes/basic.py` file from [GitHub](https://raw.github.com/ManimCommunity/manim/master/example_scenes/basic.py), or place it manually
 in your current working directory with
 ```sh
 wget https://raw.github.com/ManimCommunity/manim/master/example_scenes/basic.py
@@ -252,7 +252,7 @@ wget https://raw.github.com/ManimCommunity/manim/master/example_scenes/basic.py
 manim example_scenes/basic.py SquareToCircle -pl
 ```
 
-3. Download the [custom_template.tex](https://raw.github.com/ManimCommunity/manim/blob/master/example_scenes/custom_template.tex) and [customtex.py](https://raw.github.com/ManimCommunity/manim/blob/master/example_scenes/customtex.py) example_scenes files, and run the following command:
+3. Download the [custom_template.tex](https://raw.github.com/ManimCommunity/manim/master/example_scenes/custom_template.tex) and [customtex.py](https://raw.github.com/ManimCommunity/manim/master/example_scenes/customtex.py) example_scenes files, and run the following command:
 ```sh
 manim customtex.py --tex_template custom_template.tex -pl
 ```


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
<!-- List out your changes one by one like this:
- Change 1
- Change 2
- and so on..
-->

Fixed links to `basic.py`, `custom_template.tex` and `customtex.py`, in the readme, as they were producing 404's

## Motivation
<!-- Why you feel your changes are required. -->
It's nice when links work

## Explanation for Changes
<!-- How do your changes solve aforementioned problems? -->
changed the URLs to no longer include references to a 'blob' folder, which I presume was removed in a prior commit

## Testing Status
<!-- Optional, but recommended, your computer specs and what tests you ran with their results, if any -->
clicked the links, links work

## Further Comments
<!-- Optional, any edits/updates should preferably be written here. -->

## Acknowledgement
- [ :heavy_check_mark:  ] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
