### PR TITLE
Make VGroup and VDict printable

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -60,7 +60,7 @@ Mobjects, Scenes, and Animations
 #. The :code:`Container` class has been made into an AbstractBaseClass, i.e. in cannot be instantiated.  Instead, use one of its children classes
 #. The ``TextMobject`` and ``TexMobject`` objects have been deprecated, due to their confusing names, in favour of ``Tex`` and ``MathTex``. You can still, however, continue to use ``TextMobject`` and ``TexMobject``, albeit with Deprecation Warnings constantly reminding you to switch.
 #. Add a :code:`Variable` class for displaying text that continuously updates to reflect the value of a python variable.
-
+#. :code:`VGroup` and :code:`VDict` now support printing the contained mobjects.
 
 
 Documentation

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -60,7 +60,7 @@ Mobjects, Scenes, and Animations
 #. The :code:`Container` class has been made into an AbstractBaseClass, i.e. in cannot be instantiated.  Instead, use one of its children classes
 #. The ``TextMobject`` and ``TexMobject`` objects have been deprecated, due to their confusing names, in favour of ``Tex`` and ``MathTex``. You can still, however, continue to use ``TextMobject`` and ``TexMobject``, albeit with Deprecation Warnings constantly reminding you to switch.
 #. Add a :code:`Variable` class for displaying text that continuously updates to reflect the value of a python variable.
-#. :code:`VGroup` and :code:`VDict` now support printing the contained mobjects.
+#. :code:`VGroup` now supports printing the class names of contained mobjects and :code:`VDict` supports printing the internal dict of mobjects
 
 
 Documentation

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -62,9 +62,6 @@ class Mobject(Container):
         self.generate_points()
         self.init_colors()
 
-    def __str__(self):
-        return str(self.name)
-
     def reset_points(self):
         self.points = np.zeros((0, self.dim))
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -62,6 +62,9 @@ class Mobject(Container):
         self.generate_points()
         self.init_colors()
 
+    def __repr__(self):
+        return str(self.name)
+
     def reset_points(self):
         self.points = np.zeros((0, self.dim))
 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -878,7 +878,7 @@ class VGroup(VMobject):
 
     def __repr__(self):
         return (
-            __class__.__name__
+            self.__class__.__name__
             + "("
             + ", ".join(str(mob) for mob in self.submobjects)
             + ")"

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -876,6 +876,14 @@ class VGroup(VMobject):
         VMobject.__init__(self, **kwargs)
         self.add(*vmobjects)
 
+    def __repr__(self):
+        return (
+            __class__.__name__
+            + "("
+            + ", ".join(str(mob) for mob in self.submobjects)
+            + ")"
+        )
+
     def add(self, *vmobjects):
         """Checks if all passed elements are an instance of VMobject and then add them to submobjects
 
@@ -933,6 +941,9 @@ class VDict(VMobject):
         self.show_keys = show_keys
         self.submob_dict = {}
         self.add(mapping_or_iterable)
+
+    def __repr__(self):
+        return __class__.__name__ + "(" + repr(self.submob_dict) + ")"
 
     def add(self, mapping_or_iterable):
         """Adds the key-value pairs to the :class:`VDict` object.


### PR DESCRIPTION
Closes #497 
## List of Changes
- Added a `__repr__` method to `VGroup` and `VDict`
- Removed the `__str__` method from `Mobject` (reason explained below)

## Motivation
Just printing a VGroup or a VDict object used to print the class name only. While debugging, it is useful to know the mobjects contained. With this change, something like this is printed:
```text
VGroup(<manim.mobject.geometry.Square object at 0x00000265DAC2B610>, <manim.mobject.geometry.Circle object at 0x00000265EA936850>)
VDict({'s': <manim.mobject.geometry.Square object at 0x00000265DAC2B610>, 'c': <manim.mobject.geometry.Circle object at 0x00000265EA936850>})
```
which, I believe is more useful

## Explanation for Changes
I know the long output looks a bit ugly, but hopefully, in a separate PR, we would love to implement `__repr__` for mobjects as [suggested](https://github.com/ManimCommunity/manim/issues/497#issuecomment-702016103) by @behackl.
I had to remove the `__str__` for `Mobject` because for it `__repr__` isn't defined yet. So all the inheriting classes are using `__str__` which is what we don't want.
## Acknowledgement
- [ ] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))


