### PR TITLE
Fix #484 : Make -fp both open file folder and preview

### DIFF
--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -40,7 +40,10 @@ def open_file_if_needed(file_writer):
             file_paths.append(file_writer.gif_file_path)
 
         for file_path in file_paths:
-            open_media_file(file_path, file_writer_config["show_in_file_browser"])
+            if file_writer_config["show_in_file_browser"]:
+                open_media_file(file_path, True)
+            if file_writer_config["preview"]:
+                open_media_file(file_path, False)
 
     if file_writer_config["verbosity"] != "DEBUG":
         sys.stdout.close()


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
<!-- List out your changes one by one like this:
- Change 1
- Change 2
- and so on..

Be sure to note your changes in the [changelog](docs/source/changelog.rst) if your
changes warrant it!
-->

I changed open_file_if_needed function in manim/__main__.py to fix #484 

## Motivation
<!-- Why you feel your changes are required. -->
There is a bug to be fixed.

## Explanation for Changes
<!-- How do your changes solve aforementioned problems? -->

https://github.com/ManimCommunity/manim/issues/484#issuecomment-702411587

I changed the code so open_media_file runs twice if both -f and -p is given.

## Testing Status
<!-- Optional, but recommended, your computer specs and what tests you ran with their results, if any -->
Tested on Windows, but future testing is highly recommended.
## Further Comments
<!-- Optional, any edits/updates should preferably be written here. -->
I'm open to other suggestions on how to fix this problem in other ways, but I hope I explained the core reason why this bug exists.
## Acknowledgement
- [ ] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
