### PR TITLE
Added copyright message to docs

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -4,7 +4,9 @@ Example Gallery
 
 This gallery contains a collection of best practice code snippets
 together with their corresponding video/image output, illustrating
-different functionalities all across the library. Enjoy this taste of Manim!
+different functionalities all across the library.
+These are all under the MIT licence, so feel free to copy & paste them to your projects.
+Enjoy this taste of Manim!
 
 .. tip::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,9 @@ This project is still very much a work in progress, but I hope that the
 information here will make it easier for newcomers to get started using
 ``Manim``.
 
+.. tip:: All content of the docs are under MIT license. Especially for the examples you encounter:
+Feel free to use this code in your own projects!
+
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,8 +15,10 @@ This project is still very much a work in progress, but I hope that the
 information here will make it easier for newcomers to get started using
 ``Manim``.
 
-.. tip:: All content of the docs are under MIT license. Especially for the examples you encounter:
-Feel free to use this code in your own projects!
+.. tip:: 
+
+    All content of the docs is licensed under the MIT license. Especially for the examples
+    you encounter: Feel free to use this code in your own projects!
 
 
 .. toctree::


### PR DESCRIPTION
Added a copyright message to the docs starting page and to the example page.
One thing to note regarding licence:
https://tldrlegal.com/license/mit-license
I think we want to use the MIT license, but on this page, I found, the sentence:
"You must include the copyright notice in all copies or substantial uses of the work."
But I think we do not want people to put in a copyright notice to everything they made with manim, do we?
