### PR TITLE
fix dvisvgm error when converting pdfs

### DIFF
--- a/manim/utils/tex.py
+++ b/manim/utils/tex.py
@@ -47,7 +47,6 @@ class TexTemplate:
     default_preamble = r"""
 \usepackage[english]{babel}
 \usepackage[utf8]{inputenc}
-\usepackage[T1]{fontenc}
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{dsfont}


### PR DESCRIPTION
There is a flaw in the latex template we inherited from 3b1b.

I came across it while investigating problems I had with dviscgm (https://github.com/mgieseki/dvisvgm/issues/145) and now I see others encountering it in the discord chat.

This PR is a quick fix. 
