### PR TITLE
Fix "-" as filename feature.

### DIFF
--- a/manim/utils/module_ops.py
+++ b/manim/utils/module_ops.py
@@ -9,7 +9,7 @@ import re
 
 
 def get_module(file_name):
-    if file_name == "-":
+    if str(file_name) == "-":
         module = types.ModuleType("input_scenes")
         logger.info(
             "Enter the animation's code & end with an EOF (CTRL+D on Linux/Unix, CTRL+Z on Windows):"


### PR DESCRIPTION
## List of Changes
- Convert `file_name` to string before comparing in `get_module`

## Motivation
Fixes #667 

## Explanation for Changes
The path handling system was modified to make use of `pathlib`, so `file_name` wasn't a string when it was being compared with `-` in `get_module`. This has been fixed by typecasting `file_name` to a string.

## Testing Status
Tested on MacOS Big Sur with Python3.9

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))