### PR TITLE
Add a note in the PR template asking devs to use changelog.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,9 @@ If you don't need any of the optional sections, feel free to delete them to prev
 - Change 1
 - Change 2
 - and so on..
+
+Be sure to note your changes in the [changelog](docs/source/changelog.rst) if your
+changes warrant it!
 -->
 
 ## Motivation

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -58,6 +58,8 @@ Mobjects, Scenes, and Animations
 #. Added Scene-caching feature. Now, if a partial movie file is unchanged in your code, it isn’t rendered again! [HIGHLY UNSTABLE We're working on it ;)]
 #. Most :code:`get_` and :code:`set_` methods have been removed in favor of instance attributes and properties
 #. The :code:`Container` class has been made into an AbstractBaseClass, i.e. in cannot be instantiated.  Instead, use one of its children classes
+#. The ``TextMobject`` and ``TexMobject`` objects have been deprecated, due to their confusing names, in favour of ``Tex`` and ``MathTex``. You can still, however, continue to use ``TextMobject`` and ``TexMobject``, albeit with Deprecation Warnings constantly reminding you to switch.
+
 
 
 Documentation


### PR DESCRIPTION
Added the deprecation of `Tex[t]Mobject` to changelog.rst

## List of Changes
- Add a note in the PR template asking devs to use changelog.
- Added the deprecation of `Tex[t]Mobject` to changelog.rst

## Motivation
Often devs, (including myself!) forget to add their changes to the changelog file.

## Explanation for Changes
Adds a comment in the PR Template.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
