### PR TITLE
change default for displaying source code with manim directive

### DIFF
--- a/docs/source/manim_directive.py
+++ b/docs/source/manim_directive.py
@@ -5,7 +5,7 @@ A directive for including Manim videos in a Sphinx document
 When rendering the HTML documentation, the ``.. manim::`` directive
 implemented here allows to include rendered videos.
 
-Its basic usage that allows processing **inline content** 
+Its basic usage that allows processing **inline content**
 looks as follows::
 
     .. manim:: MyScene
@@ -41,9 +41,9 @@ Options can be passed as follows::
 The following configuration options are supported by the
 directive:
 
-    display_source
+    hide_source
         If this flag is present without argument,
-        the source code is displayed above the rendered video.
+        the source code is not displayed above the rendered video.
 
     quality : {'low', 'medium', 'high', 'fourk'}
         Controls render quality of the video, in analogy to
@@ -80,7 +80,7 @@ class ManimDirective(Directive):
     required_arguments = 1
     optional_arguments = 0
     option_spec = {
-        "display_source": bool,
+        "hide_source": bool,
         "quality": lambda arg: directives.choice(
             arg, ("low", "medium", "high", "fourk")
         ),
@@ -100,7 +100,7 @@ class ManimDirective(Directive):
         else:
             classnamedict[clsname] += 1
 
-        display_source = "display_source" in self.options
+        hide_source = "hide_source" in self.options
         save_as_gif = "save_as_gif" in self.options
         save_last_frame = "save_last_frame" in self.options
         assert not (save_as_gif and save_last_frame)
@@ -211,7 +211,7 @@ class ManimDirective(Directive):
             raise ValueError("Invalid combination of render flags received.")
 
         rendered_template = jinja2.Template(TEMPLATE).render(
-            display_source=display_source,
+            hide_source=hide_source,
             filesrc_rel=os.path.relpath(filesrc, setup.confdir),
             output_file=output_file,
             save_last_frame=save_last_frame,
@@ -238,7 +238,7 @@ def setup(app):
 
 
 TEMPLATE = r"""
-{% if display_source %}
+{% if not hide_source %}
 .. raw:: html
 
     <div class="manim-example">
@@ -258,7 +258,7 @@ TEMPLATE = r"""
     :align: center
 {% endif %}
 
-{% if display_source %}
+{% if not hide_source %}
 .. raw:: html
 
     </div>

--- a/docs/source/tutorials/a_deeper_look.rst
+++ b/docs/source/tutorials/a_deeper_look.rst
@@ -65,6 +65,7 @@ will play it once it's done since we are using the ``-p`` flag.  The output
 should look like this:
 
 .. manim:: SquareToCircle3
+   :hide_source:
    :quality: high
 
    class SquareToCircle3(Scene):

--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -61,7 +61,6 @@ screen, simply call the :meth:`~.Scene.remove` method from the containing
 :class:`.Scene`.
 
 .. manim:: CreatingMobjects
-   :display_source:
    :quality: medium
 
    class CreatingMobjects(Scene):
@@ -81,7 +80,6 @@ some mobjects to it.  This script generates a static picture that displays a
 circle, a square, and a triangle:
 
 .. manim:: Shapes
-   :display_source:
    :quality: medium
 
    class Shapes(Scene):
@@ -114,7 +112,6 @@ There are many other possible ways to place mobjects on the screen, for example
 ``MobjectPlacement`` uses all three.
 
 .. manim:: MobjectPlacement
-   :display_source:
    :quality: medium
 
    class MobjectPlacement(Scene):
@@ -163,7 +160,6 @@ Styling mobjects
 The following scene changes the default aesthetics of the mobjects.
 
 .. manim:: MobjectStyling
-   :display_source:
    :quality: medium
 
    class MobjectStyling(Scene):
@@ -200,7 +196,6 @@ The next scene is exactly the same as the ``MobjectStyling`` scene from the
 previous section, except for exactly one line.
 
 .. manim:: MobjectZOrder
-   :display_source:
    :quality: medium
 
    class MobjectZOrder(Scene):
@@ -234,7 +229,6 @@ At the heart of manim is animation.  Generally, you can add an animation to
 your scene by calling the :meth:`~.Scene.play` method.
 
 .. manim:: SomeAnimations
-   :display_source:
    :quality: medium
 
    class SomeAnimations(Scene):
@@ -271,7 +265,6 @@ method that changes a mobject's property can be used as an animation, through
 the use of :class:`.ApplyMethod`.
 
 .. manim:: ApplyMethodExample
-   :display_source:
    :quality: medium
 
    class ApplyMethodExample(Scene):
@@ -300,7 +293,6 @@ By default, any animation passed to :meth:`play` lasts for exactly one second.
 Use the :code:`run_time` argument to control the duration.
 
 .. manim:: RunTime
-   :display_source:
    :quality: medium
 
    class RunTime(Scene):

--- a/docs/source/tutorials/quickstart.rst
+++ b/docs/source/tutorials/quickstart.rst
@@ -58,6 +58,7 @@ and open that file with the default movie player application.  You should see a
 video playing the following animation.
 
 .. manim:: SquareToCircle
+   :hide_source:
    :quality: low
 
    class SquareToCircle(Scene):
@@ -153,6 +154,7 @@ And render it using the following command:
 The output should look as follows.
 
 .. manim:: SquareToCircle2
+   :hide_source:
    :quality: low
 
    class SquareToCircle2(Scene):

--- a/manim/mobject/changing.py
+++ b/manim/mobject/changing.py
@@ -16,7 +16,6 @@ class AnimatedBoundary(VGroup):
     Examples
     --------
     .. manim:: AnimatedBoundaryExample
-        :display_source:
         :quality: low
 
         class AnimatedBoundaryExample(Scene):
@@ -90,7 +89,6 @@ class TracedPath(VMobject):
     Examples
     --------
     .. manim:: TracedPathExample
-        :display_source:
         :quality: low
 
         class TracedPathExample(Scene):

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -895,7 +895,7 @@ class ArrowTip(VMobject):
     a custom one like this:
 
     .. manim:: CustomTipExample
-        :display_source:
+        :quality: low
 
         >>> class MyCustomArrowTip(ArrowTip, RegularPolygon):
         ...     def __init__(self, **kwargs):

--- a/manim/mobject/value_tracker.py
+++ b/manim/mobject/value_tracker.py
@@ -21,7 +21,6 @@ class ValueTracker(Mobject):
     Examples
     --------
     .. manim:: ValueTrackerExample
-        :display_source:
         :quality: low
 
         class ValueTrackerExample(Scene):


### PR DESCRIPTION
## List of Changes
- In coordination with @kolibril13: change the default behavior of the manim directive to display the source code by default and hide it with the `:hide_source:` flag.


## Motivation
In most cases, the source code should be included with the example.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

