### PR TITLE
Add shortcut for creating links to issues and PRs in the documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ Sphinx==3.1.2
 guzzle-sphinx-theme
 recommonmark>=0.5.0
 sphinx-copybutton
+sphinxext-opengraph

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,6 +20,11 @@ Configuration
    Configuration tutorial for details.
 
 
+Documentation
+^^^^^^^^^^^^^
+
+#. Add ``:issue:`` and ``:pr:`` directives for simplifying linking to issues and
+   pull requests on GitHub (via :pr:`685`).
 
 
 Mobjects, Scenes, and Animations

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,6 +56,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
+    "sphinxext.opengraph",
     "manim_directive",
 ]
 
@@ -101,3 +102,8 @@ html_static_path = ["_static"]
 
 # This specifies any additional css files that will override the theme's
 html_css_files = ["custom.css"]
+
+# opengraph settings
+ogp_image = "https://www.manim.community/logo.png"
+ogp_site_name = "Manim Community | Documentation"
+ogp_site_url = "https://docs.manim.community/"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,6 +56,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
+    "sphinx.ext.extlinks",
     "sphinxext.opengraph",
     "manim_directive",
 ]
@@ -102,6 +103,12 @@ html_static_path = ["_static"]
 
 # This specifies any additional css files that will override the theme's
 html_css_files = ["custom.css"]
+
+# external links
+extlinks = {
+    "issue": ("https://github.com/ManimCommunity/manim/issues/%s", "issue "),
+    "pr": ("https://github.com/ManimCommunity/manim/pull/%s", "pull request "),
+}
 
 # opengraph settings
 ogp_image = "https://www.manim.community/logo.png"


### PR DESCRIPTION
This PR adds the external link directives `:issue:` and `:pr:`. They can be used to link to issues and PRs over here.

## Motivation
We should make it easier to find the discussions behind certain changes; I propose that everything listed in the changelog should link to the corresponding issue/PR.

## Testing Status
See this:
![image](https://user-images.githubusercontent.com/11851593/98454264-e9536380-2162-11eb-88ec-2e0b8ea60d80.png)
The link to "pull request 685" is created from 
```
:pr:`685`
```
(Deployed at https://manimce--685.org.readthedocs.build/en/685/changelog.html)

## Further Comments

Depends on #684 (but only because I wanted to avoid a merge conflict)

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
