### PR TITLE
Fix overflowing images in documentation

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -4,5 +4,6 @@ td {
 
 img.align-center {
     width: 100%;
-    margin-bottom: 10px;
+    margin-bottom: 20px;
+    margin-top: 20px;
 }

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,3 +1,8 @@
 td {
     padding: 0px 10px 0px 10px;
 }
+
+img.align-center {
+    width: 100%;
+    margin-bottom: 10px;
+}


### PR DESCRIPTION
## List of Changes
Minor modification of `custom.css` for documentation.

## Motivation
Fixes #386.

## Explanation for Changes
The width of the image is set to the same size as the container it is contained in. Also, the same margin as for paragraphs is added.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

