### PR TITLE
Changed default logger level to INFO for external libraries

### DIFF
--- a/manim/logger.py
+++ b/manim/logger.py
@@ -89,3 +89,7 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger("rich")
+
+# TODO : This is only temporary to keep the terminal output clean when working with ImageMobject and matplotlib plots
+logging.getLogger("PIL").setLevel(logging.INFO)
+logging.getLogger("matplotlib").setLevel(logging.INFO)


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
Added 2 lines in logger

## Motivation
At the moment, 
there are quite long terminal outputs when working with external libraries like "PIL" (which is also used in ImageMobejct) or "matplotlib". 
With this change, when working with these libraries, there will be now a clean terminal output.
Also when someone uses another side package, they can easily set all logger levels to INFO with these lines as a reference how to change the logger level.
## Testing Status
<!-- Optional, but recommended, your computer specs and what tests you ran with their results if any -->

I tested this script  with matplotlib installed, 
then uninstalled matplotlib and run it again.
Both of the time it was working with a clean terminal output.

## Acknowledgement
- [x ] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

