### PR TITLE
Read The Docs setup

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+Sphinx==3.1.2
+guzzle-sphinx-theme
+recommonmark>=0.5.0
+-e git://github.com/ManimCommunity/manim/@master#egg=manim

--- a/docs/source/tutorials/configuration.rst
+++ b/docs/source/tutorials/configuration.rst
@@ -53,7 +53,7 @@ The output looks as follows.
                 [--log_dir LOG_DIR] [--tex_template TEX_TEMPLATE] [--dry_run]
                 [-t] [-l] [-m] [-e] [-k] [-r RESOLUTION]
                 [-n FROM_ANIMATION_NUMBER] [--config_file CONFIG_FILE]
-                [-v {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
+                [--custom_folders] [-v {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
                 [--progress_bar True/False]
                 {cfg} ... file [scene_names [scene_names ...]]
 
@@ -112,6 +112,9 @@ The output looks as follows.
                            rendering at the second value
      --config_file CONFIG_FILE
                            Specify the configuration file
+     --custom_folders      Use the folders defined in the [custom_folders]
+                           section of the config file to define the output folder
+                           structure
      -v {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --verbosity {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                            Verbosity level. Also changes the ffmpeg log level
                            unless the latter is specified in the config


### PR DESCRIPTION
This PR will allow us to have a fancy new RTD website whenever we push to master. Here is the current site:

https://manimce.readthedocs.io/en/rtd-setup/

Once this PR is merged, I will delete the `rtd-setup` branch and the website will change to

https://manimce.readthedocs.io/en/latest/

This will always be up to date with master. Once we have a stable/release branch, we can also set it up so that there are docs for the stable release.