### PR TITLE
Return matrix rows correctly

### DIFF
--- a/manim/mobject/matrix.py
+++ b/manim/mobject/matrix.py
@@ -144,7 +144,7 @@ class Matrix(VMobject):
             Each VGroup contains a row of the matrix.
         """
         return VGroup(
-            *[VGroup(*self.mob_matrix[i, :]) for i in range(self.mob_matrix.shape[1])]
+            *[VGroup(*self.mob_matrix[i, :]) for i in range(self.mob_matrix.shape[0])]
         )
 
     def set_row_colors(self, *colors):


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes

-  Simple bug / typo fix in the `get_rows` method of `Matrix` object

## Explanation for Changes
<!-- How do your changes solve aforementioned problems? -->
#726 

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
