### PR TITLE
Remove remaining occurrences of PangoText

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -16,7 +16,7 @@ Mobjects, Scenes, and Animations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #. The ``alignment`` attribute to Tex and MathTex has been removed in favour of ``tex_environment``.
-
+#. :class:`~.Text` now uses Pango for rendering. ``PangoText`` has been removed. The old implementation is still available as a fallback as :class:`~.CairoText`.
 
 
 

--- a/docs/source/examples/shapes_images_positions.rst
+++ b/docs/source/examples/shapes_images_positions.rst
@@ -16,7 +16,7 @@ Shapes, Images and Positions
             self.add(d, c, s, t)
 
 .. manim:: PointMovingOnShapes
-    
+
     class PointMovingOnShapes(Scene):
         def construct(self):
             circle = Circle(radius=1, color=BLUE)
@@ -36,7 +36,7 @@ Shapes, Images and Positions
 
 .. manim:: GradientImageFromArray
     :save_last_frame:
-    
+
     class GradientImageFromArray(Scene):
         def construct(self):
             n = 256
@@ -49,7 +49,7 @@ Shapes, Images and Positions
 
 .. manim:: ArcShapeIris
     :save_last_frame:
-    
+
     class ArcShapeIris(Scene):
         def construct(self):
             colors = [DARK_BLUE, DARK_BROWN, BLUE_E, BLUE_D, BLUE_A, TEAL_B, GREEN_B, YELLOW_E]
@@ -58,32 +58,32 @@ Shapes, Images and Positions
             circles_group = VGroup()
 
             # zip(radius, color) makes the iterator [(radius[i], color[i]) for i in range(radius)]
-            circles_group.add(*[Circle(radius=rad, stroke_width=10, color=col) 
+            circles_group.add(*[Circle(radius=rad, stroke_width=10, color=col)
                                 for rad, col in zip(radius, colors)])
             self.add(circles_group)
 
 
 .. manim:: DotInterpolation
     :save_last_frame:
-    
+
     class DotInterpolation(Scene):
         def construct(self):
             dotL = Dot(color=DARK_GREY)
             dotL.shift(2 * RIGHT)
             dotR = Dot(color=WHITE)
             dotR.shift(2 * LEFT)
-            
+
             dotMiddle = VMobject().interpolate(dotL, dotR, alpha=0.3)
-            
+
             self.add(dotL, dotR, dotMiddle)
 
 
 .. manim:: MovingAround
-    
+
     class MovingAround(Scene):
         def construct(self):
             square = Square(color=BLUE, fill_opacity=1)
-            
+
             self.play(square.shift, LEFT)
             self.play(square.set_fill, ORANGE)
             self.play(square.scale, 0.3)
@@ -92,7 +92,7 @@ Shapes, Images and Positions
 
 .. manim:: TextAlignement
     :save_last_frame:
-    
+
     class TextAlignement(Scene):
         def construct(self):
             title = Text("K-means clustering and Logistic Regression", color=WHITE)
@@ -119,7 +119,7 @@ Shapes, Images and Positions
 
 .. manim:: BezierSpline
     :save_last_frame:
-    
+
     class BezierSpline(Scene):
         def construct(self):
             np.random.seed(42)

--- a/docs/source/examples/shapes_images_positions.rst
+++ b/docs/source/examples/shapes_images_positions.rst
@@ -95,20 +95,20 @@ Shapes, Images and Positions
     
     class TextAlignement(Scene):
         def construct(self):
-            title = PangoText("K-means clustering and Logistic Regression", color=WHITE)
+            title = Text("K-means clustering and Logistic Regression", color=WHITE)
             title.scale_in_place(0.75)
             self.add(title.to_edge(UP))
 
-            t1 = PangoText("1. Measuring").set_color(WHITE)
+            t1 = Text("1. Measuring").set_color(WHITE)
             t1.next_to(ORIGIN, direction=RIGHT, aligned_edge=UP)
 
-            t2 = PangoText("2. Clustering").set_color(WHITE)
+            t2 = Text("2. Clustering").set_color(WHITE)
             t2.next_to(t1, direction=DOWN, aligned_edge=LEFT)
 
-            t3 = PangoText("3. Regression").set_color(WHITE)
+            t3 = Text("3. Regression").set_color(WHITE)
             t3.next_to(t2, direction=DOWN, aligned_edge=LEFT)
 
-            t4 = PangoText("4. Prediction").set_color(WHITE)
+            t4 = Text("4. Prediction").set_color(WHITE)
             t4.next_to(t3, direction=DOWN, aligned_edge=LEFT)
 
             x = VGroup(t1, t2, t3, t4).scale_in_place(0.7)

--- a/docs/source/examples/tex.rst
+++ b/docs/source/examples/tex.rst
@@ -76,7 +76,7 @@ We can use any standard LaTeX commands in the AMS maths packages. For example th
             tex = Tex(r'$\mathtt{Hello}$ \LaTeX').scale(3)
             self.add(tex)
 
-On the manim side, the :class:`~.Tex` class also accepts attributes to change the appearance of the output. 
+On the manim side, the :class:`~.Tex` class also accepts attributes to change the appearance of the output.
 This is very similar to the :class:`~.Text` class. For example, the ``color`` keyword changes the color of the TeX mobject:
 
 .. manim:: LaTeXAttributes
@@ -89,7 +89,7 @@ This is very similar to the :class:`~.Text` class. For example, the ``color`` ke
 
 Extra LaTeX Packages
 +++++++++++++++++++++
-Some commands require special packages to be loaded into the TeX template. For example, 
+Some commands require special packages to be loaded into the TeX template. For example,
 to use the ``mathscr`` script, we need to add the ``mathrsfs`` package. Since this package isn't loaded
 into manim's tex template by default, we add it manually:
 
@@ -120,7 +120,7 @@ in this example where we set the color of the ``\bigstar`` using :func:`~.set_co
 
 LaTeX Maths Fonts - The Template Library
 ++++++++++++++++++++++++++++++++++++++++++++
-Changing fonts in LaTeX when typesetting mathematical formulae is a little bit more tricky than 
+Changing fonts in LaTeX when typesetting mathematical formulae is a little bit more tricky than
 with regular text. It requires changing the template that is used to compile the tex code.
 Manim comes with a collection of :class:`~.TexFontTemplates` ready for you to use. These templates will all work
 in maths mode:
@@ -133,10 +133,10 @@ in maths mode:
             tex = Tex(r'$f: A \rightarrow B$', tex_template=TexFontTemplates.french_cursive).scale(3)
             self.add(tex)
 
-Manim also has a :class:`~.TexTemplateLibrary` containing the TeX templates used by 3Blue1Brown. One example 
+Manim also has a :class:`~.TexTemplateLibrary` containing the TeX templates used by 3Blue1Brown. One example
 is the ctex template, used for typesetting Chinese. For this to work, the ctex LaTeX package
 must be installed on your system. Furthermore, if you are only typesetting Text, you probably do not
-need :class:`~.Tex` at all, and should use :class:`~.Text` or :class:`~.PangoText` instead. 
+need :class:`~.Tex` at all, and should use :class:`~.Text` or :class:`~.PangoText` instead.
 
 .. manim:: LaTeXTemplateLibrary
     :save_last_frame:

--- a/docs/source/examples/tex.rst
+++ b/docs/source/examples/tex.rst
@@ -4,8 +4,8 @@ Text and LaTeX
 
 Text
 --------------
-The simplest way to add text to you animation is to use the :class:`~.Text` class. It uses the Cairo library to render text.
-A newer addition to manim is the :class:`~.PangoText` class, which uses the Pango library.
+The simplest way to add text to you animation is to use the :class:`~.Text` class. It uses the Pango library to render text.
+With Pango, you are also able to render non-English alphabets like `你好` or  `こんにちは` or `안녕하세요` or `مرحبا بالعالم`.
 
 The Text() mobject
 +++++++++++++++++++
@@ -19,11 +19,6 @@ The Text() mobject
             self.add(text)
 
 For more examples, see: :class:`~.Text`.
-
-The PangoText() mobject
-+++++++++++++++++++++++
-
-The :class:`~.PangoText` mobject uses the Pango library to render text. Use this whenever you want to use non-English alphabets like `你好` or  `こんにちは` or `안녕하세요` or `مرحبا بالعالم`.
 
 
 LaTeX
@@ -42,7 +37,7 @@ Just as you can use :class:`~.Text` to add text to your videos, you can use :cla
             self.add(tex)
 
 Note that we are using a raw string (``r'---'``) instead of a regular string (``'---'``).
-This is because TeX code uses a lot of special characters - like ``\`` for example - 
+This is because TeX code uses a lot of special characters - like ``\`` for example -
 that have special meaning within a regular python string. An alternative would have
 been to write ``\\`` as in ``Tex('\\LaTeX')``.
 

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -825,7 +825,7 @@ class Text(SVGMobject):
         """
         settings = (
             "PANGO" + self.font + self.slant + self.weight
-        )  # to differentiate Text and PangoText
+        )  # to differentiate Text and CairoText
         settings += str(self.t2f) + str(self.t2s) + str(self.t2w)
         settings += str(self.line_spacing) + str(self.size)
         id_str = self.text + settings


### PR DESCRIPTION
Follow-up to #609: some occurrences of `PangoText` were missed when removing it (and I also forgot to put a line in the changelog).

Both issues are fixed here, and the documentation should be able to build again.

## Further Comments
I am not sure why the docs were able to build on #609, it could hint towards something being configured in a wrong way.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
