### PR TITLE
Updated mobject.py, test_copy.py, and conftest.py, from os to pathlib Path

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -8,10 +8,10 @@ from functools import reduce
 import copy
 import itertools as it
 import operator as op
-import os
 import random
 import sys
 
+from pathlib import Path
 from colour import Color
 import numpy as np
 
@@ -199,7 +199,7 @@ class Mobject(Container):
 
     def save_image(self, name=None):
         self.get_image().save(
-            os.path.join(file_writer_config["video_dir"], (name or str(self)) + ".png")
+            Path(file_writer_config["video_dir"]).joinpath((name or str(self)) + ".png")
         )
 
     def copy(self):

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -20,7 +20,7 @@ def test_bracelabel_copy(tmp_path):
     # For this test to work, we need to tweak some folders temporarily
     original_text_dir = file_writer_config["text_dir"]
     original_tex_dir = file_writer_config["tex_dir"]
-    mediadir = Path(tmp_path).joinpath("deepcopy")
+    mediadir = Path(tmp_path) / "deepcopy"
     file_writer_config["text_dir"] = str(mediadir.joinpath("Text"))
     file_writer_config["tex_dir"] = str(mediadir.joinpath("Tex"))
     for el in ["text_dir", "tex_dir"]:

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -24,7 +24,7 @@ def test_bracelabel_copy(tmp_path):
     file_writer_config["text_dir"] = mediadir.joinpath("Text")
     file_writer_config["tex_dir"] = mediadir.joinpath("Tex")
     for el in ["text_dir", "tex_dir"]:
-        file_writer_config[el].mkdir()
+        file_writer_config[el].mkdir(parents=True)
 
     # Before the refactoring of Mobject.copy(), the class BraceLabel was the
     # only one to have a non-trivial definition of copy.  Here we test that it

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from manim import Mobject, BraceLabel, file_writer_config
 
 
@@ -20,11 +20,11 @@ def test_bracelabel_copy(tmp_path):
     # For this test to work, we need to tweak some folders temporarily
     original_text_dir = file_writer_config["text_dir"]
     original_tex_dir = file_writer_config["tex_dir"]
-    mediadir = os.path.join(tmp_path, "deepcopy")
-    file_writer_config["text_dir"] = os.path.join(mediadir, "Text")
-    file_writer_config["tex_dir"] = os.path.join(mediadir, "Tex")
+    mediadir = Path(tmp_path).joinpath("deepcopy")
+    file_writer_config["text_dir"] = mediadir.joinpath("Text")
+    file_writer_config["tex_dir"] = mediadir.joinpath("Tex")
     for el in ["text_dir", "tex_dir"]:
-        os.makedirs(file_writer_config[el])
+        file_writer_config[el].mkdir()
 
     # Before the refactoring of Mobject.copy(), the class BraceLabel was the
     # only one to have a non-trivial definition of copy.  Here we test that it

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -21,10 +21,10 @@ def test_bracelabel_copy(tmp_path):
     original_text_dir = file_writer_config["text_dir"]
     original_tex_dir = file_writer_config["tex_dir"]
     mediadir = Path(tmp_path).joinpath("deepcopy")
-    file_writer_config["text_dir"] = mediadir.joinpath("Text")
-    file_writer_config["tex_dir"] = mediadir.joinpath("Tex")
+    file_writer_config["text_dir"] = str(mediadir.joinpath("Text"))
+    file_writer_config["tex_dir"] = str(mediadir.joinpath("Tex"))
     for el in ["text_dir", "tex_dir"]:
-        file_writer_config[el].mkdir(parents=True)
+        Path(file_writer_config[el]).mkdir(parents=True)
 
     # Before the refactoring of Mobject.copy(), the class BraceLabel was the
     # only one to have a non-trivial definition of copy.  Here we test that it

--- a/tests/test_scene_rendering/conftest.py
+++ b/tests/test_scene_rendering/conftest.py
@@ -7,7 +7,7 @@ from manim import file_writer_config
 
 @pytest.fixture
 def manim_cfg_file():
-    return str(Path(__file__).parent.joinpath("manim.cfg"))
+    return str(Path(__file__).parent / "manim.cfg")
 
 
 @pytest.fixture

--- a/tests/test_scene_rendering/conftest.py
+++ b/tests/test_scene_rendering/conftest.py
@@ -1,15 +1,15 @@
 import pytest
-import os
 
+from pathlib import Path
 
 from manim import file_writer_config
 
 
 @pytest.fixture
 def manim_cfg_file():
-    return os.path.join(os.path.dirname(__file__), "manim.cfg")
+    return Path(__file__).parent.joinpath("manim.cfg")
 
 
 @pytest.fixture
 def simple_scenes_path():
-    return os.path.join(os.path.dirname(__file__), "simple_scenes.py")
+    return Path(__file__).parent.joinpath("simple_scenes.py")

--- a/tests/test_scene_rendering/conftest.py
+++ b/tests/test_scene_rendering/conftest.py
@@ -7,9 +7,9 @@ from manim import file_writer_config
 
 @pytest.fixture
 def manim_cfg_file():
-    return Path(__file__).parent.joinpath("manim.cfg")
+    return str(Path(__file__).parent.joinpath("manim.cfg"))
 
 
 @pytest.fixture
 def simple_scenes_path():
-    return Path(__file__).parent.joinpath("simple_scenes.py")
+    return str(Path(__file__).parent.joinpath("simple_scenes.py"))

--- a/tests/test_scene_rendering/conftest.py
+++ b/tests/test_scene_rendering/conftest.py
@@ -12,4 +12,4 @@ def manim_cfg_file():
 
 @pytest.fixture
 def simple_scenes_path():
-    return str(Path(__file__).parent.joinpath("simple_scenes.py"))
+    return str(Path(__file__).parent / "simple_scenes.py")


### PR DESCRIPTION
## List of Changes
test_copy - Replaced all instances of usage of os library, changing to the pathlib library. #485 
conftest - Replaced all instances of usage of os library, changing to the pathlib library issue #485

mobject - Updated from os to pathlib #485

## Motivation
I saw this issue and thought it would be a good first PR here :)

## Explanation for Changes
The problem statement was to move away from the os library, in favor of the pathlib library.  The changes accomplish that goal for the two files modified.

## Testing Status
Ran black to conform to code styling.  
Tested changes through assertions on my local version. (Paths generated from OS and Pathlib)

## Acknowledgement
- [X] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

Happy to contribute, I welcome feedback!  Thank you.