### PR TITLE
 Fix #453: log files when scene is not specified

### DIFF
--- a/manim/config/config.py
+++ b/manim/config/config.py
@@ -157,9 +157,18 @@ camera_config = config
 set_rich_logger(config_parser["logger"], file_writer_config["verbosity"])
 if file_writer_config["log_to_file"]:
     # IMPORTANT note about file name : The log file name will be the scene_name get from the args (contained in file_writer_config). So it can differ from the real name of the scene.
+    scene_name_suffix = "".join(file_writer_config["scene_names"])
+    scene_file_name = os.path.basename(args.file).split(".")[
+        0
+    ]  # takes filename and removes extension
+    log_file_name = (
+        f"{scene_file_name}_{scene_name_suffix}.log"
+        if scene_name_suffix
+        else f"{scene_file_name}.log"
+    )
     log_file_path = os.path.join(
         file_writer_config["log_dir"],
-        "".join(file_writer_config["scene_names"]) + ".log",
+        log_file_name,
     )
     set_file_logger(log_file_path)
-    logger.info("Log file wil be saved in %(logpath)s", {"logpath": log_file_path})
+    logger.info("Log file will be saved in %(logpath)s", {"logpath": log_file_path})

--- a/manim/config/config.py
+++ b/manim/config/config.py
@@ -156,11 +156,11 @@ camera_config = config
 # Set the different loggers
 set_rich_logger(config_parser["logger"], file_writer_config["verbosity"])
 if file_writer_config["log_to_file"]:
-    # IMPORTANT note about file name : The log file name will be the scene_name get from the args (contained in file_writer_config). So it can differ from the real name of the scene.
+    # Note about log_file_name : The log file name will be the <name_of_animation_file>_<name_of_scene>.log
+    # get from the args (contained in file_writer_config). So it can differ from the real name of the scene.
+    # <name_of_scene> would only appear if scene name was provided on manim call
     scene_name_suffix = "".join(file_writer_config["scene_names"])
-    scene_file_name = os.path.basename(args.file).split(".")[
-        0
-    ]  # takes filename and removes extension
+    scene_file_name = os.path.basename(args.file).split(".")[0]
     log_file_name = (
         f"{scene_file_name}_{scene_name_suffix}.log"
         if scene_name_suffix

--- a/tests/control_data/logs_data/BasicSceneLoggingTest.txt
+++ b/tests/control_data/logs_data/BasicSceneLoggingTest.txt
@@ -1,4 +1,4 @@
-{"levelname": "INFO", "module": "config", "message": "Log file wil be saved in <>"}
+{"levelname": "INFO", "module": "config", "message": "Log file will be saved in <>"}
 {"levelname": "DEBUG", "module": "hashing", "message": "Hashing ..."}
 {"levelname": "DEBUG", "module": "hashing", "message": "Hashing done in <> s."}
 {"levelname": "INFO", "module": "scene_file_writer", "message": "Animation 0 : Partial movie file written in <>"}

--- a/tests/test_logging/basic_scenes_square_to_circle.py
+++ b/tests/test_logging/basic_scenes_square_to_circle.py
@@ -1,0 +1,8 @@
+from manim import *
+
+# This module is used in the CLI tests in tests_CLi.py.
+
+
+class SquareToCircle(Scene):
+    def construct(self):
+        self.play(Transform(Square(), Circle()))

--- a/tests/test_logging/basic_scenes_wirte_stuff.py
+++ b/tests/test_logging/basic_scenes_wirte_stuff.py
@@ -3,11 +3,6 @@ from manim import *
 # This module is used in the CLI tests in tests_CLi.py.
 
 
-class SquareToCircle(Scene):
-    def construct(self):
-        self.play(Transform(Square(), Circle()))
-
-
 class WriteStuff(Scene):
     def construct(self):
         example_text = Tex("This is a some text", tex_to_color_map={"text": YELLOW})

--- a/tests/test_logging/test_logging.py
+++ b/tests/test_logging/test_logging.py
@@ -9,16 +9,43 @@ from ..utils.logging_tester import *
 
 
 @logs_comparison(
-    "BasicSceneLoggingTest.txt", os.path.join("logs", "SquareToCircle.log")
+    "BasicSceneLoggingTest.txt",
+    os.path.join("logs", "basic_scenes_square_to_circle_SquareToCircle.log"),
 )
 def test_logging_to_file(tmp_path, python_version):
-    path_basic_scene = os.path.join("tests", "test_logging", "basic_scenes.py")
+    path_basic_scene = os.path.join(
+        "tests", "test_logging", "basic_scenes_square_to_circle.py"
+    )
     command = [
         python_version,
         "-m",
         "manim",
         path_basic_scene,
         "SquareToCircle",
+        "-l",
+        "--log_to_file",
+        "-v",
+        "DEBUG",
+        "--media_dir",
+        str(tmp_path),
+    ]
+    _, err, exitcode = capture(command)
+    assert exitcode == 0, err
+
+
+@logs_comparison(
+    "BasicSceneLoggingTest.txt",
+    os.path.join("logs", "basic_scenes_square_to_circle.log"),
+)
+def test_logging_when_scene_is_not_specified(tmp_path, python_version):
+    path_basic_scene = os.path.join(
+        "tests", "test_logging", "basic_scenes_square_to_circle.py"
+    )
+    command = [
+        python_version,
+        "-m",
+        "manim",
+        path_basic_scene,
         "-l",
         "--log_to_file",
         "-v",


### PR DESCRIPTION
## List of Changes
- triggering `manim` without scene name fixed
- `tests/test_logging/basic_scenes.py` split into two files, to enable triggering of `SquareToCircle` without scene name in `manim` command
- test case for  triggering `manim` without scene name added

I guess as `--log_to_file` does not exist in original library and was not released yet, fix related to it should not be reflected in  `docs/source/changelog.rst` 

## Motivation
It is aimed to fix issue #453

## Explanation for Changes
Now log file name would consist of two parts <name_of_animation_file>_<name_of_scene>.log
<name_of_scene> - would be optional, only if scene name was provided on `manim` call

## Testing Status
all tests passed, Ubuntu 18.04

## Further Comments
seems like `WriteStuff`scene from `tests/test_logging/basic_scenes_wirte_stuff.py` was never triggered, nevertheless I did not remove it

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

