### PR TITLE
Fix to allow for passing height only with -r flag

### DIFF
--- a/manim/config.py
+++ b/manim/config.py
@@ -91,7 +91,8 @@ def _parse_config(config_parser, args):
             height_str, width_str = args.resolution.split(",")
             height, width = int(height_str), int(width_str)
         else:
-            height, width = int(args.resolution), int(16 * height / 9)
+            height = int(args.resolution)
+            width = int(16 * height / 9)
         config.update({"pixel_height": height, "pixel_width": width})
 
     # Handle the -c (--background_color) flag


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
<!-- List out your changes one by one like this:
- Change 1
- Change 2
- and so on..
-->
- Fix bug where passing only `height` for `-r` flag throws:
`UnboundLocalError: local variable 'height' referenced before assignment`

## Motivation
<!-- Why you feel your changes are required. -->
It appears this feature is supposed to exist as it is documented, and is already present in 3b1b's implementation, but had been implemented with a bug here

## Explanation for Changes
<!-- How do your changes solve aforementioned problems? -->
The `height` and `width` assignments are now split onto two lines

<!-- ## Testing Status -->
<!-- Optional, but recommended, your computer specs and what tests you ran with their results, if any -->

## Further Comments
<!-- Optional, any edits/updates should preferably be written here. -->
I'm aware there was a recent fix to allow for `height` and `width` to be passed together, but this use case seems to have been skipped over in testing.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
