### PR TITLE
Fixed a mistake in Fedora/CentOS/RHEL installation guide

### DIFF
--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -58,7 +58,7 @@ To install cairo:
 
   sudo dnf install cairo-devel
 
-To install ffmpeg, you have add RPMfusion repository (If it's not already added):
+To install ffmpeg, you have to add RPMfusion repository (If it's not already added):
 
 https://rpmfusion.org/Configuration/
 

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -58,13 +58,9 @@ To install cairo:
 
   sudo dnf install cairo-devel
 
-To install ffmpeg:
+To install ffmpeg, you have add RPMfusion repository (If it's not already added):
 
-Add RPMfusion repository if it's not already added:
-
-.. code-block:: bash
-
-   sudo dnf -y install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
+https://rpmfusion.org/Configuration/
 
 Install ffmpeg from RPMfusion repository:
 

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -58,7 +58,7 @@ To install cairo:
 
   sudo dnf install cairo-devel
 
-To install ffmpeg, you have to add RPMfusion repository (If it's not already added):
+To install ffmpeg, you have to add RPMfusion repository (If it's not already added). Please follow the instructions for your specific distribution in the following URL:
 
 https://rpmfusion.org/Configuration/
 


### PR DESCRIPTION
The command to add RPMfusion repository was for Fedora only, referenced a link(https://rpmfusion.org/Configuration/) for adding RPMfusion repository to all of Fedora/CentOS/RHEL distros.