### PR TITLE
[Supereasy] Fix some missing newlines before code blocks in Sphinx

### DIFF
--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -946,6 +946,7 @@ class ArrowTip(VMobject):
         Examples
         --------
         ::
+
             >>> arrow = Arrow(np.array([0, 0, 0]), np.array([2, 0, 0]), buff=0)
             >>> arrow.tip.base.round(2) + 0.  # add 0. to avoid negative 0 in output
             array([1.65, 0.  , 0.  ])
@@ -960,6 +961,7 @@ class ArrowTip(VMobject):
         Examples
         --------
         ::
+
             >>> arrow = Arrow(np.array([0, 0, 0]), np.array([2, 0, 0]), buff=0)
             >>> arrow.tip.tip_point.round(2) + 0.
             array([2., 0., 0.])
@@ -974,6 +976,7 @@ class ArrowTip(VMobject):
         Examples
         --------
         ::
+
             >>> arrow = Arrow(np.array([0, 0, 0]), np.array([2, 2, 0]), buff=0)
             >>> arrow.tip.vector.round(2) + 0.
             array([0.25, 0.25, 0.  ])
@@ -988,6 +991,7 @@ class ArrowTip(VMobject):
         Examples
         --------
         ::
+
             >>> arrow = Arrow(np.array([0, 0, 0]), np.array([1, 1, 0]), buff=0)
             >>> round(arrow.tip.tip_angle, 5) == round(PI/4, 5)
             True
@@ -1002,6 +1006,7 @@ class ArrowTip(VMobject):
         Examples
         --------
         ::
+
             >>> arrow = Arrow(np.array([0, 0, 0]), np.array([1, 2, 0]))
             >>> round(arrow.tip.tip_length, 3)
             0.35

--- a/manim/utils/color.py
+++ b/manim/utils/color.py
@@ -97,25 +97,27 @@ from ..utils.space_ops import normalize
 
 class Colors(Enum):
     """A list of pre-defined colors.
-    
+
     Examples
     --------
     The preferred way of using these colors is
-    
+
     .. code-block:: python
+
        import manim.utils.color as C
        C.WHITE   # -> '#FFFFFF'
-       
+
     Note this way uses the name of the colors in UPPERCASE.
-    
+
     Alternatively, you can also import this Enum directly and use its members
     directly, through the use of :code:`color.value`.  Note this way uses the
     name of the colors in lowercase.
-    
+
     .. code-block:: python
+
        from manim.utils.color import Colors
        Colors.white.value   # -> '#FFFFFF'
-       
+
     """
 
     dark_blue = "#236B8E"


### PR DESCRIPTION
## List of Changes
Add some missing newlines.

## Motivation
The following pages are not correctly formatted:
- https://manimce.readthedocs.io/en/latest/reference/manim.mobject.geometry.ArrowTip.html?highlight=arrowtip#manim.mobject.geometry.ArrowTip ("::" after Examples)
- https://manimce.readthedocs.io/en/latest/reference/manim.utils.color.Colors.html#manim.utils.color.Colors (missing code blocks)

## Explanation for Changes
Sphinx requires a newline between the specification of the code-block directive and the actual code.

## Testing Status
Look at rendered documentation for this PR.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

