### PR TITLE
fix 780

### DIFF
--- a/manim/mobject/coordinate_systems.py
+++ b/manim/mobject/coordinate_systems.py
@@ -342,7 +342,7 @@ class NumberPlane(Axes):
             The axis with which the lines will be perpendicular.
 
         ratio_faded_lines : :class:`float`
-            The ratio between the space between faded lines and the space between non-faded line.
+            The ratio between the space between faded lines and the space between non-faded lines.
 
         freq : :class:`float`
             Frequency of non-faded lines (number of non-faded lines per graph unit).

--- a/manim/mobject/coordinate_systems.py
+++ b/manim/mobject/coordinate_systems.py
@@ -342,7 +342,7 @@ class NumberPlane(Axes):
             The axis with which the lines will be perpendicular.
 
         ratio_faded_lines : :class:`float`
-            The number of faded lines between each non-faded line.
+            The ratio between the space between faded lines and the space between non-faded line.
 
         freq : :class:`float`
             Frequency of non-faded lines (number of non-faded lines per graph unit).
@@ -353,8 +353,9 @@ class NumberPlane(Axes):
             The first (i.e the non-faded lines parallel to `axis_parallel_to`) and second (i.e the faded lines parallel to `axis_parallel_to`) sets of lines, respectively.
         """
         line = Line(axis_parallel_to.get_start(), axis_parallel_to.get_end())
-        dense_freq = ratio_faded_lines
-        step = (1 / dense_freq) * freq
+        if ratio_faded_lines == 0:  # don't show faded lines
+            ratio_faded_lines = 1  # i.e. set ratio to 1
+        step = (1 / ratio_faded_lines) * freq
         lines1 = VGroup()
         lines2 = VGroup()
         unit_vector_axis_perp_to = axis_perpendicular_to.get_unit_vector()

--- a/manim/scene/vector_space_scene.py
+++ b/manim/scene/vector_space_scene.py
@@ -546,7 +546,7 @@ class LinearTransformationScene(VectorScene):
             "x_min": -config["frame_width"] / 2,
             "y_max": config["frame_width"] / 2,
             "y_min": -config["frame_width"] / 2,
-            "faded_line_ratio": 0,
+            "faded_line_ratio": 1,
         }
 
     def setup(self):


### PR DESCRIPTION
This PR fixes a divide-by-zero error described in issue 780. https://github.com/ManimCommunity/manim/issues/780
The problem is the default value of `faded_line_ratio` being set to 0 instead of 1.

Closes #780