### PR TITLE
Implements the unit class.

### DIFF
--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -241,20 +241,16 @@ class VariableExample(Scene):
 
 class UnitDot(Scene):
     def construct(self):
-        path = VMobject()
-        dot = Dot()
-        path.set_points_as_corners([dot.get_center(), dot.get_center()])
+        dot1 = Dot(radius=0.2, color=RED).to_edge(DOWN)
+        dot2 = Dot(radius=0.2, color=BLUE).to_edge(DOWN).shift(RIGHT)
+        dot3 = Dot(radius=0.2, color=GREEN).to_edge(DOWN).shift(2 * RIGHT)
+        dot4 = Dot(radius=0.2, color=YELLOW)
 
-        def update_path(path):
-            previus_path = path.copy()
-            previus_path.add_points_as_corners([dot.get_center()])
-            path.become(previus_path)
+        self.add(dot1, dot2, dot3, dot4)
 
-        path.add_updater(update_path)
-        self.add(path, dot)
-        self.play(Rotating(dot, radians=PI, about_point=RIGHT, run_time=2))
-        self.wait()
+        self.play(dot1.shift, PercentUnit(80 * UP))
+        self.play(dot2.shift, PercentUnit(50 * UP))
+        self.play(dot3.shift, PixelUnit(400 * UP))
+        self.play(dot3.shift, PixelUnit(100 * RIGHT))
 
-        self.play(dot.shift, PercentUnit(25 * UP))
-        self.play(dot.shift, PixelUnit(100 * LEFT))
         self.wait()

--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -13,6 +13,7 @@ from manim import *
 # Use -n <number> to skip ahead to the n'th animation of a scene.
 # Use -r <number> to specify a resolution (for example, -r 1080
 # for a 1920x1080 video)
+from manim.utils.units import PercentUnit, PixelUnit
 
 
 class OpeningManimExample(Scene):
@@ -235,4 +236,25 @@ class VariableExample(Scene):
             on_screen_int_var, DOWN
         )
         self.play(Write(on_screen_subscript_var))
+        self.wait()
+
+
+class UnitDot(Scene):
+    def construct(self):
+        path = VMobject()
+        dot = Dot()
+        path.set_points_as_corners([dot.get_center(), dot.get_center()])
+
+        def update_path(path):
+            previus_path = path.copy()
+            previus_path.add_points_as_corners([dot.get_center()])
+            path.become(previus_path)
+
+        path.add_updater(update_path)
+        self.add(path, dot)
+        self.play(Rotating(dot, radians=PI, about_point=RIGHT, run_time=2))
+        self.wait()
+
+        self.play(dot.shift, PercentUnit(25 * UP))
+        self.play(dot.shift, PixelUnit(100 * LEFT))
         self.wait()

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -30,6 +30,7 @@ from ..utils.space_ops import rotation_matrix
 
 
 # TODO: Explain array_attrs
+from ..utils.units import accepts_unit
 
 
 class Mobject(Container):
@@ -292,6 +293,7 @@ class Mobject(Container):
         for mob in self.family_members_with_points():
             func(mob)
 
+    @accepts_unit
     def shift(self, *vectors):
         total_vector = reduce(op.add, vectors)
         for mob in self.family_members_with_points():

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -30,7 +30,7 @@ from ..utils.space_ops import rotation_matrix
 
 
 # TODO: Explain array_attrs
-from ..utils.units import accepts_unit
+from ..utils.units import handle_units
 
 
 class Mobject(Container):
@@ -293,7 +293,7 @@ class Mobject(Container):
         for mob in self.family_members_with_points():
             func(mob)
 
-    @accepts_unit
+    @handle_units
     def shift(self, *vectors):
         total_vector = reduce(op.add, vectors)
         for mob in self.family_members_with_points():

--- a/manim/utils/units.py
+++ b/manim/utils/units.py
@@ -1,0 +1,19 @@
+from functools import wraps
+
+
+class Unit():
+    def __init__(self, value, unit):
+        self._value = value
+        self._unit = unit
+
+    @property
+    def value(self):
+        return self._value
+
+
+def accepts_unit(f):
+    @wraps(f)
+    def wrapper(*args):
+        return f(*[a.value if isinstance(a, Unit) else a for a in args])
+
+    return wrapper

--- a/manim/utils/units.py
+++ b/manim/utils/units.py
@@ -28,7 +28,7 @@ class Unit():
         elif self._unit == PIXELS:
             return self._value / _size_from_dimension(dim, True) * _size_from_dimension(dim)
         elif self._unit == PERCENT:
-            return self._value * _size_from_dimension(dim)
+            return self._value / 100 * _size_from_dimension(dim)
         else:
             raise ValueError("Unsupported unit.")
 

--- a/manim/utils/units.py
+++ b/manim/utils/units.py
@@ -1,4 +1,5 @@
 import copy
+import operator
 from functools import wraps
 
 import numpy as np
@@ -48,6 +49,47 @@ class Unit:
             return return_value
         else:
             raise ValueError("Unable to determine dimension.")
+
+    def apply_operator(self, other, op):
+        if issubclass(type(other), Unit):
+            if isinstance(other, type(self)):
+                # Create and return a new instance
+                return type(self)(op(self.value, other.value))
+            else:
+                # For now lets not bother with operators on different units
+                raise NotImplementedError
+        # Create and return a new instance
+        return type(self)(op(self.value, other))
+
+    def __add__(self, other):
+        return self.apply_operator(other, operator.add)
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    def __floordiv__(self, other):
+        return self.apply_operator(other, operator.floordiv)
+
+    def __rfloordiv__(self, other):
+        return self.__floordiv__(other)
+
+    def __mul__(self, other):
+        return self.apply_operator(other, operator.mul)
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
+    def __sub__(self, other):
+        return self.apply_operator(other, operator.sub)
+
+    def __rsub__(self, other):
+        return self.__sub__(other)
+
+    def __truediv__(self, other):
+        return self.apply_operator(other, operator.truediv)
+
+    def __rtruediv__(self, other):
+        return self.__truediv__(other)
 
 
 class MUnit(Unit):

--- a/manim/utils/units.py
+++ b/manim/utils/units.py
@@ -71,7 +71,7 @@ class PercentUnit(Unit):
         self._converter = lambda val, dim: val / 100 * _size_from_dimension(dim)
 
 
-def accepts_unit(f, dim=None):
+def handle_units(f, dim=None):
     @wraps(f)
     def wrapper(*args, **kwargs):
         # TODO figure what to do when dim=None, preferable determine the dim.
@@ -80,7 +80,7 @@ def accepts_unit(f, dim=None):
             **{
                 k: v.convert(dim) if isinstance(v, Unit) else v
                 for k, v in kwargs.items()
-            }
+            },
         )
 
     return wrapper

--- a/manim/utils/units.py
+++ b/manim/utils/units.py
@@ -20,9 +20,13 @@ def _is_dimensional(value):
 
 
 class Unit:
-    def __init__(self, value, converter):
+    def __init__(self, value):
         self._value = value
-        self._converter = converter
+        self._converter = lambda val, dim: val
+
+    @property
+    def value(self):
+        return self._value
 
     def convert(self, dim=None):
         if dim:

--- a/manim/utils/units.py
+++ b/manim/utils/units.py
@@ -1,14 +1,36 @@
 from functools import wraps
 
+from ..config import config
+
+PERCENT = "%"
+PIXELS = "px"
+MUNIT = "m"
+
+
+def _size_from_dimension(dim=0, pixels=False):
+    if dim == 0:
+        return config["frame_width"] if not pixels else config["pixel_width"]
+    elif dim == 1:
+        return config["frame_height"] if not pixels else config["pixel_height"]
+    else:
+        # TODO: determine size in z-direction
+        raise ValueError("Dimension not supported.")
+
 
 class Unit():
-    def __init__(self, value, unit):
+    def __init__(self, value, unit=None):
         self._value = value
         self._unit = unit
 
-    @property
-    def value(self):
-        return self._value
+    def value(self, dim=0):
+        if not self._unit or self._unit == MUNIT:
+            return self._value
+        elif self._unit == PIXELS:
+            return self._value / _size_from_dimension(dim, True) * _size_from_dimension(dim)
+        elif self._unit == PERCENT:
+            return self._value * _size_from_dimension(dim)
+        else:
+            raise ValueError("Unsupported unit.")
 
 
 def accepts_unit(f):

--- a/manim/utils/units.py
+++ b/manim/utils/units.py
@@ -7,6 +7,18 @@ import numpy as np
 from ..config import config as global_config
 
 
+def percent_to_munit(val, dim, config):
+    return val / 100 * _size_from_dimension(dim, config=config)
+
+
+def pixels_to_munit(val, dim, config):
+    return (
+        val
+        / _size_from_dimension(dim, True, config=config)
+        * _size_from_dimension(dim, config=config)
+    )
+
+
 def _size_from_dimension(
     dim=0, pixels=False, config=global_config, treat_dim2_as_dim0=True
 ):
@@ -100,19 +112,13 @@ class MUnit(Unit):
 class PixelUnit(Unit):
     def __init__(self, value):
         super(PixelUnit, self).__init__(value)
-        self._converter = (
-            lambda val, dim, config: val
-            / _size_from_dimension(dim, True, config)
-            * _size_from_dimension(dim, config=config)
-        )
+        self._converter = pixels_to_munit
 
 
 class PercentUnit(Unit):
     def __init__(self, value):
         super(PercentUnit, self).__init__(value)
-        self._converter = (
-            lambda val, dim, config: val / 100 * _size_from_dimension(dim, config)
-        )
+        self._converter = percent_to_munit
 
 
 def handle_units(f, dim=None, config=global_config):

--- a/manim/utils/units.py
+++ b/manim/utils/units.py
@@ -62,9 +62,15 @@ class PercentUnit(Unit):
         self._converter = lambda val, dim: val / 100 * _size_from_dimension(dim)
 
 
-def accepts_unit(f):
+def accepts_unit(f, dim=None):
     @wraps(f)
-    def wrapper(*args):
-        return f(*[a.value if isinstance(a, Unit) else a for a in args])
+    def wrapper(*args, **kwargs):
+        # TODO figure what to do when dim=None, preferable determine the dim.
+        nargs = [a.convert(dim) if isinstance(a, Unit) else a for a in args]
+        nkwargs = {
+            k: v.convert(dim) if isinstance(v, Unit) else v for k, v in kwargs.items()
+        }
+
+        return f(*nargs, **nkwargs)
 
     return wrapper


### PR DESCRIPTION
## List of Changes
- Implements a unit class
- Automatic conversion for annotated functions

## Motivation
This PR aims to implement the unit class as described in #275.

## Explanation
The idea of this PR is to create a `Unit` class. When accessing the value stored in a `Unit` instance it should return a scaled value the `MUnit` unit. This is the unit internally used my `manim`. Properly annotated functions that receive a `Unit` object as argument must receive the value (thus a value in `MUnits`) instead of the `Unit` object. This is what the `accepts_unit` annotation should achieve.

The biggest challenge currently is determining in which dimension the unit is and how to determine that from the function arguments. Ideas for this are very much welcome!

Another issues is how to determine how to scale the value when the dimension is the z-direction (`dim=2`). If based on the implementations for the x-direction and y-direction you have an idea of how we could achieve something analogous for the `-direction. Please let me know.

## Further Comments
This PR is still a WIP (draft), input is greatly appreciated. 

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
