### PR TITLE
Renamed "Examples" to "Example Gallery"

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,4 +1,4 @@
-Examples
+Example Gallery
 ============
 
 .. toctree::


### PR DESCRIPTION
Self explanatory.
This will hopefully give more clarity to distinguish "Reference Examples" and the "Example Gallery".