### PR TITLE
Add links from reference manual to source code on GitHub

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,6 +57,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
+    "sphinx.ext.linkcode",
     "sphinxext.opengraph",
     "manim_directive",
 ]
@@ -103,6 +104,18 @@ html_static_path = ["_static"]
 
 # This specifies any additional css files that will override the theme's
 html_css_files = ["custom.css"]
+
+# source links to github
+def linkcode_resolve(domain, info):
+    if domain != 'py':
+        return None
+    if not info['module']:
+        return None
+    filename = info['module'].replace('.', '/')
+    version = os.getenv("READTHEDOCS_VERSION", "master")
+    if version == "latest":
+        version = "master"
+    return f"https://github.com/ManimCommunity/manim/blob/{version}/{filename}.py"
 
 # external links
 extlinks = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,15 +107,16 @@ html_css_files = ["custom.css"]
 
 # source links to github
 def linkcode_resolve(domain, info):
-    if domain != 'py':
+    if domain != "py":
         return None
-    if not info['module']:
+    if not info["module"]:
         return None
-    filename = info['module'].replace('.', '/')
+    filename = info["module"].replace(".", "/")
     version = os.getenv("READTHEDOCS_VERSION", "master")
     if version == "latest":
         version = "master"
     return f"https://github.com/ManimCommunity/manim/blob/{version}/{filename}.py"
+
 
 # external links
 extlinks = {


### PR DESCRIPTION
## List of Changes
- Enable links from reference manual to source code on GitHub

## Explanation for Changes
The actual work is carried out by the `codelink` extension of Sphinx, in order to work the function `linkcode_resolve` is added. The way this is currently written ensures (in theory) that deployed documentation at RTD links to the correct versions, and when building everywhere else it links to our current master.

## Testing Status
Links work in locally built documentation.

## Further Comments
It is not (easily?) possible to have correct links for documentation previews deployed from merge requests.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
