### PR TITLE
add missing import

### DIFF
--- a/manim/utils/module_ops.py
+++ b/manim/utils/module_ops.py
@@ -6,6 +6,7 @@ import inspect
 import os
 import sys
 import types
+import re
 
 
 def get_module(file_name):

--- a/manim/utils/module_ops.py
+++ b/manim/utils/module_ops.py
@@ -4,9 +4,9 @@ from ..config.logger import logger, console
 import importlib.util
 import inspect
 import os
+import re
 import sys
 import types
-import re
 
 
 def get_module(file_name):


### PR DESCRIPTION
## List of Changes

- add missing `import re` to `utils/module_ops.py`

## Motivation
Selecting from multiple scene classes in a single file fails when providing a comma-separated list due to missing `re` import

```sh
❯ manim project/scene.py -pl
[10/07/20 15:46:14] WARNING  Option -l is deprecated please use the --quality/-q flag.
config_utils.py:660
1: SquareToCircle
2: SquareToCircle2
3: SquareToCircle3

Choose number corresponding to desired scene/arguments.
(Use comma separated list for multiple entries)
Choice(s):  1,2
Traceback (most recent call last):
  File "~/miniconda3/envs/manim/bin/manim", line 5, in <module>
    main()
  File "manim/manim/__main__.py", line 74, in main
    scene_classes_to_render = get_scenes_to_render(all_scene_classes)
  File "manim/manim/utils/module_ops.py", line 82, in get_scenes_to_render
    else prompt_user_for_choice(scene_classes)
  File "manim/manim/utils/module_ops.py", line 99, in prompt_user_for_choice
    for num_str in re.split(r"\s*,\s*", user_input.strip())
NameError: name 're' is not defined
```

## Explanation for Changes
imports the missing library


## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
