### PR TITLE
Example Gallery: Remove z_index from the first example

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -32,27 +32,20 @@ Basic Concepts
 
     class ManimCELogo(Scene):
         def construct(self):
+            self.camera.background_color = "#ece6e2"
             logo_green = "#87c2a5"
             logo_blue = "#525893"
             logo_red = "#e07a5f"
-            ds_m = MathTex(r"\mathbb{M}", z_index=20).scale(7)
-            ds_m.shift(2.25*LEFT + 1.5*UP)
-            circle = Circle(color=logo_green,
-                            fill_opacity=1,
-                            z_index=7)
-            square = Square(color=logo_blue,
-                            fill_opacity=1,
-                            z_index=5)
-            triangle = Triangle(color=logo_red,
-                                fill_opacity=1,
-                                z_index=3)
-            circle.shift(LEFT)
-            square.shift(UP)
-            triangle.shift(RIGHT)
-            logo = VGroup(triangle, square, circle, ds_m) # order matters
+            logo_black = "#343434"
+            ds_m = MathTex(r"\mathbb{M}", fill_color=logo_black).scale(7)
+            ds_m.shift(2.25 * LEFT + 1.5 * UP)
+            circle = Circle(color=logo_green, fill_opacity=1).shift(LEFT)
+            square = Square(color=logo_blue, fill_opacity=1).shift(UP)
+            triangle = Triangle(color=logo_red, fill_opacity=1).shift(RIGHT)
+            logo = VGroup(triangle, square, circle, ds_m)  # order matters
             logo.move_to(ORIGIN)
             self.add(logo)
-            self.wait()
+
 
 .. manim:: GradientImageFromArray
     :save_last_frame:


### PR DESCRIPTION
I just realized something in this example:
https://docs.manim.community/en/latest/examples.html#manimcelogo
As soon as one uses VGroup, the zindex informatation will be removed.
Here is the code:
```py
class ManimCELogo(Scene):
    def construct(self):
        logo_green = "#87c2a5"
        logo_blue = "#525893"
        logo_red = "#e07a5f"
        ds_m = MathTex(r"\mathbb{M}", z_index=20).scale(7)
        ds_m.shift(2.25*LEFT + 1.5*UP)
        circle = Circle(color=logo_green,
                        fill_opacity=1,
                        z_index=7)
        square = Square(color=logo_blue,
                        fill_opacity=1,
                        z_index=5)
        triangle = Triangle(color=logo_red,
                            fill_opacity=1,
                            z_index=3)
        circle.shift(LEFT)
        square.shift(UP)
        triangle.shift(RIGHT)
        logo = VGroup(triangle, square, circle, ds_m) # order matters
        logo.move_to(ORIGIN)
        self.add(logo)
        self.wait()
```
Note that the comment "# order matters" is in opposition to the use of z_index.
As this is the first example one sees in our gallery, this pr has the purpose to remove the z_index information.

Additionally, I thought it would be a good idea to change the background colour of this first example so that it fits with our logo