### PR TITLE
Fix 749: frame_height and frame_width can't be set via config file

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -516,6 +516,7 @@ class ManimConfig(MutableMapping):
             "upto_animation_number",
             "frame_rate",
             "max_files_cached",
+            # the next two must be set BEFORE digesting frame_width and frame_height
             "pixel_height",
             "pixel_width",
         ]:
@@ -542,15 +543,23 @@ class ManimConfig(MutableMapping):
             setattr(self, key, parser["CLI"].get(key, fallback="", raw=True))
 
         # float keys
-        for key in ["background_opacity"]:
+        for key in [
+                "background_opacity",
+                # the next two are floats but have their own logic, applied later
+                # "frame_width",
+                # "frame_height",
+        ]:
             setattr(self, key, parser["CLI"].getfloat(key))
 
-        # other logic
-        self["frame_height"] = 8.0
-        self["frame_width"] = (
-            self["frame_height"] * self["pixel_width"] / self["pixel_height"]
-        )
+        # the next two must be set AFTER digesting pixel_width and pixel_height
+        self["frame_height"] = parser["CLI"].getfloat("frame_height", 8.0)
+        width = parser["CLI"].getfloat("frame_width", None)
+        if width is None:
+            self["frame_width"] = self["frame_height"] * self["aspect_ratio"]
+        else:
+            self["frame_width"] = width
 
+        # other logic
         val = parser["CLI"].get("tex_template_file")
         if val:
             setattr(self, "tex_template_file", val)

--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -544,10 +544,10 @@ class ManimConfig(MutableMapping):
 
         # float keys
         for key in [
-                "background_opacity",
-                # the next two are floats but have their own logic, applied later
-                # "frame_width",
-                # "frame_height",
+            "background_opacity",
+            # the next two are floats but have their own logic, applied later
+            # "frame_width",
+            # "frame_height",
         ]:
             setattr(self, key, parser["CLI"].getfloat(key))
 


### PR DESCRIPTION
Closes #749 

## List of Changes
Implemented the following logic:
1. default height and width are left at 8.0 and 14.222221
2. if only one is set via config file, the other will be set using the value of aspect_ratio. Note this aspect_ratio is set using the values of pixel_height and pixel_width
3. If both are set, those values are used and aspect_ratio is ignored

## Further Comments
Thanks to @ponmike92 for reporting.
