### PR TITLE
Be more flexible about installed Manim version in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7-slim
 
 ARG MANIM_VERSION=stable
 
-RUN apt-get update -q \
+RUN apt-get update -qq \
     && apt-get install --no-install-recommends -y \
         ffmpeg \
         gcc \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,12 +27,6 @@ RUN git clone --depth 1 --branch v0.1.0 https://github.com/ManimCommunity/manim.
 WORKDIR /opt/manim
 RUN pip install --no-cache .
 
-# ensure ffi bindings are generated correctly
-WORKDIR /usr/local/lib/python3.7/site-packages
-RUN python cairocffi/ffi_build.py \
-    && python pangocffi/ffi_build.py \
-    && python pangocairocffi/ffi_build.py
-
 # create working directory for user to mount local directory into
 WORKDIR /manim
 RUN chmod 666 /manim

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.7-slim
 
+ARG MANIM_VERSION=stable
+
 RUN apt-get update -q \
     && apt-get install --no-install-recommends -y \
         ffmpeg \
@@ -23,7 +25,7 @@ RUN wget -O /tmp/install-tl-unx.tar.gz http://mirror.ctan.org/systems/texlive/tl
         setspace standalone tipa wasy wasysym xcolor xkeyval
 
 # clone and build manim
-RUN git clone --depth 1 --branch v0.1.0 https://github.com/ManimCommunity/manim.git /opt/manim
+RUN git clone --depth 1 --branch ${MANIM_VERSION} https://github.com/ManimCommunity/manim.git /opt/manim
 WORKDIR /opt/manim
 RUN pip install --no-cache .
 


### PR DESCRIPTION
## List of Changes
- With #711 merged, we can also remove the workaround in the installation of the docker file
- This introduces a `MANIM_VERSION` build argument, moving us one step closer to automatic building of dockerfiles for `stable` and tagged releases.

## Testing Status
I've just pushed the image `manimcommunity/manim:experimental` that was built using `docker build --build-arg MANIM_VERSION=master . -t manimcommunity/manim:experimental` to dockerhub, after installing pytest in this image all tests pass. (This image thus corresponds to the current commit on master, 71d1fd0e4f2d9b0572e567471ea5dca98407e15e.)

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
