### PR TITLE
FIX : 472 / Small refactor of partial-movie-files handling 

### DIFF
--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -784,7 +784,6 @@ class Scene(Container):
         the number of animations that need to be played, and
         raises an EndSceneEarlyException if they don't correspond.
         """
-
         if file_writer_config["from_animation_number"]:
             if self.num_plays < file_writer_config["from_animation_number"]:
                 file_writer_config["skip_animations"] = True
@@ -848,6 +847,10 @@ class Scene(Container):
         def wrapper(self, duration=DEFAULT_WAIT_TIME, stop_condition=None):
             self.revert_to_original_skipping_status()
             self.update_skipping_status()
+            if file_writer_config["skip_animations"]:
+                logger.debug(f"Skipping wait {self.num_plays}")
+                func(self, duration, stop_condition)
+                return
             if not file_writer_config["disable_caching"]:
                 hash_wait = get_hash_from_wait_call(
                     self, self.camera, duration, stop_condition, self.get_mobjects()

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -69,7 +69,7 @@ class Scene(Container):
             self,
             **file_writer_config,
         )
-        self.play_hashes_list = []
+        self.animations_hashes = []
         self.mobjects = []
         self.original_skipping_status = file_writer_config["skip_animations"]
         # TODO, remove need for foreground mobjects
@@ -812,13 +812,15 @@ class Scene(Container):
             if file_writer_config["skip_animations"]:
                 logger.debug(f"Skipping animation {self.num_plays}")
                 func(self, *args, **kwargs)
+                # If the animation is skipped, we mark its has as None. When sceneFileWriter will start combining partial movie files, it won't take into account None hashes.
+                self.animations_hashes.append(None)
+                self.file_writer.add_partial_movie_file(None)
                 return
             if not file_writer_config["disable_caching"]:
                 mobjects_on_scene = self.get_mobjects()
                 hash_play = get_hash_from_play_call(
                     self, self.camera, animations, mobjects_on_scene
                 )
-                self.play_hashes_list.append(hash_play)
                 if self.file_writer.is_already_cached(hash_play):
                     logger.info(
                         f"Animation {self.num_plays} : Using cached data (hash : %(hash_play)s)",
@@ -827,7 +829,12 @@ class Scene(Container):
                     file_writer_config["skip_animations"] = True
             else:
                 hash_play = "uncached_{:05}".format(self.num_plays)
-                self.play_hashes_list.append(hash_play)
+            self.animations_hashes.append(hash_play)
+            self.file_writer.add_partial_movie_file(hash_play)
+            logger.debug(
+                "Animations hashes list of the scene : (concatened to 5) %(h)s",
+                {"h": str(self.animations_hashes[:5])},
+            )
             func(self, *args, **kwargs)
 
         return wrapper
@@ -850,12 +857,14 @@ class Scene(Container):
             if file_writer_config["skip_animations"]:
                 logger.debug(f"Skipping wait {self.num_plays}")
                 func(self, duration, stop_condition)
+                # If the animation is skipped, we mark its has as None. When sceneFileWriter will start combining partial movie files, it won't take into account None hashes.
+                self.animations_hashes.append(None)
+                self.file_writer.add_partial_movie_file(None)
                 return
             if not file_writer_config["disable_caching"]:
                 hash_wait = get_hash_from_wait_call(
                     self, self.camera, duration, stop_condition, self.get_mobjects()
                 )
-                self.play_hashes_list.append(hash_wait)
                 if self.file_writer.is_already_cached(hash_wait):
                     logger.info(
                         f"Wait {self.num_plays} : Using cached data (hash : {hash_wait})"
@@ -863,7 +872,12 @@ class Scene(Container):
                     file_writer_config["skip_animations"] = True
             else:
                 hash_wait = "uncached_{:05}".format(self.num_plays)
-                self.play_hashes_list.append(hash_wait)
+            self.animations_hashes.append(hash_wait)
+            self.file_writer.add_partial_movie_file(hash_wait)
+            logger.debug(
+                "Animations hashes list of the scene : (concatened to 5) %(h)s",
+                {"h": str(self.animations_hashes[:5])},
+            )
             func(self, duration, stop_condition)
 
         return wrapper

--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -247,9 +247,13 @@ def get_hash_from_play_call(
     ]
     t_end = perf_counter()
     logger.debug("Hashing done in %(time)s s.", {"time": str(t_end - t_start)[:8]})
+    hash_complete = "{}_{}_{}".format(
+        hash_camera, hash_animations, hash_current_mobjects
+    )
     # This will reset ALREADY_PROCESSED_ID as all the hashing processus is finished.
     ALREADY_PROCESSED_ID = {}
-    return "{}_{}_{}".format(hash_camera, hash_animations, hash_current_mobjects)
+    logger.debug("Hash generated :  %(h)s", {"h": hash_complete})
+    return hash_complete
 
 
 def get_hash_from_wait_call(
@@ -294,15 +298,19 @@ def get_hash_from_wait_call(
         ALREADY_PROCESSED_ID = {}
         t_end = perf_counter()
         logger.debug("Hashing done in %(time)s s.", {"time": str(t_end - t_start)[:8]})
-        return "{}_{}{}_{}".format(
+        hash_complete = "{}_{}{}_{}".format(
             hash_camera,
             str(wait_time).replace(".", "-"),
             hash_function,
             hash_current_mobjects,
         )
+        logger.debug("Hash generated :  %(h)s", {"h": hash_complete})
+        return hash_complete
     ALREADY_PROCESSED_ID = {}
     t_end = perf_counter()
     logger.debug("Hashing done in %(time)s s.", {"time": str(t_end - t_start)[:8]})
-    return "{}_{}_{}".format(
+    hash_complete = "{}_{}_{}".format(
         hash_camera, str(wait_time).replace(".", "-"), hash_current_mobjects
     )
+    logger.debug("Hash generated :  %(h)s", {"h": hash_complete})
+    return hash_complete

--- a/tests/control_data/logs_data/BasicSceneLoggingTest.txt
+++ b/tests/control_data/logs_data/BasicSceneLoggingTest.txt
@@ -1,6 +1,9 @@
 {"levelname": "INFO", "module": "config", "message": "Log file wil be saved in <>"}
 {"levelname": "DEBUG", "module": "hashing", "message": "Hashing ..."}
 {"levelname": "DEBUG", "module": "hashing", "message": "Hashing done in <> s."}
+{"levelname": "DEBUG", "module": "hashing", "message": "Hash generated :  <>"}
+{"levelname": "DEBUG", "module": "scene", "message": "Animations hashes list of the scene : (concatened to 5) <>"}
 {"levelname": "INFO", "module": "scene_file_writer", "message": "Animation 0 : Partial movie file written in <>"}
+{"levelname": "DEBUG", "module": "scene_file_writer", "message": "Partial movie files to combine (1 files): <>"}
 {"levelname": "INFO", "module": "scene_file_writer", "message": "\nFile ready at <>\n"}
 {"levelname": "INFO", "module": "scene", "message": "Rendered SquareToCircle\nPlayed 1 animations"}

--- a/tests/control_data/videos_data/SceneWithMultiplePlayCallsWithNFlag.json
+++ b/tests/control_data/videos_data/SceneWithMultiplePlayCallsWithNFlag.json
@@ -1,0 +1,11 @@
+{
+    "name": "SceneWithMultiplePlayCallsWithNFlag",
+    "config": {
+        "codec_name": "h264",
+        "width": 854,
+        "height": 480,
+        "avg_frame_rate": "15/1",
+        "duration": "7.000000",
+        "nb_frames": "105"
+    }
+}

--- a/tests/control_data/videos_data/SceneWithMultipleWaitCallsWithNFlag.json
+++ b/tests/control_data/videos_data/SceneWithMultipleWaitCallsWithNFlag.json
@@ -1,0 +1,11 @@
+{
+    "name": "SceneWithMultipleWaitCallsWithNFlag",
+    "config": {
+        "codec_name": "h264",
+        "width": 854,
+        "height": 480,
+        "avg_frame_rate": "15/1",
+        "duration": "5.000000",
+        "nb_frames": "75"
+    }
+}

--- a/tests/test_scene_rendering/simple_scenes.py
+++ b/tests/test_scene_rendering/simple_scenes.py
@@ -15,3 +15,15 @@ class SceneWithMultipleCalls(Scene):
         for i in range(10):
             number.become(Integer(i))
             self.play(Animation(number))
+
+
+class SceneWithMultipleWaitCalls(Scene):
+    def construct(self):
+        self.play(ShowCreation(Square()))
+        self.wait(1)
+        self.play(ShowCreation(Square().shift(DOWN)))
+        self.wait(1)
+        self.play(ShowCreation(Square().shift(2 * DOWN)))
+        self.wait(1)
+        self.play(ShowCreation(Square().shift(3 * DOWN)))
+        self.wait(1)

--- a/tests/test_scene_rendering/test_caching_relalted.py
+++ b/tests/test_scene_rendering/test_caching_relalted.py
@@ -1,0 +1,53 @@
+import os
+import pytest
+import subprocess
+from manim import file_writer_config
+
+from ..utils.commands import capture
+from ..utils.video_tester import *
+
+
+@video_comparison(
+    "SceneWithMultipleWaitCallsWithNFlag.json",
+    "videos/simple_scenes/480p15/SceneWithMultipleWaitCalls.mp4",
+)
+def test_wait_skip(tmp_path, manim_cfg_file, simple_scenes_path):
+    # Test for PR #468. Intended to test if wait calls are correctly skipped.
+    scene_name = "SceneWithMultipleWaitCalls"
+    command = [
+        "python",
+        "-m",
+        "manim",
+        simple_scenes_path,
+        scene_name,
+        "-l",
+        "--media_dir",
+        str(tmp_path),
+        "-n",
+        "3",
+    ]
+    out, err, exit_code = capture(command)
+    assert exit_code == 0, err
+
+
+@video_comparison(
+    "SceneWithMultiplePlayCallsWithNFlag.json",
+    "videos/simple_scenes/480p15/SceneWithMultipleCalls.mp4",
+)
+def test_play_skip(tmp_path, manim_cfg_file, simple_scenes_path):
+    # Intended to test if play calls are correctly skipped.
+    scene_name = "SceneWithMultipleCalls"
+    command = [
+        "python",
+        "-m",
+        "manim",
+        simple_scenes_path,
+        scene_name,
+        "-l",
+        "--media_dir",
+        str(tmp_path),
+        "-n",
+        "3",
+    ]
+    out, err, exit_code = capture(command)
+    assert exit_code == 0, err


### PR DESCRIPTION
## List of Changes
- Refactored partial movie files handling. See explanation below. 
- Added some extra logs that output partial movie files stuff, to make debugging easier.

## Motivation
- This fixes #472 

## Explanation for Changes
#472 undercovers two issues : 
- The first one is related to SceneFileWriter. To write a new partial movie file, it used to take in order the next hash in `animation_hashes` list of a scene. SceneFileWriter keeps its own index of partial movie files, independently of Scene. I think some code is better than my explanations : See get_next_partial_movie_file method, and scene_file_writer own index is `self.index_partial_movie_file `.

https://github.com/ManimCommunity/manim/blob/master/manim/scene/scene_file_writer.py#L189-L210

This is bad, very bad, in some particular cases, like when the first animation is skipped as already cached. Then, the list of partial movie file is updated, but as sceneFIleWriter has its own index, sceneFIleWriter will think it's the first animation instead of the second one. I know, it's tricky. I fixed this by getting rid of this index. The index is now `scene.num_plays`.

- Manim didn't make any difference between animation skipped because cached and animation skipped because of -n. The first ones have to be rendered in the final movie, the second one not. This is now fixed. If an animation has to be skipped because of a flag, the animation_hashes_list will be appened by None, and by the hash otherwise. Like this, the index (`scene.num_plays`) is not bigger than `animation_hashes` list. 

## Testing Status
WIP. 


## Acknowledgement
- [ x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

