### PR TITLE
Succession honors individual animations run times

### DIFF
--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,0 +1,78 @@
+import pytest
+from manim.animation.composition import Succession
+from manim.animation.fading import FadeInFrom, FadeOutAndShift
+from manim.constants import DOWN
+from manim.mobject.geometry import Line
+
+
+def test_succession_timing():
+    """Test timing of animations in a succession."""
+    line = Line()
+    animation_1s = FadeInFrom(line, direction=DOWN, run_time=1.0)
+    animation_4s = FadeOutAndShift(line, direction=DOWN, run_time=4.0)
+    succession = Succession(animation_1s, animation_4s)
+    assert succession.get_run_time() == 5.0
+    succession.begin()
+    assert succession.active_index == 0
+    # The first animation takes 20% of the total run time.
+    succession.interpolate(0.199)
+    assert succession.active_index == 0
+    succession.interpolate(0.2)
+    assert succession.active_index == 1
+    succession.interpolate(0.8)
+    assert succession.active_index == 1
+    # At 100% and more, no animation must be active anymore.
+    succession.interpolate(1.0)
+    assert succession.active_index == 2
+    assert succession.active_animation is None
+    succession.interpolate(1.2)
+    assert succession.active_index == 2
+    assert succession.active_animation is None
+
+
+def test_succession_in_succession_timing():
+    """Test timing of nested successions."""
+    line = Line()
+    animation_1s = FadeInFrom(line, direction=DOWN, run_time=1.0)
+    animation_4s = FadeOutAndShift(line, direction=DOWN, run_time=4.0)
+    nested_succession = Succession(animation_1s, animation_4s)
+    succession = Succession(
+        FadeInFrom(line, direction=DOWN, run_time=4.0),
+        nested_succession,
+        FadeInFrom(line, direction=DOWN, run_time=1.0),
+    )
+    assert nested_succession.get_run_time() == 5.0
+    assert succession.get_run_time() == 10.0
+    succession.begin()
+    succession.interpolate(0.1)
+    assert succession.active_index == 0
+    # The nested succession must not be active yet, and as a result hasn't set active_animation yet.
+    assert not hasattr(nested_succession, "active_animation")
+    succession.interpolate(0.39)
+    assert succession.active_index == 0
+    assert not hasattr(nested_succession, "active_animation")
+    # The nested succession starts at 40% of total run time
+    succession.interpolate(0.4)
+    assert succession.active_index == 1
+    assert nested_succession.active_index == 0
+    # The nested succession second animation starts at 50% of total run time.
+    succession.interpolate(0.49)
+    assert succession.active_index == 1
+    assert nested_succession.active_index == 0
+    succession.interpolate(0.5)
+    assert succession.active_index == 1
+    assert nested_succession.active_index == 1
+    # The last animation starts at 90% of total run time. The nested succession must be finished at that time.
+    succession.interpolate(0.89)
+    assert succession.active_index == 1
+    assert nested_succession.active_index == 1
+    succession.interpolate(0.9)
+    assert succession.active_index == 2
+    assert nested_succession.active_index == 2
+    assert nested_succession.active_animation is None
+    # After 100%, nothing must be playing anymore.
+    succession.interpolate(1.0)
+    assert succession.active_index == 3
+    assert succession.active_animation is None
+    assert nested_succession.active_index == 2
+    assert nested_succession.active_animation is None


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
- Succession honors individual animations run times

## Motivation
Succession ignores run times of individual animations, and instead plays every animation for the same period of time.

For example, if I create a succession with:

`succession = Succession(FadeInFrom(line, direction=DOWN, run_time=1.0), FadeOutAndShift(line, direction=DOWN, run_time=4.0))`

I expect to get a line fading in going up for 1 second, and then fading out going down for 4 seconds. Instead, the line fades in going up for 2.5 seconds, and fades out going down for 2.5 seconds.

Because of this, it is complicated to use successions in conjunction with other animations.

## Explanation for Changes
This change modifies Succession so that it takes into account individual animation times, and plays them at the right time. Instead of interpolating on the total run time, the individual run times are taken into account.

Here is an example of the result:

```python
from manim import *

class SuccessionDemo(Scene):
    def construct(self):
        line = Line()
        succession = Succession(
            FadeInFrom(line, direction=DOWN, run_time=1.0),
            FadeOutAndShift(line, direction=DOWN, run_time=4.0)
        )
        self.play(succession)
```

Before the change:

![SuccessionDemo_before-change](https://user-images.githubusercontent.com/34718998/98685180-58010e80-2367-11eb-8086-c8727ef6eec2.gif)

After the change:

![SuccessionDemo_run-time-honored](https://user-images.githubusercontent.com/34718998/98685158-51729700-2367-11eb-98fc-b341de3c6580.gif)

## Acknowledgement
- [X] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
