### PR TITLE
docs: update install instructions [chocolatey]

### DIFF
--- a/docs/source/installation/win.rst
+++ b/docs/source/installation/win.rst
@@ -8,19 +8,15 @@ instructions.
 Installing using Chocolatey
 ***************************
 
-.. important:: This is an outdated version. We are currently not able to update this package, though we are working on it. Please use other installation methods until
-               this problem is fixed. More inforation about this problem 
-               is on _`this chat 
-               <https://discord.com/channels/581738731934056449/581738732646957057/768900904887123988>`_.
-
 You can install manim very easily using chocolatey, by typing the following command.
 
 .. code-block:: powershell
 
-      choco install manim
+      choco install manimce
 
 
 And then you can skip all the other steps and move to installing :ref:`latex-installation`.
+Please see :ref:`troubleshooting` section for details about OSError.
 
 Pango Installation
 ******************


### PR DESCRIPTION
## List of Changes
- The chocolatey package [`manimce`](https://chocolatey.org/packages/manimce) is the current package where the latest versions are published. Also, people who have installed  [`manim`](https://chocolatey.org/packages/manim), will simply get an upgrade on this if they do `choco upgrade manim` and will `manimce` package automatically installed. 

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

