### PR TITLE
pass html_favicon as string

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,7 +80,7 @@ import guzzle_sphinx_theme
 
 html_theme_path = guzzle_sphinx_theme.html_theme_path()
 html_theme = "guzzle_sphinx_theme"
-html_favicon = Path("_static/favicon.ico")
+html_favicon = str(Path("_static/favicon.ico"))
 
 # There's a standing issue with Sphinx's new-style sidebars.  This is a
 # workaround.  Taken from


### PR DESCRIPTION
## List of Changes
- Pass `html_favicon` as string instead of as `Path`.

## Motivation
Resolves #642. 

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

