### PR TITLE
added guide for more distros and a more complete guide

### DIFF
--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -43,7 +43,7 @@ If you don't have python3-pip installed, install it:
 
 .. code-block:: bash
    
-   sudo apt install python-pip
+   sudo apt install python3-pip
   
 .. note:: These instructions are also valid for other Debian-based
           distributions or distributions that use the ``apt`` package manager.
@@ -113,7 +113,7 @@ To install LaTeX:
 
    sudo pacman -S texlive-most
 
-If you don't have python3-pip installed, install it:
+If you don't have python-pip installed, install it:
 
 .. code-block:: bash
    

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -42,6 +42,7 @@ To install LaTeX:
 If you don't have python3-pip installed, install it:
 
 .. code-block:: bash
+   
    sudo apt install python3-pip
   
 .. note:: These instructions are also valid for other Debian-based

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -113,6 +113,12 @@ To install LaTeX:
 
    sudo pacman -S texlive-most
 
+If you don't have python3-pip installed, install it:
+
+.. code-block:: bash
+   
+   sudo apt install python-pip
+
 
 .. note:: These instructions are also valid for other Arch-based
           distributions or distributions that use the ``pacman`` package

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -10,7 +10,7 @@ instructions in `Certifying a clean install`_.
 The two necessary dependencies are cairo and ffmpeg.  LaTeX is strongly
 recommended, as it is necessary to have access to the ``Tex`` and ``MathTex`` classes.
 
-Ubuntu/Debian
+Ubuntu/Mint/Debian
 *************
 
 Before installing anything, make sure that your system is up to date.
@@ -45,6 +45,12 @@ To install LaTeX:
 
 Arch/Manjaro
 ************
+
+Before installing anything, make sure that your system is up to date.
+
+.. code-block:: bash
+
+   sudo pacman -Syu
 
 To install cairo:
 

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -117,7 +117,7 @@ If you don't have python3-pip installed, install it:
 
 .. code-block:: bash
    
-   sudo apt install python-pip
+   sudo pacman -S python-pip
 
 
 .. note:: These instructions are also valid for other Arch-based

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -43,6 +43,35 @@ To install LaTeX:
           distributions or distributions that use the ``apt`` package manager.
 
 
+Fedora/CentOS/RHEL
+*************
+
+Before installing anything, make sure that your system is up to date.
+
+.. code-block:: bash
+
+   sudo apt update
+   sudo apt upgrade
+
+To install cairo:
+
+.. code-block:: bash
+
+  sudo yum install cairo-devel
+
+To install ffmpeg:
+
+.. code-block:: bash
+
+   sudo dnf install ffmpeg
+
+To install LaTeX:
+
+.. code-block:: bash
+
+   sudo dnf install texlive-scheme-medium
+
+
 Arch/Manjaro
 ************
 

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -39,6 +39,11 @@ To install LaTeX:
    sudo apt install texlive texlive-latex-extra texlive-fonts-extra \
    texlive-latex-recommended texlive-science texlive-fonts-extra tipa
 
+If you don't have python3-pip installed, install it:
+
+.. code-block:: bash
+   sudo apt install python3-pip
+  
 .. note:: These instructions are also valid for other Debian-based
           distributions or distributions that use the ``apt`` package manager.
 

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -46,18 +46,11 @@ To install LaTeX:
 Fedora/CentOS/RHEL
 *************
 
-Before installing anything, make sure that your system is up to date.
-
-.. code-block:: bash
-
-   sudo apt update
-   sudo apt upgrade
-
 To install cairo:
 
 .. code-block:: bash
 
-  sudo yum install cairo-devel
+  sudo dnf install cairo-devel
 
 To install ffmpeg:
 

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -43,7 +43,7 @@ If you don't have python3-pip installed, install it:
 
 .. code-block:: bash
    
-   sudo apt install python3-pip
+   sudo apt install python-pip
   
 .. note:: These instructions are also valid for other Debian-based
           distributions or distributions that use the ``apt`` package manager.

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -54,9 +54,23 @@ To install cairo:
 
 To install ffmpeg:
 
+Add RPMfusion repository if it's not already added:
+
+.. code-block:: bash
+
+   sudo dnf -y install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
+
+Install ffmpeg from RPMfusion repository:
+
 .. code-block:: bash
 
    sudo dnf install ffmpeg
+
+Install python development headers in order to successfully build pycairo wheel:
+
+.. code-block:: bash
+
+   sudo dnf install python3-devel
 
 To install LaTeX:
 


### PR DESCRIPTION

1: Added dependency guide installation for Fedora, CentOS and RHEL.
2: More complete guide for Arch/Manjaro and Ubuntu/Mint/Debian