### PR TITLE
remove Scene.set_variables_as_attrs()

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,7 +20,7 @@ Mobjects, Scenes, and Animations
 #. **New**: Variations of :class:`~.Dot` have been added as :class:`~.AnnotationDot`
    (a bigger dot with bolder stroke) and :class:`~.LabeledDot` (a dot containing a
    label).
-#. Scene.set_variables_as_attrs has been removed :pr:`692`.
+#. Scene.set_variables_as_attrs has been removed (via :pr:`692`).
 
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,7 +20,7 @@ Mobjects, Scenes, and Animations
 #. **New**: Variations of :class:`~.Dot` have been added as :class:`~.AnnotationDot`
    (a bigger dot with bolder stroke) and :class:`~.LabeledDot` (a dot containing a
    label).
-
+#. Scene.set_variables_as_attrs has been removed :pr:`692`.
 
 
 
@@ -142,6 +142,3 @@ Other Changes
 #. Rename package from manimlib to manim
 #. Move all imports to :code:`__init__`, so :code:`from manim import *` replaces :code:`from manimlib.imports import *`
 #. Global dir variable handling has been removed. Instead :code:`initialize_directories`, if needed, overrides the values from the cfg files at runtime.
-
-
-

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -123,21 +123,6 @@ class Scene(Container):
     def __str__(self):
         return self.__class__.__name__
 
-    def set_variables_as_attrs(self, *objects, **newly_named_objects):
-        """
-        This method is slightly hacky, making it a little easier
-        for certain methods (typically subroutines of construct)
-        to share local variables.
-        """
-        caller_locals = inspect.currentframe().f_back.f_locals
-        for key, value in list(caller_locals.items()):
-            for o in objects:
-                if value is o:
-                    setattr(self, key, value)
-        for key, value in list(newly_named_objects.items()):
-            setattr(self, key, value)
-        return self
-
     def get_attrs(self, *keys):
         """
         Gets attributes of a scene given the attribute's identifier/name.


### PR DESCRIPTION
## List of Changes
- remove Scene.set_variables_as_attrs()

## Motivation
I find this method very very niche, un-pythonic, and honestly fairly unnecessary. It is also never used in the rest of the codebase, it's meant to be purely user-facing. But without documentation, I doubt that anyone is actually using it.

## Explanation for Changes
The intended use case of this method seems to be when there are many variables that are local to the `construct` method of `Scene` and the user may want to quickly set them all as attributes, so that other methods can access them.
```python
class MyScene(Scene):
    def construct(self):
        var1, var2, var3, var4 = Mobject(), Mobject(), Mobject(), Mobject()
        self.set_variables_as_attrs(var1, var2, var3, var4)
    def some_other_method(self):
        # can now access self.var1, self.var2, etc
```

If something like this is necessary, we can now encourage the use of `VDict` instead:
```python
class MyScene(Scene):
    def construct(self):
        var1, var2, var3, var4 = Mobject(), Mobject(), Mobject(), Mobject()
        self.my_vars = VDict({"var1": var1, "var2": var2, "var3": var3, "var4": var4})
    def some_other_method(self):
        # can now access self.my_vars["var1"]
```

Or simply add each variable manually.

## Further Comments
I think the question of whether or not we should remove this has to do with what kind of code we want to encourage. Do we want to encourage the user to define a ton of variables and pass them around to a lot of methods, therefore necessitating a lot of instance attributes? Or do we want to encourage modularity, separation of concerns, encapsulation, etc? 
