### PR TITLE
Add missing returns

### DIFF
--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -395,7 +395,7 @@ class Circle(Arc):
         self.replace(mobject, dim_to_match, stretch)
 
         self.set_width(np.sqrt(mobject.get_width() ** 2 + mobject.get_height() ** 2))
-        self.scale(buffer_factor)
+        return self.scale(buffer_factor)
 
     def point_at_angle(self, angle):
         start_angle = angle_of_vector(self.points[0] - self.get_center())
@@ -628,10 +628,10 @@ class Line(TipableVMobject):
         return np.tan(self.get_angle())
 
     def set_angle(self, angle):
-        self.rotate(angle - self.get_angle(), about_point=self.get_start())
+        return self.rotate(angle - self.get_angle(), about_point=self.get_start())
 
     def set_length(self, length):
-        self.scale(length / self.get_length())
+        return self.scale(length / self.get_length())
 
     def set_opacity(self, opacity, family=True):
         # Overwrite default, which would set


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
<!-- List out your changes one by one like this:-->
- Added missing `return`s in `Line.set_angle`, `Line.set_length` and `Circle.surround` methods.

## Motivation
<!-- Why you feel your changes are required. -->
Code as simple as `self.add(Line().set_length(<length>))` throws `AttributeError: 'NoneType' object has no attribute 'z_index'` because of missing returns. Same is the case with other methods mentioned above.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
