### PR TITLE
Fix width (at 14 2/9 units) by default

### DIFF
--- a/manim/config/config.py
+++ b/manim/config/config.py
@@ -112,7 +112,9 @@ def _parse_config(config_parser, args):
 
     # Set the rest of the frame properties
     config["frame_width"] = 8 * 16 / 9
-    config["frame_height"] = config["frame_width"] * config["pixel_height"] / config["pixel_width"]
+    config["frame_height"] = (
+        config["frame_width"] * config["pixel_height"] / config["pixel_width"]
+    )
     config["frame_y_radius"] = config["frame_height"] / 2
     config["frame_x_radius"] = config["frame_width"] / 2
     config["top"] = config["frame_y_radius"] * constants.UP

--- a/manim/config/config.py
+++ b/manim/config/config.py
@@ -111,10 +111,8 @@ def _parse_config(config_parser, args):
     config["background_color"] = background_color
 
     # Set the rest of the frame properties
-    config["frame_height"] = 8.0
-    config["frame_width"] = (
-        config["frame_height"] * config["pixel_width"] / config["pixel_height"]
-    )
+    config["frame_width"] = 8 * 16 / 9
+    config["frame_height"] = config["frame_width"] * config["pixel_height"] / config["pixel_width"]
     config["frame_y_radius"] = config["frame_height"] / 2
     config["frame_x_radius"] = config["frame_width"] / 2
     config["top"] = config["frame_y_radius"] * constants.UP


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
- Changed the default fixed-height to fixed-width
<!-- List out your changes one by one like this:
- Change 1
- Change 2
- and so on..

Be sure to note your changes in the [changelog](docs/source/changelog.rst) if your
changes warrant it!
-->

## Motivation
- It appears that the change from 3b1b's fixed-width by default to a fixed-height may have been incidental. To clarify, at a 16:9 aspect ratio, the frame is 14 2/9 by 8. If a square video is made, for example, 3b1b will produce a frame that's 14 2/9 by 14 2/9, whereas Manim Community will produce a frame that's 8 by 8.
<!-- Why you feel your changes are required. -->

## Further Comments
- I have the point illustrated in [issue 275](https://github.com/ManimCommunity/manim/issues/275#issuecomment-687534061)
- I didn't find anything indicating that this was done intentionally, hence this pull request, but perhaps someone else can confirm/deny this inference?
<!-- Optional, any edits/updates should preferably be written here. -->

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
