### PR TITLE
Show module-level functions in documentation

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -14,6 +14,10 @@ p {
     color: #353535;
 }
 
+dl.function {
+    border-bottom: 1px solid #ccc;
+}
+
 .sidebar-toc ul li a:hover {
     background-color: #e07a5f;
 }

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -53,6 +53,11 @@ div.highlight pre {
     border-color: #525893;
 }
 
+div.seealso {
+    background-color: #d9edf7;
+    border: 1px solid #525893;
+}
+
 .footer-relations a.btn.btn-default {
     display: flex;
     align-items: center;

--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -15,17 +15,6 @@
    {% endif %}
    {% endblock %}
 
-   {% block functions %}
-   {% if functions %}
-   .. rubric:: {{ _('Functions') }}
-
-   .. autosummary::
-   {% for item in functions %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
    {% block classes %}
    {% if classes %}
    .. rubric:: Classes
@@ -36,6 +25,16 @@
       {% for class in classes %}
         {{ class }}
       {% endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   {% for item in functions %}
+   .. autofunction:: {{ item }}
+   {%- endfor %}
    {% endif %}
    {% endblock %}
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,6 +62,10 @@ extensions = [
 # Automatically generate stub pages when using the .. autosummary directive
 autosummary_generate = True
 
+# controls whether functions documented by the autofunction directive
+# appear with their full module names
+add_module_names = False
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
## List of Changes
Our documentation currently does not render the full documentation of module-level functions. This PR changes the autosummary (the table with names/oneline summaries) for functions to rendering the full documentation for these functions.

## Motivation
Whenever we have documentation to show, it should be rendered somehow.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

