### PR TITLE
get_project_root() for getting the anchor dir of manim

### DIFF
--- a/manim/config/utils.py
+++ b/manim/config/utils.py
@@ -31,6 +31,7 @@ def config_file_paths():
     folder_wide = Path("manim.cfg")
     return [library_wide, user_wide, folder_wide]
 
+
 def get_project_root() -> Path:
     return Path(__file__).parent.parent.parent
 

--- a/manim/config/utils.py
+++ b/manim/config/utils.py
@@ -31,6 +31,9 @@ def config_file_paths():
     folder_wide = Path("manim.cfg")
     return [library_wide, user_wide, folder_wide]
 
+def get_project_root() -> Path:
+    return Path(__file__).parent.parent.parent
+
 
 def make_config_parser(custom_file=None):
     """Make a ConfigParser object and load the .cfg files.

--- a/manim/config/utils.py
+++ b/manim/config/utils.py
@@ -32,10 +32,6 @@ def config_file_paths():
     return [library_wide, user_wide, folder_wide]
 
 
-def get_project_root() -> Path:
-    return Path(__file__).parent.parent.parent
-
-
 def make_config_parser(custom_file=None):
     """Make a ConfigParser object and load the .cfg files.
 

--- a/tests/helpers/path_utils.py
+++ b/tests/helpers/path_utils.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+
+def get_project_root() -> Path:
+    return Path(__file__).parent.parent.parent


### PR DESCRIPTION
With this function get_project_root, one can navigate very robust through the file systems.
```py
from manim import *
from manim.config.utils import get_project_root

class ABC(Scene):
    def construct(self):
        path = Path(get_project_root()) / "tests/test_graphical_units/img_svg_resources/weight.svg"
        print(path)
        svg_obj = SVGMobject(str(path))
```
Might solve the issue in https://github.com/ManimCommunity/manim/pull/649

Idea comes from here:
https://stackoverflow.com/questions/25389095/python-get-path-of-root-project-structure