### PR TITLE
Show inheritance in Documentation

### DIFF
--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -3,6 +3,7 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
+   :show-inheritance:
    :members:
 
    {% block methods %}

--- a/docs/source/tutorials/configuration.rst
+++ b/docs/source/tutorials/configuration.rst
@@ -47,71 +47,76 @@ The output looks as follows.
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
    usage: manim [-h] [-o OUTPUT_FILE] [-p] [-f] [--leave_progress_bars] [-a] [-w] [-s] [-g] [-i] [--disable_caching] [--flush_cache] [--log_to_file] [-c BACKGROUND_COLOR]
-             [--background_opacity BACKGROUND_OPACITY] [--media_dir MEDIA_DIR] [--log_dir LOG_DIR] [--tex_template TEX_TEMPLATE] [--dry_run] [-t] [-q {k,p,h,m,l}] [--low_quality] [--medium_quality]
-             [--high_quality] [--production_quality] [--fourk_quality] [-r RESOLUTION] [-n FROM_ANIMATION_NUMBER] [--use_js_renderer] [--js_renderer_path JS_RENDERER_PATH] [--config_file CONFIG_FILE] [--custom_folders]
-             [-v {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--progress_bar True/False]
-             {cfg} ... file [scene_names [scene_names ...]]
+                [--background_opacity BACKGROUND_OPACITY] [--media_dir MEDIA_DIR] [--log_dir LOG_DIR] [--tex_template TEX_TEMPLATE] [--dry_run] [-t] [-q {k,p,h,m,l}]
+                [--low_quality] [--medium_quality] [--high_quality] [--production_quality] [--fourk_quality] [-l] [-m] [-e] [-k] [-r RESOLUTION] [-n FROM_ANIMATION_NUMBER]
+                [--use_js_renderer] [--js_renderer_path JS_RENDERER_PATH] [--config_file CONFIG_FILE] [--custom_folders] [-v {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
+                [--progress_bar True/False]
+                {cfg} ... file [scene_names [scene_names ...]]
 
-Animation engine for explanatory math videos
+   Animation engine for explanatory math videos
 
-positional arguments:
-  {cfg}
-  file                  path to file holding the python code for the scene
-  scene_names           Name of the Scene class you want to see
+   positional arguments:
+     {cfg}
+     file                  path to file holding the python code for the scene
+     scene_names           Name of the Scene class you want to see
 
-optional arguments:
-  -h, --help            show this help message and exit
-  -o OUTPUT_FILE, --output_file OUTPUT_FILE
-                        Specify the name of the output file, if it should be different from the scene class name
-  -p, --preview         Automatically open the saved file once its done
-  -f, --show_in_file_browser
-                        Show the output file in the File Browser
-  --leave_progress_bars
-                        Leave progress bars displayed in terminal
-  -a, --write_all       Write all the scenes from a file
-  -w, --write_to_movie  Render the scene as a movie file (this is on by default)
-  -s, --save_last_frame
-                        Save the last frame only (no movie file is generated)
-  -g, --save_pngs       Save each frame as a png
-  -i, --save_as_gif     Save the video as gif
-  --disable_caching     Disable caching (will generate partial-movie-files anyway)
-  --flush_cache         Remove all cached partial-movie-files
-  --log_to_file         Log terminal output to file
-  -c BACKGROUND_COLOR, --background_color BACKGROUND_COLOR
-                        Specify background color
-  --background_opacity BACKGROUND_OPACITY
-                        Specify background opacity
-  --media_dir MEDIA_DIR
-                        Directory to store media (including video files)
-  --log_dir LOG_DIR     Directory to store log files
-  --tex_template TEX_TEMPLATE
-                        Specify a custom TeX template file
-  --dry_run             Do a dry run (render scenes but generate no output files)
-  -t, --transparent     Render a scene with an alpha channel
-  -q {k,p,h,m,l}, --quality {k,p,h,m,l}
-                        Render at specific quality, short form of the --*_quality flags
-  --low_quality         Render at low quality
-  --medium_quality      Render at medium quality
-  --high_quality        Render at high quality
-  --production_quality  Render at default production quality
-  --fourk_quality       Render at 4K quality
-  -r RESOLUTION, --resolution RESOLUTION
-                        Resolution, passed as "height,width". Overrides any quality flags, if present
-  -n FROM_ANIMATION_NUMBER, --from_animation_number FROM_ANIMATION_NUMBER
-                        Start rendering at the specified animation index, instead of the first animation. If you pass in two comma separated values, e.g. '3,6', it will end the rendering at the second
-                        value
-  --use_js_renderer     Render animations using the javascript frontend
-  --js_renderer_path JS_RENDERER_PATH
-                        Path to the javascript frontend
-  --config_file CONFIG_FILE
-                        Specify the configuration file
-  --custom_folders      Use the folders defined in the [custom_folders] section of the config file to define the output folder structure
-  -v {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --verbosity {DEBUG,INFO,WARNING,ERROR,CRITICAL}
-                        Verbosity level. Also changes the ffmpeg log level unless the latter is specified in the config
-  --progress_bar True/False
-                        Display the progress bar
+   optional arguments:
+     -h, --help            show this help message and exit
+     -o OUTPUT_FILE, --output_file OUTPUT_FILE
+                           Specify the name of the output file, if it should be different from the scene class name
+     -p, --preview         Automatically open the saved file once its done
+     -f, --show_in_file_browser
+                           Show the output file in the File Browser
+     --leave_progress_bars
+                           Leave progress bars displayed in terminal
+     -a, --write_all       Write all the scenes from a file
+     -w, --write_to_movie  Render the scene as a movie file (this is on by default)
+     -s, --save_last_frame
+                           Save the last frame only (no movie file is generated)
+     -g, --save_pngs       Save each frame as a png
+     -i, --save_as_gif     Save the video as gif
+     --disable_caching     Disable caching (will generate partial-movie-files anyway)
+     --flush_cache         Remove all cached partial-movie-files
+     --log_to_file         Log terminal output to file
+     -c BACKGROUND_COLOR, --background_color BACKGROUND_COLOR
+                           Specify background color
+     --background_opacity BACKGROUND_OPACITY
+                           Specify background opacity
+     --media_dir MEDIA_DIR
+                           Directory to store media (including video files)
+     --log_dir LOG_DIR     Directory to store log files
+     --tex_template TEX_TEMPLATE
+                           Specify a custom TeX template file
+     --dry_run             Do a dry run (render scenes but generate no output files)
+     -t, --transparent     Render a scene with an alpha channel
+     -q {k,p,h,m,l}, --quality {k,p,h,m,l}
+                           Render at specific quality, short form of the --*_quality flags
+     --low_quality         Render at low quality
+     --medium_quality      Render at medium quality
+     --high_quality        Render at high quality
+     --production_quality  Render at default production quality
+     --fourk_quality       Render at 4K quality
+     -l                    DEPRECATED: USE -ql or --quality l
+     -m                    DEPRECATED: USE -qm or --quality m
+     -e                    DEPRECATED: USE -qh or --quality h
+     -k                    DEPRECATED: USE -qk or --quality k
+     -r RESOLUTION, --resolution RESOLUTION
+                           Resolution, passed as "height,width". Overrides any quality flags, if present
+     -n FROM_ANIMATION_NUMBER, --from_animation_number FROM_ANIMATION_NUMBER
+                           Start rendering at the specified animation index, instead of the first animation. If you pass in two comma separated values, e.g. '3,6', it will end
+                           the rendering at the second value
+     --use_js_renderer     Render animations using the javascript frontend
+     --js_renderer_path JS_RENDERER_PATH
+                           Path to the javascript frontend
+     --config_file CONFIG_FILE
+                           Specify the configuration file
+     --custom_folders      Use the folders defined in the [custom_folders] section of the config file to define the output folder structure
+     -v {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --verbosity {DEBUG,INFO,WARNING,ERROR,CRITICAL}
+                           Verbosity level. Also changes the ffmpeg log level unless the latter is specified in the config
+     --progress_bar True/False
+                           Display the progress bar
 
-Made with <3 by the manim community devs
+   Made with <3 by the manim community devs
 
 For example, to render a scene in high quality, but only output the last frame
 of the scene instead of the whole video, you can execute


### PR DESCRIPTION
## List of Changes
- In the reference manual, classes now display where they are inherited from.
- #514 introduced some warnings during documentation build (due to a misformatted `testoutput` block). This is also fixed here.

## Further Comments
The doctest in `configuration.rst` is currently not run as part of the pipeline... maybe we should enable this. (Which would require calling `make doctest` from the `docs` directory.)

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
