### PR TITLE
Improve design of documentation

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -3,11 +3,15 @@ td {
 }
 
 a {
-    color: #e07a5f;
+    color: #b0604b;
 }
 
 a:hover {
-    color: #efc0b3;
+    color: #ad9088;
+}
+
+p {
+    color: #353535;
 }
 
 .sidebar-toc ul li a:hover {
@@ -49,8 +53,8 @@ div.highlight pre {
     display: flex;
     align-items: center;
     background-image: none;
-    color: #e07a5f;
-    border-color: #e07a5f;
+    color: #b0604b;
+    border-color: #b0604b;
 }
 
 .footer-relations .pull-left a.btn.btn-default::before {
@@ -69,9 +73,9 @@ div.highlight pre {
 
 .footer-relations a.btn.btn-default:hover {
     background-image: none;
-    background-color: #e07a5f;
+    background-color: #b0604b;
     color: #fff;
-    border-color: #e07a5f;
+    border-color: #b0604b;
     transition: all 0.3s ease;
     text-shadow: none;
 }

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -2,34 +2,141 @@ td {
     padding: 0px 10px 0px 10px;
 }
 
+a {
+    color: #e07a5f;
+}
+
+a:hover {
+    color: #efc0b3;
+}
+
+.sidebar-toc ul li a:hover {
+    background-color: #e07a5f;
+}
+
+.text-logo {
+    background-color: #87c2a5;
+}
+
+h1 {
+    background-color: #e3f1ea;
+    border-bottom: 1px solid #87c2a5;
+}
+
 img.align-center {
     width: 100%;
     margin-bottom: 20px;
     margin-top: 20px;
 }
+
 img {
     display: block;
     max-width: 100%;
     height: auto;
 }
-.manim-video {
-    width: 100%;
+
+div.highlight {
+    background-color: #fafafa;
+    margin: 8px 0;
 }
 
-.manim-example pre {
-    border-left: none;
-    margin: 0;
-    padding: 0 0 14px 0;
+div.highlight pre {
+    background-color: inherit;
+}
+
+.footer-relations a.btn.btn-default {
+    display: flex;
+    align-items: center;
+    background-image: none;
+    color: #e07a5f;
+    border-color: #e07a5f;
+}
+
+.footer-relations .pull-left a.btn.btn-default::before {
+    font-family: 'Glyphicons Halflings';
+    content: "\e079";
+    margin-right: 4px;
+    margin-left: -2px;
+}
+
+.footer-relations .pull-right a.btn.btn-default::after {
+    font-family: 'Glyphicons Halflings';
+    content: "\e080";
+    margin-left: 4px;
+    margin-right: -2px;
+}
+
+.footer-relations a.btn.btn-default:hover {
+    background-image: none;
+    background-color: #e07a5f;
+    color: #fff;
+    border-color: #e07a5f;
+    transition: all 0.3s ease;
+    text-shadow: none;
+}
+
+.manim-video {
+    width: 100%;
+    padding: 8px 0;
 }
 
 .manim-example {
-    border-left: 2px solid #eee;
-    border-radius: 4px;
-    padding: 14px 0 14px 20px;
-    margin: 20px 0;
+    background-color: #525893;
+    margin-bottom: 50px;
+    box-shadow: 2px 2px 4px #ddd;
 }
 
-div.example-reference {
-    background-color: #dff0d8;
-    border: 1px solid #3c763d;
+.manim-example .manim-video {
+    padding: 0;
+}
+
+.manim-example img {
+    margin-bottom: 0;
+}
+
+.example-header {
+    font-size: 18px;
+    font-weight: bold;
+    padding: 8px 16px;
+    color: white;
+}
+
+.manim-example .highlight {
+    background-color: #fafafa;
+    border: 2px solid #525893;
+    padding: 8px 8px 16px 8px;
+    margin: 0;
+}
+
+.manim-example .highlight pre {
+    background-color: inherit;
+    border-left: none;
+    margin: 0;
+    padding: 0 6px 0 6px;
+}
+
+.manim-example .admonition {
+    margin-top: 0;
+}
+
+.manim-example .admonition-title {
+    font-size: 14px;
+}
+
+.manim-example .example-reference {
+    border: none;
+    background-color: inherit;
+}
+
+.manim-example .example-reference p:not(:first-child) {
+    margin-bottom: 0;
+}
+
+.manim-example .copybtn {
+    margin-right: 6px;
+    font-size: 18px;
+}
+
+.manim-example .copybtn:hover {
+    cursor: pointer;
 }

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -42,6 +42,7 @@ div.highlight {
 
 div.highlight pre {
     background-color: inherit;
+    border-color: #525893;
 }
 
 .footer-relations a.btn.btn-default {

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -119,10 +119,13 @@ div.highlight pre {
 
 .manim-example .admonition {
     margin-top: 0;
+    padding: 12px 20px;
 }
 
 .manim-example .admonition-title {
     font-size: 14px;
+    font-weight: 500;
+    color: white;
 }
 
 .manim-example .example-reference {

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -78,6 +78,7 @@ div.highlight pre {
 .manim-video {
     width: 100%;
     padding: 8px 0;
+    outline: 0;
 }
 
 .manim-example {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,12 +20,13 @@ information here will make it easier for newcomers to get started using
    :maxdepth: 2
 
    installation
-   reference
-   examples
    tutorials
+   examples
+   changelog
+   reference
    reporting_bugs
    contributing
-   changelog
+
 
 Navigation
 ==================

--- a/docs/source/manim_directive.py
+++ b/docs/source/manim_directive.py
@@ -251,6 +251,7 @@ class ManimDirective(Directive):
             raise ValueError("Invalid combination of render flags received.")
 
         rendered_template = jinja2.Template(TEMPLATE).render(
+            clsname=clsname,
             hide_source=hide_source,
             filesrc_rel=os.path.relpath(filesrc, setup.confdir),
             output_file=output_file,
@@ -284,8 +285,6 @@ TEMPLATE = r"""
 
     <div class="manim-example">
 
-{{ source_block }}
-{{ ref_block }}
 {% endif %}
 
 {% if not (save_as_gif or save_last_frame) %}
@@ -299,10 +298,16 @@ TEMPLATE = r"""
 .. image:: /{{ filesrc_rel }}
     :align: center
 {% endif %}
-
 {% if not hide_source %}
 .. raw:: html
 
-    </div>
+    <div class="example-header">{{ clsname }}</div>
+
+{{ source_block }}
+{{ ref_block }}
 {% endif %}
+
+.. raw:: html
+
+    </div>
 """

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -10,9 +10,9 @@ the :doc:`changelog`.
 
 .. currentmodule:: manim
 
-********************
-Mathematical Objects
-********************
+********
+Mobjects
+********
 
 .. autosummary::
    :toctree: reference


### PR DESCRIPTION
## List of Changes
- Completely redesign example blocks with included source code
- Introduce colors from color palette across our docs
- Improve design of non-example code blocks

## Motivation
As discussed in #607, our manim-directive generated example blocks did not have a very good design. This PR improves this. And while throwing on some custom design, I also changed some colors in our docs to match the color palette of our new logo.

Closes #612. 

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
