### PR TITLE
Update default_coordinate_labels

### DIFF
--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -150,6 +150,7 @@ class NumberLine(Line):
         numbers = np.arange(
             np.floor(self.leftmost_tick),
             np.ceil(self.x_max),
+            self.tick_frequency,
         )
         if self.exclude_zero_from_default_numbers:
             numbers = numbers[numbers != 0]


### PR DESCRIPTION
Supports changes in the config, specifically tick_frequency. Before, it would bundle up and always assume a tick spacing of 1. After the change, it looks cleaner and is able to display the numbers neatly without any additional calls in a Scene class.

<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
- Added tick_frequency as an arg to np.arange in NumberLine

## Motivation
<!-- Why you feel your changes are required. -->
This makes it easier to get an Axes object labelled properly and neatly.

## Explanation for Changes
<!-- How do your changes solve aforementioned problems? -->
This change allows making labelling easier for any object that uses NumberLine 

## Testing Status
<!-- Optional, but recommended, your computer specs and what tests you ran with their results, if any -->

<details><summary>Images/GIFs</summary>

Before: ![alt text](https://i.imgur.com/CxmstNx.png)
After: ![alt text](https://i.imgur.com/Y0gUDlo.png)

</details>




## Further Comments
<!-- Optional, any edits/updates should preferably be written here. -->

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

<!-- Once again, thanks for helping out by contributing to manim! -->
