### PR TITLE
Add skip-manim tag when building the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,6 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
 import os
-import subprocess
 import sys
 from distutils.sysconfig import get_python_lib
 from pathlib import Path

--- a/docs/source/manim_directive.py
+++ b/docs/source/manim_directive.py
@@ -89,7 +89,7 @@ class skip_manim_node(nodes.Admonition, nodes.Element):
     pass
 
 
-def visit(self, node, name=''):
+def visit(self, node, name=""):
     self.visit_admonition(node, name)
 
 
@@ -137,12 +137,10 @@ class ManimDirective(Directive):
     final_argument_whitespace = True
 
     def run(self):
-        if 'skip-manim' in self.state.document.settings.env.app.builder.tags.tags:
+        if "skip-manim" in self.state.document.settings.env.app.builder.tags.tags:
             node = skip_manim_node()
             self.state.nested_parse(
-                StringList(self.content[0]),
-                self.content_offset,
-                node
+                StringList(self.content[0]), self.content_offset, node
             )
             return [node]
 

--- a/docs/source/manim_directive.py
+++ b/docs/source/manim_directive.py
@@ -269,7 +269,7 @@ class ManimDirective(Directive):
 def setup(app):
     import manim
 
-    app.add_node(my_node, html=(visit, depart))
+    app.add_node(skip_manim_node, html=(visit, depart))
 
     setup.app = app
     setup.config = app.config

--- a/docs/source/manim_directive.py
+++ b/docs/source/manim_directive.py
@@ -68,7 +68,9 @@ directive:
         that is rendered in a reference block after the source code.
 
 """
+from docutils import nodes
 from docutils.parsers.rst import directives, Directive
+from docutils.statemachine import StringList
 
 import jinja2
 import os
@@ -81,6 +83,18 @@ import shutil
 from manim import QUALITIES
 
 classnamedict = {}
+
+
+class skip_manim_node(nodes.Admonition, nodes.Element):
+    pass
+
+
+def visit(self, node, name=''):
+    self.visit_admonition(node, name)
+
+
+def depart(self, node):
+    self.depart_admonition(node)
 
 
 def process_name_list(option_input: str, reference_type: str) -> List[str]:
@@ -123,6 +137,15 @@ class ManimDirective(Directive):
     final_argument_whitespace = True
 
     def run(self):
+        if 'skip-manim' in self.state.document.settings.env.app.builder.tags.tags:
+            node = skip_manim_node()
+            self.state.nested_parse(
+                StringList(self.content[0]),
+                self.content_offset,
+                node
+            )
+            return [node]
+
         from manim import config
 
         global classnamedict
@@ -248,9 +271,12 @@ class ManimDirective(Directive):
 def setup(app):
     import manim
 
+    app.add_node(my_node, html=(visit, depart))
+
     setup.app = app
     setup.config = app.config
     setup.confdir = app.confdir
+
     app.add_directive("manim", ManimDirective)
 
     metadata = {"parallel_read_safe": False, "parallel_write_safe": True}


### PR DESCRIPTION
## List of Changes
- This PR allows us to run `make html O=-tskip-manim` in order to build the documentation without rendering manim code examples.

## Motivation
Sometimes when I build the docs, _all_ manim scenes are re-rendered, even if the files they come from have not been modified.

## Explanation for Changes
This PR makes it so that running sphinx with the `-t skip-manim` tag will signal to the manim directive to not render anything. This tag can be used in one of two ways: `sphinx-build -M html <source_dir> <dest_dir> -t skip-manim` OR by using the makefile: `make html O=-tskip-manim`. Unfortunately, ugly as it is, this is the only way to pass the -t tag to the underlying sphinx process.

## Testing Status
Local pass.

## Further Comments
Right now, the output looks ugly. If anyone has any ideas for how to make it prettier, then I'm all ears. However I'm not too concerned with it since the point of the -t skip-manim flag is to be used only for quick-and-dirty things. No need for pretty.
