### PR TITLE
Remove two removed modules from reference manual

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -35,7 +35,6 @@ Mobjects
    ~mobject.vector_field
    ~mobject.svg.brace
    ~mobject.svg.code_mobject
-   ~mobject.svg.drawings
    ~mobject.svg.svg_mobject
    ~mobject.svg.tex_mobject
    ~mobject.svg.text_mobject
@@ -78,7 +77,6 @@ Animations
    ~animation.movement
    ~animation.numbers
    ~animation.rotation
-   ~animation.specialized
    ~animation.transform
    ~animation.update
 


### PR DESCRIPTION
Follow-up to #665: remove the corresponding modules (`drawings`, `animations.specialized`) from the reference manual as well.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

