### PR TITLE
FEAT : Add increment using += support for ValueTracker

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -62,6 +62,7 @@ Mobjects, Scenes, and Animations
 #. Add a :code:`Variable` class for displaying text that continuously updates to reflect the value of a python variable.
 #. The ``Tex`` and ``MathTex`` objects allow you to specify a custom TexTemplate using the ``template`` keyword argument.
 #. :code:`VGroup` now supports printing the class names of contained mobjects and :code:`VDict` supports printing the internal dict of mobjects
+#. :code:`ValueTracker` now supports increment using the `+=` operator (in addition to the already existing `increment_value` method)
 
 
 Documentation

--- a/manim/mobject/value_tracker.py
+++ b/manim/mobject/value_tracker.py
@@ -57,6 +57,9 @@ class ValueTracker(Mobject):
     def increment_value(self, d_value):
         self.set_value(self.get_value() + d_value)
 
+    def __iadd__(self, d_value):
+        return ValueTracker(self.get_value() + d_value)
+
     def interpolate(self, mobject1, mobject2, alpha, path_func=straight_path):
         """
         Turns self into an interpolation between mobject1

--- a/manim/mobject/value_tracker.py
+++ b/manim/mobject/value_tracker.py
@@ -58,7 +58,8 @@ class ValueTracker(Mobject):
         self.set_value(self.get_value() + d_value)
 
     def __iadd__(self, d_value):
-        return ValueTracker(self.get_value() + d_value)
+        self.increment_value(d_value)
+        return self
 
     def interpolate(self, mobject1, mobject2, alpha, path_func=straight_path):
         """

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,3 +1,4 @@
+from manim.mobject.value_tracker import ValueTracker
 import pytest
 from manim import Container, Mobject, Scene
 
@@ -73,3 +74,15 @@ def test_scene_remove():
     """Test Scene.remove()."""
     scene = Scene()
     container_remove(scene, lambda: scene.mobjects)
+
+def test_value_tracker_increment_value():
+    """Test ValueTracker.increment_value()"""
+    tracker = ValueTracker(0.0)
+    tracker.increment_value(10.0)
+    assert(tracker.get_value() == 10.0)
+
+def test_value_tracker_iadd():
+    """Test ValueTracker.__iadd__()"""
+    tracker = ValueTracker(0.0)
+    tracker += 10.0
+    assert(tracker.get_value() == 10.0)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -73,5 +73,3 @@ def test_scene_remove():
     """Test Scene.remove()."""
     scene = Scene()
     container_remove(scene, lambda: scene.mobjects)
-
-

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -75,14 +75,16 @@ def test_scene_remove():
     scene = Scene()
     container_remove(scene, lambda: scene.mobjects)
 
+
 def test_value_tracker_increment_value():
     """Test ValueTracker.increment_value()"""
     tracker = ValueTracker(0.0)
     tracker.increment_value(10.0)
-    assert(tracker.get_value() == 10.0)
+    assert tracker.get_value() == 10.0
+
 
 def test_value_tracker_iadd():
     """Test ValueTracker.__iadd__()"""
     tracker = ValueTracker(0.0)
     tracker += 10.0
-    assert(tracker.get_value() == 10.0)
+    assert tracker.get_value() == 10.0

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,4 +1,3 @@
-from manim.mobject.value_tracker import ValueTracker
 import pytest
 from manim import Container, Mobject, Scene
 
@@ -76,15 +75,3 @@ def test_scene_remove():
     container_remove(scene, lambda: scene.mobjects)
 
 
-def test_value_tracker_increment_value():
-    """Test ValueTracker.increment_value()"""
-    tracker = ValueTracker(0.0)
-    tracker.increment_value(10.0)
-    assert tracker.get_value() == 10.0
-
-
-def test_value_tracker_iadd():
-    """Test ValueTracker.__iadd__()"""
-    tracker = ValueTracker(0.0)
-    tracker += 10.0
-    assert tracker.get_value() == 10.0

--- a/tests/test_value_tracker.py
+++ b/tests/test_value_tracker.py
@@ -1,15 +1,18 @@
 from manim.mobject.value_tracker import ValueTracker
 
+
 def test_value_tracker_set_value():
     """Test ValueTracker.set_value()"""
     tracker = ValueTracker()
     tracker.set_value(10.0)
     assert tracker.get_value() == 10.0
 
+
 def test_value_tracker_get_value():
     """Test ValueTracker.get_value()"""
     tracker = ValueTracker(10.0)
     assert tracker.get_value() == 10.0
+
 
 def test_value_tracker_increment_value():
     """Test ValueTracker.increment_value()"""

--- a/tests/test_value_tracker.py
+++ b/tests/test_value_tracker.py
@@ -1,0 +1,25 @@
+from manim.mobject.value_tracker import ValueTracker
+
+def test_value_tracker_set_value():
+    """Test ValueTracker.set_value"""
+    tracker = ValueTracker()
+    tracker.set_value(10.0)
+    assert tracker.get_value() == 10.0
+
+def test_value_tracker_get_value():
+    """Test ValueTracker.get_value"""
+    tracker = ValueTracker(10.0)
+    assert tracker.get_value() == 10.0
+
+def test_value_tracker_increment_value():
+    """Test ValueTracker.increment_value()"""
+    tracker = ValueTracker(0.0)
+    tracker.increment_value(10.0)
+    assert tracker.get_value() == 10.0
+
+
+def test_value_tracker_iadd():
+    """Test ValueTracker.__iadd__()"""
+    tracker = ValueTracker(0.0)
+    tracker += 10.0
+    assert tracker.get_value() == 10.0

--- a/tests/test_value_tracker.py
+++ b/tests/test_value_tracker.py
@@ -1,13 +1,13 @@
 from manim.mobject.value_tracker import ValueTracker
 
 def test_value_tracker_set_value():
-    """Test ValueTracker.set_value"""
+    """Test ValueTracker.set_value()"""
     tracker = ValueTracker()
     tracker.set_value(10.0)
     assert tracker.get_value() == 10.0
 
 def test_value_tracker_get_value():
-    """Test ValueTracker.get_value"""
+    """Test ValueTracker.get_value()"""
     tracker = ValueTracker(10.0)
     assert tracker.get_value() == 10.0
 


### PR DESCRIPTION
Closes #507 

## List of Changes
- Add the `__iadd__` method for `ValueTracker`

## Motivation
Ease of use like `tracker += 3.0`

## Explanation for Changes
The `__iadd__` method in Python is used for overloading the operator `+=`

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
