### PR TITLE
Fix importing files in the same directory as the input file

### DIFF
--- a/manim/utils/module_ops.py
+++ b/manim/utils/module_ops.py
@@ -35,6 +35,7 @@ def get_module(file_name):
             spec = importlib.util.spec_from_file_location(module_name, file_name)
             module = importlib.util.module_from_spec(spec)
             sys.modules[module_name] = module
+            sys.path.insert(0, str(file_name.parent.absolute()))
             spec.loader.exec_module(module)
             return module
         else:


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
<!-- List out your changes one by one like this:
- Change 1
- Change 2
- and so on..

Be sure to note your changes in the [changelog](docs/source/changelog.rst) if your
changes warrant it!
-->
- Added the input file's parent directory to `sys.path` before executing it, as the normal `python` command would. I tried a couple different things, like passing the absolute path of the input file instead of the relative path to `importlib.util.spec_from_file_location`, but I couldn't find anything else that worked besides this, which is unfortunate since it seems a little icky to be modifying manim's `sys.path` for the input file, but at least it works. I convert the absolute path of the parent directory to a string to be in line with how `sys.path` would be if executed with the `python` command, though I don't think it's necessary.

## Motivation
<!-- Why you feel your changes are required. -->
I created a custom mobject (is it pronounced em-ob-ject or mob-ject? because I use the latter) that I wanted to use in multiple scripts, so I put it in a `common.py` file, but when I tried to do `from common import *`, it yelled at me because it couldn't find the `common` module.

## Explanation for Changes
<!-- How do your changes solve aforementioned problems? -->
Adding the parent directory of the input file to `sys.path` allows python to look in that directory when resolving imports.

## Testing Status
<!-- Optional, but recommended, your computer specs and what tests you ran with their results, if any -->
I ran both a dummy test script that printed `sys.path` and tried to import my relative `common` module, and a real scene that I knew worked before, but now with my custom mobject imported from my `common` module, and both worked.

## Further Comments
<!-- Optional, any edits/updates should preferably be written here. -->
I noticed while perusing the code involving this stuff that you guys mix `os.path` code with `pathlib.Path` code, like using `os.path.exists(file_name)` instead of `file_name.exists()` and `os.path.abspath(file_name)` instead of `file_name.absolute()` and other stuff like that. Not really related much to this PR but maybe something to rework in the future.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
