### PR TITLE
Fix 305: mobject.add should do input validation

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -96,6 +96,9 @@ class Mobject(Container):
         ------
         :class:`ValueError`
             When a mobject tries to add itself.
+        :class:`TypeError`
+            When trying to add an object that is not an instance of :class:`Mobject`.
+
 
         Notes
         -----
@@ -130,8 +133,11 @@ class Mobject(Container):
             ValueError: Mobject cannot contain self
 
         """
-        if self in mobjects:
-            raise ValueError("Mobject cannot contain self")
+        for m in mobjects:
+            if not isinstance(m, Mobject):
+                raise TypeError("All submobjects must be of type Mobject")
+            if m is self:
+                raise ValueError("Mobject cannot contain self")
         self.submobjects = list_update(self.submobjects, mobjects)
         return self
 
@@ -1242,7 +1248,5 @@ class Group(Mobject):
     """Groups together multiple Mobjects."""
 
     def __init__(self, *mobjects, **kwargs):
-        if not all([isinstance(m, Mobject) for m in mobjects]):
-            raise TypeError("All submobjects must be of type Mobject")
         Mobject.__init__(self, **kwargs)
         self.add(*mobjects)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -60,7 +60,7 @@ def test_mobject_add():
 
     # can only add Mobjects
     with pytest.raises(TypeError):
-        obj.add('foo')
+        obj.add("foo")
 
 
 def test_mobject_remove():

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -58,6 +58,10 @@ def test_mobject_add():
     with pytest.raises(ValueError):
         obj.add(obj)
 
+    # can only add Mobjects
+    with pytest.raises(TypeError):
+        obj.add('foo')
+
 
 def test_mobject_remove():
     """Test Mobject.remove()."""


### PR DESCRIPTION
## List of Changes
- Moved input validation from Group.__init__ to Mobject.add
- Added a test

## Motivation
Before, type was being checked only when a Group was created. If one called Group.add() after creation, there was no input validation.

## Further Comments
Closes #305
