### PR TITLE
fix RTD documentation build for non-master branches

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 Sphinx==3.1.2
 guzzle-sphinx-theme
 recommonmark>=0.5.0
-https://github.com/ManimCommunity/manim/archive/master.zip

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -1,2 +1,2 @@
 imageio-ffmpeg
--e git://github.com/ManimCommunity/manim/@master#egg=manim
+-e git://github.com/ManimCommunity/manim/@master#egg=manimlib

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -1,1 +1,2 @@
 imageio-ffmpeg
+-e git://github.com/ManimCommunity/manim/@master#egg=manim

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -1,2 +1,1 @@
 imageio-ffmpeg
--e git://github.com/ManimCommunity/manim/@master#egg=manimlib

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -233,6 +233,7 @@ class TipableVMobject(VMobject):
 
 
 class Arc(TipableVMobject):
+    """A circular arc."""
     CONFIG = {
         "radius": 1.0,
         "num_components": 9,

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -234,6 +234,7 @@ class TipableVMobject(VMobject):
 
 class Arc(TipableVMobject):
     """A circular arc."""
+
     CONFIG = {
         "radius": 1.0,
         "num_components": 9,


### PR DESCRIPTION
## Explanation for Changes
We have been installing manim twice during the setup of the RTD build environment; the installation of the master branch overwrote the installation of the checked out changes leading to all branches building the documentation of the current master branch.

This is fixed here by removing `https://github.com/ManimCommunity/manim/archive/master.zip` from the requirements (the local `manim(lib)` package is installed nonetheless due to the configuration in `.readthedocs.yml`).

## Testing Status
Lets see what the pipeline does with this.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

