### PR TITLE
Remove unused imports

### DIFF
--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -1,10 +1,8 @@
 import os
-import platform
 import sys
 import traceback
 
-from manim import constants, logger, console, config
-from manim import Scene
+from manim import logger, config
 from manim.utils.module_ops import (
     get_module,
     get_scene_classes_from_module,

--- a/manim/_config/cfg_subcmds.py
+++ b/manim/_config/cfg_subcmds.py
@@ -10,7 +10,7 @@ The functions below can be called via the `manim cfg` subcommand.
 import os
 from ast import literal_eval
 
-from manim import logger, console, config
+from manim import console, config
 from manim._config.utils import config_file_paths, make_config_parser
 from manim.utils.file_ops import guarantee_existence, open_file
 

--- a/manim/_config/main_utils.py
+++ b/manim/_config/main_utils.py
@@ -1,16 +1,9 @@
 """Utilities called from ``__main__.py`` to interact with the config."""
 
 import os
-import sys
 import argparse
-import logging
 
-import colour
-
-from manim import constants, logger, config
-from .utils import make_config_parser
-from .logger_utils import JSONFormatter
-from ..utils.tex import TexTemplate, TexTemplateFromFile
+from manim import constants
 
 
 __all__ = ["parse_args"]

--- a/manim/animation/composition.py
+++ b/manim/animation/composition.py
@@ -3,7 +3,6 @@ import numpy as np
 
 from ..animation.animation import Animation
 from ..mobject.mobject import Group
-from ..utils.bezier import integer_interpolate
 from ..utils.bezier import interpolate
 from ..utils.config_ops import digest_config
 from ..utils.iterables import remove_list_redundancies

--- a/manim/camera/camera.py
+++ b/manim/camera/camera.py
@@ -20,11 +20,10 @@ from ..mobject.types.image_mobject import AbstractImageMobject
 from ..mobject.mobject import Mobject
 from ..mobject.types.point_cloud_mobject import PMobject
 from ..mobject.types.vectorized_mobject import VMobject
-from ..utils.color import color_to_int_rgba, BLACK
+from ..utils.color import color_to_int_rgba
 from ..utils.config_ops import digest_config
 from ..utils.images import get_full_raster_image_path
 from ..utils.iterables import list_difference_update
-from ..utils.iterables import remove_list_redundancies
 from ..utils.simple_functions import fdiv
 from ..utils.space_ops import angle_of_vector
 from ..utils.space_ops import get_norm

--- a/manim/camera/three_d_camera.py
+++ b/manim/camera/three_d_camera.py
@@ -15,7 +15,6 @@ from ..mobject.three_d_utils import get_3d_vmob_start_corner_unit_normal
 from ..mobject.types.point_cloud_mobject import Point
 from ..mobject.value_tracker import ValueTracker
 from ..utils.color import get_shaded_rgb
-from ..utils.simple_functions import clip_in_place
 from ..utils.space_ops import rotation_about_z
 from ..utils.space_ops import rotation_matrix
 from ..utils.family import extract_mobject_family_members
@@ -281,7 +280,6 @@ class ThreeDCamera(Camera):
             else:
                 factor = distance / (distance - zs)
                 factor[(distance - zs) < 0] = 10 ** 6
-                # clip_in_place(factor, 0, 10**6)
             points[:, i] *= factor
         points = points + frame_center
         return points

--- a/manim/grpc/impl/frame_server_impl.py
+++ b/manim/grpc/impl/frame_server_impl.py
@@ -1,12 +1,10 @@
 from ... import config
-from ...scene import scene
 from ..gen import frameserver_pb2
 from ..gen import frameserver_pb2_grpc
 from ..gen import renderserver_pb2
 from ..gen import renderserver_pb2_grpc
 from concurrent import futures
-from google.protobuf import json_format
-from watchdog.events import LoggingEventHandler, FileSystemEventHandler
+from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 import grpc
 import subprocess as sp

--- a/manim/mobject/coordinate_systems.py
+++ b/manim/mobject/coordinate_systems.py
@@ -14,7 +14,6 @@ from ..mobject.geometry import Line
 from ..mobject.number_line import NumberLine
 from ..mobject.svg.tex_mobject import MathTex
 from ..mobject.types.vectorized_mobject import VGroup
-from ..utils.config_ops import digest_config
 from ..utils.config_ops import merge_dicts_recursively
 from ..utils.simple_functions import binary_search
 from ..utils.space_ops import angle_of_vector

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -57,12 +57,11 @@ import pangocffi
 
 from ... import config, logger
 from ...constants import *
-from ...container import Container
-from ...mobject.geometry import Dot, Rectangle
+from ...mobject.geometry import Dot
 from ...mobject.svg.svg_mobject import SVGMobject
 from ...mobject.types.vectorized_mobject import VGroup
 from ...utils.config_ops import digest_config
-from ...utils.color import WHITE, BLACK
+from ...utils.color import WHITE
 
 TEXT_MOB_SCALE_FACTOR = 0.05
 

--- a/manim/renderer/cairo_renderer.py
+++ b/manim/renderer/cairo_renderer.py
@@ -2,7 +2,6 @@ import numpy as np
 from .. import config
 from ..utils.iterables import list_update
 from ..utils.exceptions import EndSceneEarlyException
-from ..constants import DEFAULT_WAIT_TIME
 from ..scene.scene_file_writer import SceneFileWriter
 from ..utils.caching import handle_caching_play
 from ..camera.camera import Camera

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -8,21 +8,18 @@ import inspect
 import random
 import warnings
 import platform
-import copy
 
 from tqdm import tqdm as ProgressDisplay
 import numpy as np
 
 from .. import config, logger
 from ..animation.animation import Animation, Wait
-from ..animation.transform import MoveToTarget, ApplyMethod
+from ..animation.transform import MoveToTarget
 from ..camera.camera import Camera
 from ..constants import *
 from ..container import Container
 from ..mobject.mobject import Mobject
-from ..scene.scene_file_writer import SceneFileWriter
 from ..utils.iterables import list_update, list_difference_update
-from ..utils.hashing import get_hash_from_play_call, get_hash_from_wait_call
 from ..utils.family import extract_mobject_family_members
 from ..renderer.cairo_renderer import CairoRenderer
 from ..utils.exceptions import EndSceneEarlyException

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -8,13 +8,12 @@ from pydub import AudioSegment
 import shutil
 import subprocess
 import os
-import _thread as thread
 from time import sleep
 import datetime
 from PIL import Image
 from pathlib import Path
 
-from .. import config, logger, console
+from .. import config, logger
 from ..constants import FFMPEG_BIN, GIF_FILE_EXTENSION
 from ..utils.config_ops import digest_config
 from ..utils.file_ops import guarantee_existence

--- a/manim/scene/three_d_scene.py
+++ b/manim/scene/three_d_scene.py
@@ -308,11 +308,11 @@ class SpecialThreeDScene(ThreeDScene):
     def __init__(self, **kwargs):
         digest_config(self, kwargs)
         if self.renderer.camera_config["pixel_width"] == config["pixel_width"]:
-            config = {}
+            _config = {}
         else:
-            config = self.low_quality_config
-        config = merge_dicts_recursively(config, kwargs)
-        ThreeDScene.__init__(self, **config)
+            _config = self.low_quality_config
+        _config = merge_dicts_recursively(_config, kwargs)
+        ThreeDScene.__init__(self, **_config)
 
     def get_axes(self):
         """Return a set of 3D axes.

--- a/manim/utils/caching.py
+++ b/manim/utils/caching.py
@@ -1,6 +1,5 @@
 from .. import config, logger
-from ..utils.hashing import get_hash_from_play_call, get_hash_from_wait_call
-from ..constants import DEFAULT_WAIT_TIME
+from ..utils.hashing import get_hash_from_play_call
 
 
 def handle_caching_play(func):

--- a/manim/utils/tex.py
+++ b/manim/utils/tex.py
@@ -6,7 +6,6 @@ __all__ = [
 ]
 
 
-import os
 import re
 
 


### PR DESCRIPTION
Title. General cleanup. Easy review.

## List of Changes
- Removed unused imports. These were found by running `pylint --disable=all --enable=unused-import`
- There is one function that was defining a local variable caleld `config`, which was occluding the global `config`. I renamed it to `_config`.
- There is one `unused-import` left. This is an import that is not used in the code of its module, but it is used in the docstrings/examples. So the linter cannot catch it, but it is still necessary.

## Motivation
Linter is driving me crazy.
