### PR TITLE
Changing Exception() uses to more specific subclasses

### DIFF
--- a/logo/logo.py
+++ b/logo/logo.py
@@ -98,9 +98,7 @@ class Thumbnail(GraphScene):
         graph_dot_p2.move_to(get_graph_point(input_tracker_p2))
 
         #
-        self.play(
-            ShowCreation(graph),
-        )
+        self.play(ShowCreation(graph))
         # Animacion del punto a
         self.add_foreground_mobject(graph_dot_p1)
         self.add_foreground_mobject(graph_dot_p2)

--- a/logo/logo.py
+++ b/logo/logo.py
@@ -98,7 +98,9 @@ class Thumbnail(GraphScene):
         graph_dot_p2.move_to(get_graph_point(input_tracker_p2))
 
         #
-        self.play(ShowCreation(graph),)
+        self.play(
+            ShowCreation(graph),
+        )
         # Animacion del punto a
         self.add_foreground_mobject(graph_dot_p1)
         self.add_foreground_mobject(graph_dot_p2)
@@ -150,7 +152,11 @@ class Thumbnail(GraphScene):
         )
 
         self.add(
-            input_triangle_p2, graph_dot_p2, v_line_p2, h_line_p2, output_triangle_p2,
+            input_triangle_p2,
+            graph_dot_p2,
+            v_line_p2,
+            h_line_p2,
+            output_triangle_p2,
         )
         self.play(FadeIn(grupo_secante))
 

--- a/manim/animation/creation.py
+++ b/manim/animation/creation.py
@@ -37,7 +37,7 @@ class ShowPartial(Animation):
         submob.pointwise_become_partial(start_submob, *self.get_bounds(alpha))
 
     def get_bounds(self, alpha):
-        raise Exception("Not Implemented")
+        raise NotImplementedError()
 
 
 class ShowCreation(ShowPartial):
@@ -69,7 +69,7 @@ class DrawBorderThenFill(Animation):
 
     def check_validity_of_input(self, vmobject):
         if not isinstance(vmobject, VMobject):
-            raise Exception("DrawBorderThenFill only works for VMobjects")
+            raise TypeError("DrawBorderThenFill only works for VMobjects")
 
     def begin(self):
         self.outline = self.get_outline()

--- a/manim/animation/numbers.py
+++ b/manim/animation/numbers.py
@@ -23,7 +23,7 @@ class ChangingDecimal(Animation):
 
     def check_validity_of_input(self, decimal_mob):
         if not isinstance(decimal_mob, DecimalNumber):
-            raise Exception("ChangingDecimal can only take " "in a DecimalNumber")
+            raise TypeError("ChangingDecimal can only take " "in a DecimalNumber")
 
     def yell_about_depricated_configuration(self, **kwargs):
         # Obviously this would optimally be removed at

--- a/manim/animation/numbers.py
+++ b/manim/animation/numbers.py
@@ -23,7 +23,7 @@ class ChangingDecimal(Animation):
 
     def check_validity_of_input(self, decimal_mob):
         if not isinstance(decimal_mob, DecimalNumber):
-            raise TypeError("ChangingDecimal can only take " "in a DecimalNumber")
+            raise TypeError("ChangingDecimal can only take in a DecimalNumber")
 
     def yell_about_depricated_configuration(self, **kwargs):
         # Obviously this would optimally be removed at

--- a/manim/animation/specialized.py
+++ b/manim/animation/specialized.py
@@ -29,7 +29,7 @@ class MoveCar(ApplyMethod):
 
     def check_if_input_is_car(self, car):
         if not isinstance(car, Car):
-            raise Exception("MoveCar must take in Car object")
+            raise TypeError("MoveCar must take in Car object")
 
     def begin(self):
         super().begin()

--- a/manim/animation/transform.py
+++ b/manim/animation/transform.py
@@ -84,7 +84,7 @@ class Transform(Animation):
     def check_target_mobject_validity(self):
         if self.target_mobject is None:
             message = "{}.create_target not properly implemented"
-            raise Exception(message.format(self.__class__.__name__))
+            raise NotImplementedError(message.format(self.__class__.__name__))
 
     def clean_up_from_scene(self, scene):
         super().clean_up_from_scene(scene)
@@ -157,7 +157,7 @@ class MoveToTarget(Transform):
 
     def check_validity_of_input(self, mobject):
         if not hasattr(mobject, "target"):
-            raise Exception(
+            raise ValueError(
                 "MoveToTarget called on mobject" "without attribute 'target'"
             )
 
@@ -179,7 +179,7 @@ class ApplyMethod(Transform):
 
     def check_validity_of_input(self, method):
         if not inspect.ismethod(method):
-            raise Exception(
+            raise ValueError(
                 "Whoops, looks like you accidentally invoked "
                 "the method you want to animate"
             )
@@ -244,7 +244,7 @@ class ApplyFunction(Transform):
     def create_target(self):
         target = self.function(self.mobject.copy())
         if not isinstance(target, Mobject):
-            raise Exception(
+            raise TypeError(
                 "Functions passed to ApplyFunction must return object of type Mobject"
             )
         return target
@@ -266,7 +266,7 @@ class ApplyMatrix(ApplyPointwiseFunction):
             new_matrix[:2, :2] = matrix
             matrix = new_matrix
         elif matrix.shape != (3, 3):
-            raise Exception("Matrix has bad dimensions")
+            raise ValueError("Matrix has bad dimensions")
         return matrix
 
 

--- a/manim/mobject/coordinate_systems.py
+++ b/manim/mobject/coordinate_systems.py
@@ -41,10 +41,10 @@ class CoordinateSystem:
             self.y_max = config["frame_y_radius"]
 
     def coords_to_point(self, *coords):
-        raise Exception("Not implemented")
+        raise NotImplementedError()
 
     def point_to_coords(self, point):
-        raise Exception("Not implemented")
+        raise NotImplementedError()
 
     def c2p(self, *coords):
         """Abbreviation for coords_to_point"""
@@ -55,7 +55,7 @@ class CoordinateSystem:
         return self.point_to_coords(point)
 
     def get_axes(self):
-        raise Exception("Not implemented")
+        raise NotImplementedError()
 
     def get_axis(self, index):
         return self.get_axes()[index]

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -670,7 +670,7 @@ class Mobject(Container):
 
     def set_submobject_colors_by_gradient(self, *colors):
         if len(colors) == 0:
-            raise Exception("Need at least one color")
+            raise ValueError("Need at least one color")
         elif len(colors) == 1:
             return self.set_color(*colors)
 
@@ -1182,6 +1182,6 @@ class Group(Mobject):
 
     def __init__(self, *mobjects, **kwargs):
         if not all([isinstance(m, Mobject) for m in mobjects]):
-            raise Exception("All submobjects must be of type Mobject")
+            raise TypeError("All submobjects must be of type Mobject")
         Mobject.__init__(self, **kwargs)
         self.add(*mobjects)

--- a/manim/mobject/svg/drawings.py
+++ b/manim/mobject/svg/drawings.py
@@ -1001,7 +1001,7 @@ class SuitSymbol(SVGMobject):
             "clubs": self.black,
         }
         if suit_name not in suits_to_colors:
-            raise Exception("Invalid suit name")
+            raise ValueError("Invalid suit name")
         SVGMobject.__init__(self, file_name=suit_name, **kwargs)
 
         color = suits_to_colors[suit_name]

--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -396,7 +396,7 @@ class VMobjectFromSVGPathstring(VMobject):
             # TODO, this is a suboptimal approximation
             new_points = np.append([new_points[0]], new_points, axis=0)
         elif command == "A":  # elliptical Arc
-            raise Exception("Not implemented")
+            raise NotImplementedError("Not yet implemented")
         elif command == "Z":  # closepath
             return
 

--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -396,7 +396,7 @@ class VMobjectFromSVGPathstring(VMobject):
             # TODO, this is a suboptimal approximation
             new_points = np.append([new_points[0]], new_points, axis=0)
         elif command == "A":  # elliptical Arc
-            raise NotImplementedError("Not yet implemented")
+            raise NotImplementedError()
         elif command == "Z":  # closepath
             return
 

--- a/manim/mobject/svg/tex_mobject.py
+++ b/manim/mobject/svg/tex_mobject.py
@@ -249,7 +249,7 @@ class MathTex(SingleStringMathTex):
     def index_of_part(self, part):
         split_self = self.split()
         if part not in split_self:
-            raise Exception("Trying to get index of part not in MathTex")
+            raise ValueError("Trying to get index of part not in MathTex")
         return split_self.index(part)
 
     def index_of_part_by_tex(self, tex, **kwargs):
@@ -292,7 +292,7 @@ class BulletedList(Tex):
         elif isinstance(arg, int):
             part = self.submobjects[arg]
         else:
-            raise Exception("Expected int or string, got {0}".format(arg))
+            raise TypeError("Expected int or string, got {0}".format(arg))
         for other_part in self.submobjects:
             if other_part is part:
                 other_part.set_fill(opacity=1)

--- a/manim/mobject/types/image_mobject.py
+++ b/manim/mobject/types/image_mobject.py
@@ -27,7 +27,7 @@ class AbstractImageMobject(Mobject):
     }
 
     def get_pixel_array(self):
-        raise Exception("Not implemented")
+        raise NotImplementedError()
 
     def set_color(self):
         # Likely to be implemented in subclasses, but no obgligation

--- a/manim/mobject/types/point_cloud_mobject.py
+++ b/manim/mobject/types/point_cloud_mobject.py
@@ -39,7 +39,7 @@ class PMobject(Mobject):
             color = Color(color) if color else self.color
             rgbas = np.repeat([color_to_rgba(color, alpha)], num_new_points, axis=0)
         elif len(rgbas) != len(points):
-            raise Exception("points and rgbas must have same shape")
+            raise ValueError("points and rgbas must have same shape")
         self.rgbas = np.append(self.rgbas, rgbas, axis=0)
         return self
 
@@ -214,7 +214,7 @@ class Mobject2D(PMobject):
 class PGroup(PMobject):
     def __init__(self, *pmobs, **kwargs):
         if not all([isinstance(m, PMobject) for m in pmobs]):
-            raise Exception("All submobjects must be of type PMobject")
+            raise ValueError("All submobjects must be of type PMobject")
         super().__init__(**kwargs)
         self.add(*pmobs)
 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -471,7 +471,7 @@ class VMobject(Mobject):
             handle2, new_anchor = points
         else:
             name = sys._getframe(0).f_code.co_name
-            raise Exception("Only call {} with 1 or 2 points".format(name))
+            raise ValueError("Only call {} with 1 or 2 points".format(name))
 
         if self.has_new_path_started():
             self.add_line_to(new_anchor)

--- a/manim/scene/graph_scene.py
+++ b/manim/scene/graph_scene.py
@@ -520,7 +520,7 @@ class GraphScene(Scene):
             elif input_sample_type == "center":
                 sample_input = x + 0.5 * dx
             else:
-                raise Exception("Invalid input sample type")
+                raise ValueError("Invalid input sample type")
             graph_point = self.input_to_graph_point(sample_input, graph)
             if bounded_graph == None:
                 y_point = 0
@@ -1027,7 +1027,7 @@ class GraphScene(Scene):
         NOTE: At least one of target_dx and target_x should be not None.
         """
         if target_dx is None and target_x is None:
-            raise Exception("At least one of target_x and target_dx must not be None")
+            raise ValueError("At least one of target_x and target_dx must not be None")
         if added_anims is None:
             added_anims = []
 

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -799,14 +799,14 @@ class Scene(Container):
             elif state["curr_method"] is not None:
                 state["method_args"].append(arg)
             elif isinstance(arg, Mobject):
-                raise Exception(
+                raise ValueError(
                     """
                     I think you may have invoked a method
                     you meant to pass in as a Scene.play argument
-                """
-                )
+                    """
+                    )
             else:
-                raise Exception("Invalid play arguments")
+                raise ValueError("Invalid play arguments")
         compile_method(state)
 
         for animation in animations:

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -804,7 +804,7 @@ class Scene(Container):
                     I think you may have invoked a method
                     you meant to pass in as a Scene.play argument
                     """
-                    )
+                )
             else:
                 raise ValueError("Invalid play arguments")
         compile_method(state)

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -261,7 +261,7 @@ class SceneFileWriter(object):
         if time is None:
             time = curr_end
         if time < 0:
-            raise Exception("Adding sound at timestamp < 0")
+            raise ValueError("Adding sound at timestamp < 0")
 
         new_end = time + new_segment.duration_seconds
         diff = new_end - curr_end

--- a/manim/scene/vector_space_scene.py
+++ b/manim/scene/vector_space_scene.py
@@ -868,7 +868,7 @@ class LinearTransformationScene(VectorScene):
             new_matrix[:2, :2] = transposed_matrix
             transposed_matrix = new_matrix
         elif transposed_matrix.shape != (3, 3):
-            raise Exception("Matrix has bad dimensions")
+            raise ValueError("Matrix has bad dimensions")
         return lambda point: np.dot(point, transposed_matrix)
 
     def get_piece_movement(self, pieces):

--- a/manim/utils/color.py
+++ b/manim/utils/color.py
@@ -264,7 +264,7 @@ def color_to_rgb(color):
     elif isinstance(color, Color):
         return np.array(color.get_rgb())
     else:
-        raise Exception("Invalid color type")
+        raise ValueError("Invalid color type")
 
 
 def color_to_rgba(color, alpha=1):

--- a/manim/utils/module_ops.py
+++ b/manim/utils/module_ops.py
@@ -30,7 +30,7 @@ def get_module(file_name):
     else:
         if os.path.exists(file_name):
             if file_name[-3:] != ".py":
-                raise Exception(f"{file_name} is not a valid Manim python script.")
+                raise ValueError(f"{file_name} is not a valid Manim python script.")
             module_name = file_name[:-3].replace(os.sep, ".").split(".")[-1]
             spec = importlib.util.spec_from_file_location(module_name, file_name)
             module = importlib.util.module_from_spec(spec)

--- a/manim/utils/space_ops.py
+++ b/manim/utils/space_ops.py
@@ -92,7 +92,7 @@ def rotate_vector(vector, angle, axis=OUT):
         product = reduce(quaternion_mult, [quat, np.append(0, vector), quat_inv])
         return product[1:]
     else:
-        raise Exception("vector must be of dimension 2 or 3")
+        raise ValueError("vector must be of dimension 2 or 3")
 
 
 def thick_diagonal(dim, thickness=2):
@@ -238,7 +238,7 @@ def line_intersection(line1, line2):
 
     div = det(x_diff, y_diff)
     if div == 0:
-        raise Exception("Lines do not intersect")
+        raise ValueError("Lines do not intersect")
     d = (det(*line1), det(*line2))
     x = det(d, x_diff) / div
     y = det(d, y_diff) / div


### PR DESCRIPTION
Changed many of the Exception("message") calls to other subclasses, like ValueError, TypeError, NotImplementedError, according to [Python documentation](https://docs.python.org/3/library/exceptions.html)
I only changed exceptions for their subclasses so try/except clauses will not broke. I did with most care, and I did not change Exceptions of which use i was not sure.

## List of Changes
- Changed most of the generic raise Exception("message") to more specific subclasses

## Testing Status
Tests passed on my Debian machine, but i do not see anything that could be broken by this changes

## Motivation
I just read the source code and my java-developper heart stopped when i saw Exception("Not implemented")

## Acknowledgement
- [X] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
