### PR TITLE
Fix 321: get rid of "time-based" updaters

### DIFF
--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -60,7 +60,7 @@ class FocusOn(Transform):
     def create_target(self):
         little_dot = Dot(radius=0)
         little_dot.set_fill(self.color, opacity=self.opacity)
-        little_dot.add_updater(lambda d: d.move_to(self.focus_point))
+        little_dot.add_updater(lambda d, _: d.move_to(self.focus_point))
         return little_dot
 
     def create_starting_mobject(self):
@@ -116,7 +116,7 @@ class Flash(AnimationGroup):
             lines.add(line)
         lines.set_color(self.color)
         lines.set_stroke(width=3)
-        lines.add_updater(lambda l: l.move_to(self.point))
+        lines.add_updater(lambda l, _: l.move_to(self.point))
         return lines
 
     def create_line_anims(self):
@@ -139,7 +139,7 @@ class CircleIndicate(Indicate):
 
     def get_circle(self, mobject):
         circle = Circle(**self.circle_config)
-        circle.add_updater(lambda c: c.surround(mobject))
+        circle.add_updater(lambda c, _: c.surround(mobject))
         return circle
 
     def interpolate_mobject(self, alpha):
@@ -216,7 +216,7 @@ class AnimationOnSurroundingRectangle(AnimationGroup):
         self.mobject_to_surround = mobject
 
         rect = self.get_rect()
-        rect.add_updater(lambda r: r.move_to(mobject))
+        rect.add_updater(lambda r, _: r.move_to(mobject))
 
         super().__init__(
             self.rect_animation(rect, **kwargs),

--- a/manim/mobject/changing.py
+++ b/manim/mobject/changing.py
@@ -95,7 +95,7 @@ class TracedPath(VMobject):
                 dot = Dot(color=RED).move_to(circ.get_start())
                 rolling_circle = VGroup(circ, dot)
                 trace = TracedPath(circ.get_start)
-                rolling_circle.add_updater(lambda m: m.rotate(-0.3))
+                rolling_circle.add_updater(lambda m, _: m.rotate(-0.3))
                 self.add(trace, rolling_circle)
                 self.play(rolling_circle.shift, 8*RIGHT, run_time=4, rate_func=linear)
 
@@ -110,7 +110,7 @@ class TracedPath(VMobject):
     def __init__(self, traced_point_func, **kwargs):
         super().__init__(**kwargs)
         self.traced_point_func = traced_point_func
-        self.add_updater(lambda m: m.update_path())
+        self.add_updater(lambda m, _: m.update_path())
 
     def update_path(self):
         new_point = self.traced_point_func()

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -219,24 +219,11 @@ class Mobject(Container):
         if self.updating_suspended:
             return self
         for updater in self.updaters:
-            parameters = get_parameters(updater)
-            if "dt" in parameters:
-                updater(self, dt)
-            else:
-                updater(self)
+            updater(self, dt)
         if recursive:
             for submob in self.submobjects:
                 submob.update(dt, recursive)
         return self
-
-    def get_time_based_updaters(self):
-        return [updater for updater in self.updaters if "dt" in get_parameters(updater)]
-
-    def has_time_based_updater(self):
-        for updater in self.updaters:
-            if "dt" in get_parameters(updater):
-                return True
-        return False
 
     def get_updaters(self):
         return self.updaters

--- a/manim/mobject/mobject_update_utils.py
+++ b/manim/mobject/mobject_update_utils.py
@@ -30,7 +30,7 @@ def always(method, *args, **kwargs):
     assert_is_mobject_method(method)
     mobject = method.__self__
     func = method.__func__
-    mobject.add_updater(lambda m: func(m, *args, **kwargs))
+    mobject.add_updater(lambda m, _: func(m, *args, **kwargs))
     return mobject
 
 
@@ -44,7 +44,7 @@ def f_always(method, *arg_generators, **kwargs):
     mobject = method.__self__
     func = method.__func__
 
-    def updater(mob):
+    def updater(mob, _):
         args = [arg_generator() for arg_generator in arg_generators]
         func(mob, *args, **kwargs)
 
@@ -54,7 +54,7 @@ def f_always(method, *arg_generators, **kwargs):
 
 def always_redraw(func):
     mob = func()
-    mob.add_updater(lambda m: mob.become(func()))
+    mob.add_updater(lambda m, _: mob.become(func()))
     return mob
 
 

--- a/manim/mobject/numbers.py
+++ b/manim/mobject/numbers.py
@@ -27,8 +27,8 @@ class DecimalNumber(VMobject):
                 )
                 square = Square().to_edge(UP)
 
-                decimal.add_updater(lambda d: d.next_to(square, RIGHT))
-                decimal.add_updater(lambda d: d.set_value(square.get_center()[1]))
+                decimal.add_updater(lambda d, _: d.next_to(square, RIGHT))
+                decimal.add_updater(lambda d, _: d.set_value(square.get_center()[1]))
                 self.add(square, decimal)
                 self.play(
                     square.to_edge,
@@ -284,9 +284,9 @@ class Variable(VMobject):
         elif var_type == Integer:
             self.value = Integer(self.tracker.get_value())
 
-        self.value.add_updater(lambda v: v.set_value(self.tracker.get_value())).next_to(
-            self.label, RIGHT
-        )
+        self.value.add_updater(
+            lambda v, _: v.set_value(self.tracker.get_value())
+        ).next_to(self.label, RIGHT)
 
         VMobject.__init__(self, **kwargs)
         self.add(self.label, self.value)

--- a/manim/mobject/value_tracker.py
+++ b/manim/mobject/value_tracker.py
@@ -26,11 +26,11 @@ class ValueTracker(Mobject):
             def construct(self):
                 number_line = NumberLine()
                 pointer = Vector(DOWN)
-                label = MathTex("x").add_updater(lambda m: m.next_to(pointer, UP))
+                label = MathTex("x").add_updater(lambda m, _: m.next_to(pointer, UP))
 
                 pointer_value = ValueTracker(0)
                 pointer.add_updater(
-                    lambda m: m.next_to(
+                    lambda m, _: m.next_to(
                                 number_line.n2p(pointer_value.get_value()),
                                 UP
                             )

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -163,7 +163,7 @@ class Scene(Container):
             bool
         """
         return self.always_update_mobjects or any(
-            [mob.has_time_based_updater() for mob in self.get_mobject_family_members()]
+            len(mob.updaters) > 0 for mob in self.get_mobject_family_members()
         )
 
     def get_top_level_mobjects(self):

--- a/tests/test_graphical_units/test_updaters.py
+++ b/tests/test_graphical_units/test_updaters.py
@@ -10,7 +10,7 @@ class UpdaterTest(Scene):
         dot = Dot()
         square = Square()
         self.add(dot, square)
-        square.add_updater(lambda m: m.next_to(dot, RIGHT, buff=SMALL_BUFF))
+        square.add_updater(lambda m, _: m.next_to(dot, RIGHT, buff=SMALL_BUFF))
         self.add(square)
         self.play(dot.shift, UP * 2)
         square.clear_updaters()


### PR DESCRIPTION
As noted in #321, it seems very unnecessary to have two different signatures for updaters: `func(obj)` and `func(obj, dt)`. Besides, the implementation using the inspect module was _very_ slow and was adding a lot of unnecessary overheard to all scenes.

## List of Changes
- Get rid of time-based updaters. Now all updaters must accept two parameters.

Closes #321 

cc @kolibril13 I feel you have a lot of experience with updaters. Could you please take a look? Thanks