### PR TITLE
Added copy button for the sphinx page

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx==3.1.2
 guzzle-sphinx-theme
 recommonmark>=0.5.0
+sphinx-copybutton

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,7 @@ author = "The Manim Community Dev Team"
 extensions = [
     "sphinx.ext.autodoc",
     "recommonmark",
-    'sphinx_copybutton',
+    "sphinx_copybutton",
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,7 @@ author = "The Manim Community Dev Team"
 extensions = [
     "sphinx.ext.autodoc",
     "recommonmark",
+    'sphinx_copybutton',
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",


### PR DESCRIPTION
As seen here: https://sphinx-copybutton.readthedocs.io/en/latest/
Our examples in the docs will have small buttons on the top right to copy the code to clipboard.

