### PR TITLE
ci: upload release assets

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -35,7 +35,7 @@ jobs:
         tag_act: ${{ github.ref }}
       run: |
           ref_tag=$(python -c "print('${tag_act}'.split('/')[-1])")
-          res=$(curl -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${access_token}" https://api.github.com/repos/ManimCommunity/manim-windows/releases/tags/${ref_tag})
+          res=$(curl -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${access_token}" https://api.github.com/repos/ManimCommunity/manim/releases/tags/${ref_tag})
           upload_url=$(python -c "import json;print(json.loads('''${res}''')['upload_url'])")
           echo "::set-output name=upload_url::${upload_url}"
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,3 +26,26 @@ jobs:
 
     - name: Publish release to pypi
       run: poetry publish --build
+
+    - name: Get Upload URL
+      id: create_release
+      shell: bash
+      env:
+        access_token: ${{ secrets.GITHUB_TOKEN }}
+        tag_act: ${{ github.ref }}
+      run: |
+          ref_tag=$(python -c "print('${tag_act}'.split('/')[-1])")
+          res=$(curl -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${access_token}" https://api.github.com/repos/ManimCommunity/manim-windows/releases/tags/${ref_tag})
+          upload_url=$(python -c "import json;print(json.loads('''${res}''')['upload_url'])")
+          echo "::set-output name=upload_url::${upload_url}"
+
+    - name: Upload Release Asset
+      id: upload-release
+      uses: actions/upload-release-asset@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: dist/*.tar.gz
+          asset_name: manimce-${{ steps.tag.outputs.tag }}.tar.gz
+          asset_content_type: application/gzip


### PR DESCRIPTION
## List of Changes
This was a request from AUR package maintainer to upload the release asset to Github Release.

## Explanation for Changes
Using action/upload-release-asset action this is easy.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
