### PR TITLE
Add basic opengraph metadata to documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ Sphinx==3.1.2
 guzzle-sphinx-theme
 recommonmark>=0.5.0
 sphinx-copybutton
+sphinxext-opengraph

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,6 +56,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
+    "sphinxext.opengraph",
     "manim_directive",
 ]
 
@@ -101,3 +102,8 @@ html_static_path = ["_static"]
 
 # This specifies any additional css files that will override the theme's
 html_css_files = ["custom.css"]
+
+# opengraph settings
+ogp_image = "https://www.manim.community/logo.png"
+ogp_site_name = "Manim Community | Documentation"
+ogp_site_url = "https://docs.manim.community/"


### PR DESCRIPTION
This uses the [Sphinx opengraph extension](https://pypi.org/project/sphinxext-opengraph/) to include basic opengraph metadata to all of our documentation pages.

## Motivation
Resolves #407.

## Testing Status
The injected meta tags for the deployed test page are here:
![image](https://user-images.githubusercontent.com/11851593/98454182-e6a43e80-2161-11eb-80c2-8f78b9783250.png)
The Facebook share card looks something like this:
![image](https://user-images.githubusercontent.com/11851593/98454198-1e12eb00-2162-11eb-8773-ca6375ac99f9.png)
... and the Twitter card testing tool refuses to work because RTD actually denies access to crawlers via `robots.txt`.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))