### PR TITLE
Enable rendering type hints (PEP 484)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,6 +64,10 @@ extensions = [
 # Automatically generate stub pages when using the .. autosummary directive
 autosummary_generate = True
 
+# generate documentation from type hints
+autodoc_typehints = 'description'
+autoclass_content = 'both'
+
 # controls whether functions documented by the autofunction directive
 # appear with their full module names
 add_module_names = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,8 +65,8 @@ extensions = [
 autosummary_generate = True
 
 # generate documentation from type hints
-autodoc_typehints = 'description'
-autoclass_content = 'both'
+autodoc_typehints = "description"
+autoclass_content = "both"
 
 # controls whether functions documented by the autofunction directive
 # appear with their full module names


### PR DESCRIPTION
## List of Changes
This PR makes Sphinx process type hints in the same way that is currently recommended in our guidelines.

## Motivation
If someone chooses to document code using PEP 484-style type hints, we should respect (and actually encourage) that. The chances for users getting these type hints right is a lot better than requiring a specific syntax in a string, as the IDE can help with completion in the former case.

## Explanation for Changes
As an example: adding a method like
```py
from typing import Optional

class SomeAwesomeManimClass:
    def test(self, a: int, b: Mobject, c: Optional[int] = 42) -> Mobject:
        r"""This is a small test function to see what type annotations
        are doing.

        This is where a more detailed description would go.

        Parameters
        ----------

        a
            This is documentation for a.
        b
            Some documentation for b.
        c
            And c is an optional parameter.
        """
        pass
```

renders in the docs as

![image](https://user-images.githubusercontent.com/11851593/99076785-030a0600-25bc-11eb-9edf-da88200209d8.png)

## Further Comments
The one thing that is currently not possible it seems, is to make the references in the type hints render with their (short) name instead of their fully qualified one. See https://github.com/sphinx-doc/sphinx/issues/7119 -- but I think we should still enable rendering from type hints.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
