### PR TITLE
Cleanup sphinx extension list

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,7 +29,6 @@ author = "The Manim Community Dev Team"
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx_rtd_theme",
     "recommonmark",
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",


### PR DESCRIPTION
## List of Changes

Remove `sphinx_rtd_theme` from sphinx extensions.


## Motivation

We don't use it, and it sneaked back in some merge. :-)


## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

