### PR TITLE
Fix spacing when using latex

### DIFF
--- a/manim/mobject/svg/tex_mobject.py
+++ b/manim/mobject/svg/tex_mobject.py
@@ -52,7 +52,7 @@ class SingleStringMathTex(SVGMobject):
     CONFIG = {
         "stroke_width": 0,
         "fill_opacity": 1.0,
-        "background_stroke_width": 1,
+        "background_stroke_width": 0,
         "background_stroke_color": BLACK,
         "should_center": True,
         "height": None,


### PR DESCRIPTION
Sometimes, svgs that were correctly created from latex were displayed with very small gaps in their structures.
See for example here:
![image](https://user-images.githubusercontent.com/44469195/96448001-0dcab880-1213-11eb-8736-01dd3dc2c1f6.png)


Setting    "background_stroke_width": 0 in tex_mobject solves this problem.

See here:

![Example1LaTeX](https://user-images.githubusercontent.com/44469195/96448164-45d1fb80-1213-11eb-8537-6740d47de8ff.png)

The corresponding issue is here: https://github.com/ManimCommunity/manim/issues/566
