### PR TITLE
Add a note asking the dev to uninstall pip manimce if using git version.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+Sphinx==3.1.2
+guzzle-sphinx-theme
+recommonmark>=0.5.0
+-e git://github.com/ManimCommunity/manim/@master#egg=manim

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -53,7 +53,7 @@ cloned this repo, run the following:
    python3 -m pip install -r requirements.txt
 
 .. warning::
-    If you want to contribute to ``manim-community`` and have clone the
+    If you want to contribute to ``manim-community`` and have cloned the
     repository to your local device, please uninstall the pip-installed version
     of ``manim-community``, if you had installed it previously.
     This is to avoid any accidental usage of the pip-installed version when developing

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -51,3 +51,10 @@ cloned this repo, run the following:
 .. code-block:: bash
 
    python3 -m pip install -r requirements.txt
+
+.. warning::
+    If you want to contribute to ``manim-community`` and have clone the
+    repository to your local device, please uninstall the pip-installed version
+    of ``manim-community``, if you had installed it previously.
+    This is to avoid any accidental usage of the pip-installed version when developing
+    and testing on your local copy of the repository.

--- a/docs/source/tutorials/configuration.rst
+++ b/docs/source/tutorials/configuration.rst
@@ -53,7 +53,7 @@ The output looks as follows.
                 [--log_dir LOG_DIR] [--tex_template TEX_TEMPLATE] [--dry_run]
                 [-t] [-l] [-m] [-e] [-k] [-r RESOLUTION]
                 [-n FROM_ANIMATION_NUMBER] [--config_file CONFIG_FILE]
-                [-v {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
+                [--custom_folders] [-v {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
                 [--progress_bar True/False]
                 {cfg} ... file [scene_names [scene_names ...]]
 
@@ -112,6 +112,9 @@ The output looks as follows.
                            rendering at the second value
      --config_file CONFIG_FILE
                            Specify the configuration file
+     --custom_folders      Use the folders defined in the [custom_folders]
+                           section of the config file to define the output folder
+                           structure
      -v {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --verbosity {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                            Verbosity level. Also changes the ffmpeg log level
                            unless the latter is specified in the config


### PR DESCRIPTION
## List of Changes
- Add a note asking the dev to uninstall pip manimce if using git version.

## Motivation
We had issues caused by the dev having both the pip installed ManimCE as well as the git version of ManimCE, where while testing, the code of the (unchanged) pip version would be used, which is obviously unwanted.

## Explanation for Changes
The dev would be informed that they need to uninstall the pip version of ManimCE if developing on the Git version to avoid such clashes.

## Testing Status
Github's preview of the rst file looks okay.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

