### PR TITLE
Cleanup Scene: remove some unpythonic or niche methods

### DIFF
--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -177,14 +177,13 @@ class Scene(Container):
         """
         # Return only those which are not in the family
         # of another mobject from the scene
-        mobjects = self.get_mobjects()
-        families = [m.get_family() for m in mobjects]
+        families = [m.get_family() for m in self.mobjects]
 
         def is_top_level(mobject):
             num_families = sum([(mobject in family) for family in families])
             return num_families == 1
 
-        return list(filter(is_top_level, mobjects))
+        return list(filter(is_top_level, self.mobjects))
 
     def get_mobject_family_members(self):
         """
@@ -221,15 +220,6 @@ class Scene(Container):
         mobjects = [*mobjects, *self.foreground_mobjects]
         self.restructure_mobjects(to_remove=mobjects)
         self.mobjects += mobjects
-        return self
-
-    def add_mobjects_among(self, values):
-        """
-        This is meant mostly for quick prototyping,
-        e.g. to add all mobjects defined up to a point,
-        call self.add_mobjects_among(locals().values())
-        """
-        self.add(*filter(lambda m: isinstance(m, Mobject), values))
         return self
 
     def add_mobjects_from_animations(self, animations):
@@ -459,30 +449,6 @@ class Scene(Container):
         self.foreground_mobjects = []
         return self
 
-    def get_mobjects(self):
-        """
-        Returns all the mobjects in self.mobjects
-
-        Returns
-        ------
-        list
-            The list of self.mobjects .
-        """
-        return list(self.mobjects)
-
-    def get_mobject_copies(self):
-        """
-        Returns a copy of all mobjects present in
-        self.mobjects .
-
-        Returns
-        ------
-        list
-            A list of the copies of all the mobjects
-            in self.mobjects
-        """
-        return [m.copy() for m in self.mobjects]
-
     def get_moving_mobjects(self, *animations):
         """
         Gets all moving mobjects in the passed animation(s).
@@ -654,7 +620,7 @@ class Scene(Container):
         )
         return time_progression
 
-    def get_animation_time_progression(self, animations):
+    def _get_animation_time_progression(self, animations):
         """
         You will hardly use this when making your own animations.
         This method is for Manim's internal use.
@@ -687,7 +653,7 @@ class Scene(Container):
         )
         return time_progression
 
-    def get_wait_time_progression(self, duration, stop_condition):
+    def _get_wait_time_progression(self, duration, stop_condition):
         """
         This method is used internally to obtain the CommandLine
         Progressbar for when self.wait() is called in a scene.
@@ -803,7 +769,7 @@ class Scene(Container):
             duration = animations[0].duration
             stop_condition = animations[0].stop_condition
             self.static_image = None
-            time_progression = self.get_wait_time_progression(duration, stop_condition)
+            time_progression = self._get_wait_time_progression(duration, stop_condition)
         else:
             # Paint all non-moving objects onto the screen, so they don't
             # have to be rendered every frame
@@ -813,7 +779,7 @@ class Scene(Container):
             ) = self.get_moving_and_stationary_mobjects(animations)
             self.renderer.update_frame(self, mobjects=stationary_mobjects)
             self.static_image = self.renderer.get_frame()
-            time_progression = self.get_animation_time_progression(animations)
+            time_progression = self._get_animation_time_progression(animations)
 
         last_t = 0
         for t in time_progression:

--- a/manim/utils/caching.py
+++ b/manim/utils/caching.py
@@ -32,7 +32,7 @@ def handle_caching_play(func):
             self.file_writer.add_partial_movie_file(None)
             return
         if not config["disable_caching"]:
-            mobjects_on_scene = scene.get_mobjects()
+            mobjects_on_scene = scene.mobjects
             hash_play = get_hash_from_play_call(
                 self, self.camera, animations, mobjects_on_scene
             )


### PR DESCRIPTION
## Motivation
All the removed methods seem either very niche, or outright useless.

## Testing Status
Local pass.

## Further Comments
Strictly speaking, these are all breaking changes, but I think it's safe to just remove them. Perhaps with the exception of Scene.get_mobjects, I don't think anyone is using these.
