### PR TITLE
Remove Documentation caption from sidebar

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,7 +18,6 @@ information here will make it easier for newcomers to get started using
 
 .. toctree::
    :maxdepth: 2
-   :caption: Documentation
 
    installation
    reference


### PR DESCRIPTION
## List of Changes

See title.

## Motivation
The non-clickable caption in the table of contents is confusing, I feel.

## Explanation for Changes
No caption => no confusion.


## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

