### PR TITLE
Custom "Example reference"-blocks for examples with manim directive

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -28,3 +28,8 @@ img {
     padding: 14px 0 14px 20px;
     margin: 20px 0;
 }
+
+div.example-reference {
+    background-color: #dff0d8;
+    border: 1px solid #3c763d;
+}

--- a/docs/source/examples/advanced_projects.rst
+++ b/docs/source/examples/advanced_projects.rst
@@ -2,7 +2,7 @@ Advanced Projects
 =================================
 
 .. manim:: OpeningManimExample
-    :quality: low
+    :seealso_classes: Tex MathTex NumberPlane
 
     class OpeningManimExample(Scene):
         def construct(self):
@@ -245,7 +245,7 @@ Advanced Projects
 .. manim:: ExampleSineCurve
 
     class ExampleSineCurve(Scene):
-        # contributed by heejin_park, https://infograph.tistory.com/230 
+        # contributed by heejin_park, https://infograph.tistory.com/230
         def construct(self):
             self.show_axis()
             self.show_circle()

--- a/docs/source/examples/advanced_projects.rst
+++ b/docs/source/examples/advanced_projects.rst
@@ -2,7 +2,7 @@ Advanced Projects
 =================================
 
 .. manim:: OpeningManimExample
-    :seealso_classes: Tex MathTex NumberPlane
+    :ref_classes: Tex MathTex NumberPlane
 
     class OpeningManimExample(Scene):
         def construct(self):

--- a/docs/source/manim_directive.py
+++ b/docs/source/manim_directive.py
@@ -21,6 +21,7 @@ As a second application, the directive can also be used to
 render scenes that are defined within doctests, for example::
 
     .. manim:: DirectiveDoctestExample
+        :ref_classes: Dot
 
         >>> dot = Dot(color=RED)
         >>> dot.color
@@ -58,13 +59,13 @@ directive:
         an image representing the last frame of the scene will
         be rendered and displayed, instead of a video.
 
-    seealso_classes
+    ref_classes
         A list of classes, separated by spaces, that is
-        rendered in a SEEALSO block after the source code.
+        rendered in a reference block after the source code.
 
-    seealso_functions
+    ref_functions
         A list of functions and methods, separated by spaces,
-        that is rendered in a SEEALSO block after the source code.
+        that is rendered in a reference block after the source code.
 
 """
 from docutils.parsers.rst import directives, Directive
@@ -112,8 +113,8 @@ class ManimDirective(Directive):
         ),
         "save_as_gif": bool,
         "save_last_frame": bool,
-        "seealso_classes": lambda arg: process_name_list(arg, "class"),
-        "seealso_functions": lambda arg: process_name_list(arg, "func"),
+        "ref_classes": lambda arg: process_name_list(arg, "class"),
+        "ref_functions": lambda arg: process_name_list(arg, "func"),
     }
     final_argument_whitespace = True
 
@@ -132,13 +133,17 @@ class ManimDirective(Directive):
         save_as_gif = "save_as_gif" in self.options
         save_last_frame = "save_last_frame" in self.options
         assert not (save_as_gif and save_last_frame)
-        if "seealso_classes" in self.options or "seealso_functions" in self.options:
-            seealso_classes = self.options.get("seealso_classes", [])
-            seealso_functions = self.options.get("seealso_functions", [])
-            seealso_content = seealso_classes + seealso_functions
-            seealso_block = f".. seealso::\n\n    {' '.join(seealso_content)}"
+        if "ref_classes" in self.options or "ref_functions" in self.options:
+            ref_classes = self.options.get("ref_classes", [])
+            ref_functions = self.options.get("ref_functions", [])
+            ref_content = ref_classes + ref_functions
+            ref_block = f"""
+.. admonition:: Example References
+    :class: example-reference
+
+    {' '.join(ref_content)}"""
         else:
-            seealso_block = ""
+            ref_block = ""
 
         frame_rate = 30
         pixel_height = 480
@@ -252,7 +257,7 @@ class ManimDirective(Directive):
             save_last_frame=save_last_frame,
             save_as_gif=save_as_gif,
             source_block=source_block,
-            seealso_block=seealso_block,
+            ref_block=ref_block,
         )
         state_machine.insert_input(
             rendered_template.split("\n"), source=document.attributes["source"]
@@ -280,7 +285,7 @@ TEMPLATE = r"""
     <div class="manim-example">
 
 {{ source_block }}
-{{ seealso_block }}
+{{ ref_block }}
 {% endif %}
 
 {% if not (save_as_gif or save_last_frame) %}

--- a/docs/source/manim_directive.py
+++ b/docs/source/manim_directive.py
@@ -68,7 +68,6 @@ directive:
 
 """
 from docutils.parsers.rst import directives, Directive
-from docutils.parsers.rst.directives.images import Image
 
 import jinja2
 import os


### PR DESCRIPTION
## List of Changes
- Add options `:ref_classes:` and `:ref_functions:` to the manim directive. Specifying either with a list of space separated class/function names renders a "Example reference" block between source code and video that contains links (!) to the classes/functions in the reference manual.

## Motivation
This is a suggestion for an approach tackling #448, and thus strengthening the future connection between our example gallery and the reference manual.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
