### PR TITLE
Make set_test_scene more robust when missing self.wait()

### DIFF
--- a/tests/helpers/graphical_units.py
+++ b/tests/helpers/graphical_units.py
@@ -30,6 +30,7 @@ def set_test_scene(scene_object, module_name):
     config["skip_animations"] = True
     config["write_to_movie"] = False
     config["disable_caching"] = True
+    config["save_last_frame"] = True
     config["pixel_height"] = 480
     config["pixel_width"] = 854
     config["frame_rate"] = 15


### PR DESCRIPTION
Currently, creating test data like this will result in the following error when you don't have a self.wait() in your test in the end:
```python
class TEST(Scene):
    def construct(self):
        dot= Dot()
        self.add(dot)



set_test_scene(
    TEST, "newnew"
)  # <module_name> can be e.g.  "geometry" or "movements"
```
```console
AssertionError: Control data generated for TEST only contains empty pixels.
```
This can be fixed by adding a line save_last_frame in the config of set_test_scene 
