### PR TITLE
Scene caching optimisation but ignoring mappingproxy 

### DIFF
--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -52,9 +52,10 @@ class CustomEncoder(json.JSONEncoder):
             return repr(obj)
         elif hasattr(obj, "__dict__"):
             temp = getattr(obj, "__dict__")
-            # MappingProxy is not supported by the Json Encoder
+            # MappingProxy is scene-caching nightmare. It contains all of the object methods and attributes. We skip it as the mechanism will at some point process the object, but instancied
+            # Indeed, there is certainly no case where scene-caching will recieve only a non instancied object, as this is never used in the library or encouraged to be used user-side.
             if isinstance(temp, MappingProxyType):
-                return dict(temp)
+                return "MappingProxy"
             return self._check_iterable(temp)
         elif isinstance(obj, np.uint8):
             return int(obj)

--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -54,7 +54,7 @@ class CustomEncoder(json.JSONEncoder):
             temp = getattr(obj, "__dict__")
             # MappingProxy is not supported by the Json Encoder
             if isinstance(temp, MappingProxyType):
-                return dict(temp)
+                return "mappingproxy"
             return self._check_iterable(temp)
         elif isinstance(obj, np.uint8):
             return int(obj)

--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -54,7 +54,7 @@ class CustomEncoder(json.JSONEncoder):
             temp = getattr(obj, "__dict__")
             # MappingProxy is not supported by the Json Encoder
             if isinstance(temp, MappingProxyType):
-                return "mappingproxy"
+                return dict(temp)
             return self._check_iterable(temp)
         elif isinstance(obj, np.uint8):
             return int(obj)


### PR DESCRIPTION
Very quick but massive scene-caching optimisation.  Pinging @Aathish04 , he participated in building this boy.

MappingProxys should be skipped for two reasons : 
- They are very, very heavy. They contain all the methods of the object (as well as attributes) which will be in turn serialized by the json encoder. For example, at some point there is MappingProxy for `Scene` object that goes through the scene-caching mechanism, with all the methods of the scenes + their attributes, which is **huge** and useless for the scene-caching. This is even more huge when you think that all of the method will be serialized, all of the non local variables afterward, etc. 
- They are useless for scene-caching. It does not change anything when ignoring it or not. 


Here is an insight of the gain of speed (x10 faster !)
(before this PR): 
![image](https://user-images.githubusercontent.com/36239975/92656024-9f7d0700-f2f2-11ea-8cb1-c9d2d2ed0e68.png)

(after this PR)
![image](https://user-images.githubusercontent.com/36239975/92655888-5f1d8900-f2f2-11ea-9d92-e2ec7ffa4c88.png)


PS: did I succeed in messing up commits of a one line change ? yes.
