### PR TITLE
fix formatting of warning block in installation.rst

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -56,9 +56,10 @@ cloned this repo, run the following:
 Please see :doc:`contributing` for more details about contributing to Manim.
 
 .. warning::
-    If you want to contribute to ``manim-community`` and have cloned the
-    repository to your local device, please uninstall the pip-installed version
-    of ``manim-community``, if you had installed it previously.
-    This is to avoid any accidental usage of the pip-installed version when developing
-    and testing on your local copy of the repository. This warning doesn't apply for
-	users who use [poetry](https://python-poetry.org).
+
+   If you want to contribute to ``manim-community`` and have cloned the
+   repository to your local device, please uninstall the pip-installed version
+   of ``manim-community``, if you had installed it previously.
+   This is to avoid any accidental usage of the pip-installed version when developing
+   and testing on your local copy of the repository. This warning doesn't apply for
+   users who use `poetry <https://python-poetry.org>`_.


### PR DESCRIPTION
## List of Changes
- fix formatting in documentation

before:
![image](https://user-images.githubusercontent.com/11851593/92923687-2091e680-f438-11ea-96ab-b40f0ef3e444.png)

after:
![image](https://user-images.githubusercontent.com/11851593/92923726-2be51200-f438-11ea-9cb0-10a9ba0be2c6.png)



## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
