### PR TITLE
Align Images in Mobile - Sphinx

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -7,7 +7,11 @@ img.align-center {
     margin-bottom: 20px;
     margin-top: 20px;
 }
-
+img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+}
 .manim-video {
     width: 100%;
 }


### PR DESCRIPTION


## List of Changes
- Fix Image Alignment in mobile using CSS
![Screen Shot 2020-09-13 at 17 07 20](https://user-images.githubusercontent.com/49693820/93017127-d2b9e180-f5e3-11ea-8c47-bbf0b2ab59c0.png)
to
![Screen Shot 2020-09-13 at 17 09 55](https://user-images.githubusercontent.com/49693820/93017141-fa10ae80-f5e3-11ea-8b9a-d4ba20dc7320.png)
As a result, disabling vertical scroll in mobile.

## Motivation
Docs should look good in Mobile also.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
