### PR TITLE
Fix docs build directory

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,12 +5,14 @@
 # from the environment for the first two.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = source
-BUILDDIR      = build
+
+# Path base is the source directory
+SOURCEDIR     = .
+BUILDDIR      = ../build
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@(cd source; $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O))
 
 .PHONY: help Makefile
 
@@ -23,4 +25,4 @@ cleanall: clean
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@(cd source; $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O))

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,7 +1,6 @@
 @ECHO OFF
 
-pushd %~dp0
-pushd source
+pushd %~dp0\source
 
 REM Command file for Sphinx documentation
 
@@ -35,5 +34,4 @@ goto end
 %SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 
 :end
-popd
 popd

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,6 +1,7 @@
 @ECHO OFF
 
-pushd %~dp0/source
+pushd %~dp0
+pushd source
 
 REM Command file for Sphinx documentation
 
@@ -34,4 +35,5 @@ goto end
 %SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 
 :end
+popd
 popd

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,14 +1,16 @@
 @ECHO OFF
 
-pushd %~dp0
+pushd %~dp0/source
 
 REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
-set SOURCEDIR=source
-set BUILDDIR=build
+
+REM The paths are taken from the source directory
+set SOURCEDIR=.
+set BUILDDIR=..\build
 
 if "%1" == "" goto help
 


### PR DESCRIPTION
A bug appeared with examples which used files in the _static folder.
If you used the make files, the build was launched from the docs/ folder.
But readthedocs builds everything from the docs/source/ folder. So we cannot have static path on the examples and build from the docs/ folder at the same time.

## Changes
Makefile and make.cmd now work from docs/source/ folder instead of docs/.


## Testing Status
The make.cmd file **HAS NOT BEEN TESTED ON WINDOWS**, so i hope someone from @ManimCommunity/windows  can test it. If you do so (and everything works), feel free to undraft the PR and merge it.

## Acknowledgement
- [X] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
