### PR TITLE
document workaround for a weird issue with zlib

### DIFF
--- a/docs/source/installation/troubleshooting.rst
+++ b/docs/source/installation/troubleshooting.rst
@@ -36,6 +36,32 @@ run:
 This should generate the missing ``_generated.ffi`` modules.
 
 
+(Windows) OSError: dlopen() failed to load a library: pango?
+------------------------------------------------------------
+
+If your manual installation of Manim (or even the installation using
+Chocolatey) fails with the error
+
+.. code-block::
+
+  OSError: dlopen() failed to load a library: pango / pango-1 / pango-1.0 / pango-1.0-0
+
+possibly combined with alerts warning about procedure entry points
+``"deflateSetHeader"`` and ``"inflateReset2"`` that could not be
+located, you might run into an issue with a patched version of ``zlib1.dll``
+shipped by Intel, `as described here <https://github.com/msys2/MINGW-packages/issues/813>`_.
+
+To resolve this issue, you can copy ``zlib1.dll`` from the directory
+provided for the Pango binaries to the directory Manim is installed to.
+
+For a more global solution (try at your own risk!), try renaming the
+file ``zlib1.dll`` located at ``C:\Program Files\Intel\Wifi\bin`` to
+something like ``zlib1.dll.bak`` -- and then try installing Manim again
+(either using ``pip install manimce`` or with Chocolatey). Ensure that
+you are able to revert this name change in case you run into troubles
+with your WiFi (we did not get any reports about such a problem, however).
+
+
 Some letters are missing from TextMobject/TexMobject output?
 ------------------------------------------------------------
 


### PR DESCRIPTION
This documents a workaround for a problem caused by a patched version of `zlib1.dll` shipped by Intel.

This has been reported by a colleague of mine (credit for this solution also belongs to him), and the very same issue occurred for someone in Discord today as well; the proposed solution (renaming the file provided by Intel) also was reported to work in that case.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

