### PR TITLE
FIX : fixed tuples in hashing, by converting them to lists

### DIFF
--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -112,7 +112,7 @@ class CustomEncoder(json.JSONEncoder):
             # A deepcopy isn't necessary as it is already recursive.
             lst_copy = copy.copy(lst)
             if isinstance(lst, tuple):
-                # NOTE : Sometimes a tuple can pass through this function. As a tuple is unmutable, we convert it to a list to be able to modify it.
+                # NOTE : Sometimes a tuple can pass through this function. As a tuple is immutable, we convert it to a list to be able to modify it.
                 # It's ok as it's a copy.
                 lst_copy = list(lst_copy)
             for i, el in enumerate(lst):

--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -112,8 +112,9 @@ class CustomEncoder(json.JSONEncoder):
             # A deepcopy isn't necessary as it is already recursive.
             lst_copy = copy.copy(lst)
             if isinstance(lst, tuple):
-                # NOTE : Sometimes a tuple can pass through this function. As a tuple is immutable, we convert it to a list to be able to modify it.
-                # It's ok as it's a copy.
+                # NOTE: Sometimes a tuple can pass through this function. As a tuple
+                # is immutable, we convert it to a list to be able to modify it.
+                # It's ok as it is a copy.
                 lst_copy = list(lst_copy)
             for i, el in enumerate(lst):
                 if not isinstance(lst, tuple):

--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -111,6 +111,10 @@ class CustomEncoder(json.JSONEncoder):
             # We have to make a copy, as we don't want to touch to the original list
             # A deepcopy isn't necessary as it is already recursive.
             lst_copy = copy.copy(lst)
+            if isinstance(lst, tuple):
+                # NOTE : Sometimes a tuple can pass through this function. As a tuple is unmutable, we convert it to a list to be able to modify it.
+                # It's ok as it's a copy.
+                lst_copy = list(lst_copy)
             for i, el in enumerate(lst):
                 if not isinstance(lst, tuple):
                     lst_copy[i] = self._handle_already_processed(

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -108,3 +108,9 @@ def test_JSON_with_big_np_array():
     a = np.zeros((1000, 1000))
     o_ser = hashing.get_json(a)
     assert "TRUNCATED ARRAY" in o_ser
+
+
+def test_JSON_with_tuple():
+    o = [(1, [1])]
+    o_ser = hashing.get_json(o)
+    assert o_ser == "[[1, [1]]]"


### PR DESCRIPTION


##  List of Changes
- Fix #491 

## Explanation for Changes
Generally, scene caching iteratively check in every iterables for circular references. If one is found, then the value in the iterable causing the circular reference is replaced. Same if an element has already been processed.
The issue is, if the iterable is a tuple, as tuples are immutable, it is impossible to modyuf it 

## Testing Status
- Added a test for this case. 


## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

