### PR TITLE
Restore examples/basic.py

### DIFF
--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -14,6 +14,16 @@ from manim import *
 # for a 1920x1080 video)
 
 from manim import *
+# To watch one of these scenes, run the following:
+# python --quality m manim example_scenes.py SquareToCircle -p
+#
+# Use the flag --quality l for a faster rendering at a lower quality.
+# Use -s to skip to the end and just save the final frame
+# Use the -p to have a preview of the animation (or image, if -s was
+# used) pop up once done.
+# Use -n <number> to skip ahead to the n'th animation of a scene.
+# Use -r <number> to specify a resolution (for example, -r 1080
+# for a 1920x1080 video)```
 
 # To watch one of these scenes, run the following:
 # python --quality m manim example_scenes.py SquareToCircle -p

--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -16,11 +16,58 @@ from manim import *
 from manim import *
 
 
-class Dot1(Scene):
+class OpeningManimExample(Scene):
     def construct(self):
-        dot = Dot().set_color(GREEN)
-        self.add(dot)
-        self.wait(1)
+        title = Tex("This is some \\LaTeX")
+        basel = MathTex("\\sum_{n=1}^\\infty " "\\frac{1}{n^2} = \\frac{\\pi^2}{6}")
+        VGroup(title, basel).arrange(DOWN)
+        self.play(
+            Write(title),
+            FadeInFrom(basel, UP),
+        )
+        self.wait()
+
+        transform_title = Tex("That was a transform")
+        transform_title.to_corner(UP + LEFT)
+        self.play(
+            Transform(title, transform_title),
+            LaggedStart(*map(FadeOutAndShiftDown, basel)),
+        )
+        self.wait()
+
+        grid = NumberPlane()
+        grid_title = Tex("This is a grid")
+        grid_title.scale(1.5)
+        grid_title.move_to(transform_title)
+
+        self.add(grid, grid_title)  # Make sure title is on top of grid
+        self.play(
+            FadeOut(title),
+            FadeInFromDown(grid_title),
+            ShowCreation(grid, run_time=3, lag_ratio=0.1),
+        )
+        self.wait()
+
+        grid_transform_title = Tex(
+            "That was a non-linear function \\\\" "applied to the grid"
+        )
+        grid_transform_title.move_to(grid_title, UL)
+        grid.prepare_for_nonlinear_transform()
+        self.play(
+            grid.apply_function,
+            lambda p: p
+            + np.array(
+                [
+                    np.sin(p[1]),
+                    np.sin(p[0]),
+                    0,
+                ]
+            ),
+            run_time=3,
+        )
+        self.wait()
+        self.play(Transform(grid_title, grid_transform_title))
+        self.wait()
 
 
 class SquareToCircle(Scene):
@@ -43,5 +90,42 @@ class WarpSquare(Scene):
             ApplyPointwiseFunction(
                 lambda point: complex_to_R3(np.exp(R3_to_complex(point))), square
             )
+        )
+        self.wait()
+
+
+class WriteStuff(Scene):
+    def construct(self):
+        example_text = Tex("This is a some text", tex_to_color_map={"text": YELLOW})
+        example_tex = MathTex(
+            "\\sum_{k=1}^\\infty {1 \\over k^2} = {\\pi^2 \\over 6}",
+        )
+        group = VGroup(example_text, example_tex)
+        group.arrange(DOWN)
+        group.set_width(config["frame_width"] - 2 * LARGE_BUFF)
+
+        self.play(Write(example_text))
+        self.play(Write(example_tex))
+        self.wait()
+
+
+class UpdatersExample(Scene):
+    def construct(self):
+        decimal = DecimalNumber(
+            0,
+            show_ellipsis=True,
+            num_decimal_places=3,
+            include_sign=True,
+        )
+        square = Square().to_edge(UP)
+
+        decimal.add_updater(lambda d: d.next_to(square, RIGHT))
+        decimal.add_updater(lambda d: d.set_value(square.get_center()[1]))
+        self.add(square, decimal)
+        self.play(
+            square.to_edge,
+            DOWN,
+            rate_func=there_and_back,
+            run_time=5,
         )
         self.wait()

--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -14,6 +14,16 @@ from manim import *
 # for a 1920x1080 video)
 
 from manim import *
+# To watch one of these scenes, run the following:
+# python --quality m manim example_scenes.py SquareToCircle -p
+#
+# Use the flag --quality l for a faster rendering at a lower quality.
+# Use -s to skip to the end and just save the final frame
+# Use the -p to have a preview of the animation (or image, if -s was
+# used) pop up once done.
+# Use -n <number> to skip ahead to the n'th animation of a scene.
+# Use -r <number> to specify a resolution (for example, -r 1080
+# for a 1920x1080 video)```
 
 
 class OpeningManimExample(Scene):

--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -14,6 +14,7 @@ from manim import *
 # for a 1920x1080 video)
 
 from manim import *
+
 # To watch one of these scenes, run the following:
 # python --quality m manim example_scenes.py SquareToCircle -p
 #

--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -14,6 +14,7 @@ from manim import *
 # for a 1920x1080 video)
 
 from manim import *
+
 # To watch one of these scenes, run the following:
 # python --quality m manim example_scenes.py SquareToCircle -p
 #
@@ -139,5 +140,6 @@ class UpdatersExample(Scene):
             run_time=5,
         )
         self.wait()
-        
+
+
 # See many more examples at https://manimce.readthedocs.io/en/latest/examples.html

--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -13,30 +13,6 @@ from manim import *
 # Use -r <number> to specify a resolution (for example, -r 1080
 # for a 1920x1080 video)
 
-from manim import *
-
-# To watch one of these scenes, run the following:
-# python --quality m manim example_scenes.py SquareToCircle -p
-#
-# Use the flag --quality l for a faster rendering at a lower quality.
-# Use -s to skip to the end and just save the final frame
-# Use the -p to have a preview of the animation (or image, if -s was
-# used) pop up once done.
-# Use -n <number> to skip ahead to the n'th animation of a scene.
-# Use -r <number> to specify a resolution (for example, -r 1080
-# for a 1920x1080 video)```
-
-# To watch one of these scenes, run the following:
-# python --quality m manim example_scenes.py SquareToCircle -p
-#
-# Use the flag --quality l for a faster rendering at a lower quality.
-# Use -s to skip to the end and just save the final frame
-# Use the -p to have a preview of the animation (or image, if -s was
-# used) pop up once done.
-# Use -n <number> to skip ahead to the n'th animation of a scene.
-# Use -r <number> to specify a resolution (for example, -r 1080
-# for a 1920x1080 video)```
-
 
 class OpeningManimExample(Scene):
     def construct(self):

--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -129,3 +129,5 @@ class UpdatersExample(Scene):
             run_time=5,
         )
         self.wait()
+        
+# See many more examples at https://manimce.readthedocs.io/en/latest/examples.html


### PR DESCRIPTION
Adds the original examples back to `example_scenes/basic.py`. These both allow new users
to see how these concepts can be composed into more complex animations and allow for
quick testing of the features during development.
