### PR TITLE
ci: fix publishing to pip

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,7 +2,7 @@ name: Publish Release
 
 on:
   release:
-    types: [created]
+    types: [released]
 
 jobs:
   release:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,4 +1,3 @@
-  
 name: Publish Release
 
 on:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,16 +1,29 @@
-name: Upload Python Package
+  
+name: Publish Release
 
 on:
   release:
-    types:
-      - created
+    types: [created]
+
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    #TODO: Set an API key from PyPI `PYPI_API_KEY` in secrets tab.
-    - name: Build and publish to pypi
-      uses: JRubics/poetry-publish@v1
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
       with:
-        pypi_token:  ${{ secrets.PYPI_API_KEY }}
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: python -m pip install --upgrade poetry
+
+    # TODO: Set PYPI_API_TOKEN to api token from pip in secrets
+    - name: Configure pypi credentials
+      env:
+        PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      run: poetry config http-basic.pypi __token__ "$PYPI_API_TOKEN"
+
+    - name: Publish release to pypi
+      run: poetry publish --build


### PR DESCRIPTION
## List of Changes
- The publishing to pip CI I previously did in #165 seems broken
- Fixed a publishing CI which automatically push to pip when we do a new Release.

## Note
@leotrs or @eulertour You should set the API token of the PyPi repo in secret's tab as `PYPI_API_TOKEN`.

## Motivation
For the release

## Testing Status
I had tried it in one of my projects.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

