### PR TITLE
Fix formatting of formulas in the readthedocs-documentation

### DIFF
--- a/manim/utils/tex.py
+++ b/manim/utils/tex.py
@@ -62,7 +62,7 @@ class TexTemplate:
 \usepackage{physics}
 \usepackage{xcolor}
 \usepackage{microtype}
-\DisableLigatures{encoding = *, family = *}
+\DisableLigatures{encoding = *, family = * }
 \linespread{1}
 """
     default_placeholder_text = "YourTextHere"

--- a/manim/utils/tex.py
+++ b/manim/utils/tex.py
@@ -123,6 +123,7 @@ class TexTemplate:
             + "\n"
             + self.placeholder_text
             + "\n"
+            + "\n"
             + r"\end{document}"
             + "\n"
         )

--- a/manim/utils/tex.py
+++ b/manim/utils/tex.py
@@ -62,7 +62,7 @@ class TexTemplate:
 \usepackage{physics}
 \usepackage{xcolor}
 \usepackage{microtype}
-\DisableLigatures{encoding = *, family = * }
+\DisableLigatures{encoding = *, family = *}
 \linespread{1}
 """
     default_placeholder_text = "YourTextHere"


### PR DESCRIPTION
## List of Changes
Add an additional newline in the tex template to avoid a weird shift in the coordinates of the produces SVG which does weird things (but only when RTD tries to render it, maybe due to an old version of dvisvgm).

Before: https://manimce.readthedocs.io/en/latest/examples/formulas.html
After: https://manimce--554.org.readthedocs.build/en/554/examples/formulas.html

## Additional Comments
This was an actual, literal nightmare to debug. 🙃 

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
