### PR TITLE
Fix docs for VDict

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -973,6 +973,7 @@ class VDict(VMobject):
         Examples
         --------
         Normal usage::
+
             square_obj = Square()
             my_dict.add([('s', square_obj)])
         """
@@ -1000,6 +1001,7 @@ class VDict(VMobject):
         Examples
         --------
         Normal usage::
+
             my_dict.remove('square')
         """
         if key not in self.submob_dict:
@@ -1024,6 +1026,7 @@ class VDict(VMobject):
         Examples
         --------
         Normal usage::
+
            self.play(ShowCreation(my_dict['s']))
         """
         submob = self.submob_dict[key]
@@ -1046,6 +1049,7 @@ class VDict(VMobject):
         Examples
         --------
         Normal usage::
+
             square_obj = Square()
             my_dict['sq'] = square_obj
         """
@@ -1064,6 +1068,7 @@ class VDict(VMobject):
         Examples
         --------
         Normal usage::
+
             for submob in my_dict.get_all_submobjects():
                 self.play(ShowCreation(submob))
         """
@@ -1093,6 +1098,7 @@ class VDict(VMobject):
         Examples
         --------
         Normal usage::
+        
             square_obj = Square()
             self.add_key_value_pair('s', square_obj)
 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1098,7 +1098,7 @@ class VDict(VMobject):
         Examples
         --------
         Normal usage::
-        
+
             square_obj = Square()
             self.add_key_value_pair('s', square_obj)
 


### PR DESCRIPTION
## List of Changes
- Add a new line after `Normal usage::` in order for the code in examples section to correctly render

## Motivation
Currently, the [doc for VDict](https://manimce.readthedocs.io/en/latest/reference/manim.mobject.types.vectorized_mobject.VDict.html#manim.mobject.types.vectorized_mobject.VDict) does not render the code in examples section correctly. Feel free to view the docs for the whole class and suggest other corrections as well.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

