### PR TITLE
Fix assertion message in ImageMobject interpolation

### DIFF
--- a/manim/mobject/types/image_mobject.py
+++ b/manim/mobject/types/image_mobject.py
@@ -187,7 +187,7 @@ class ImageMobject(AbstractImageMobject):
         assert mobject1.pixel_array.shape == mobject2.pixel_array.shape, (
             f"Mobject pixel array shapes incompatible for interpolation.\n"
             f"Mobject 1 ({mobject1}) : {mobject1.pixel_array.shape}\n"
-            f"Mobject 2 ({mobject2}) : {mobject1.pixel_array.shape}"
+            f"Mobject 2 ({mobject2}) : {mobject2.pixel_array.shape}"
         )
         self.pixel_array = interpolate(
             mobject1.pixel_array, mobject2.pixel_array, alpha
@@ -229,7 +229,7 @@ class ImageMobjectFromCamera(AbstractImageMobject):
         assert mobject1.pixel_array.shape == mobject2.pixel_array.shape, (
             f"Mobject pixel array shapes incompatible for interpolation.\n"
             f"Mobject 1 ({mobject1}) : {mobject1.pixel_array.shape}\n"
-            f"Mobject 2 ({mobject2}) : {mobject1.pixel_array.shape}"
+            f"Mobject 2 ({mobject2}) : {mobject2.pixel_array.shape}"
         )
         self.pixel_array = interpolate(
             mobject1.pixel_array, mobject2.pixel_array, alpha


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
<!-- List out your changes one by one like this:
- Change 1
- Change 2
- and so on..

Be sure to note your changes in the [changelog](docs/source/changelog.rst) if your
changes warrant it!
-->
- Replaced `mobject1` with `mobject2` where the latter was meant but the former was used in the `ImageMobject.interpolate_color` method

## Motivation
<!-- Why you feel your changes are required. -->
When I tried to transform an image to another it spat out that their pixel array shapes weren't compatible but showed that they had the same shape in the assert message when they in fact did not.

## Explanation for Changes
<!-- How do your changes solve aforementioned problems? -->
Now it will show the correct shapes, showing that they are in fact not equal.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
