### PR TITLE
make Paragraph use CairoText

### DIFF
--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -399,6 +399,11 @@ class Paragraph(VGroup):
         `weird <https://github.com/3b1b/manim/issues/1067>`_. Consider using
         :meth:`remove_invisible_chars` to resolve this issue.
 
+    .. note::
+
+        Due to issues with the Pango-powered :class:`.Text`, this class uses
+        :class:`.CairoText`.
+
     Parameters
     ----------
     line_spacing : :class:`int`, optional
@@ -431,7 +436,7 @@ class Paragraph(VGroup):
         VGroup.__init__(self, **config)
 
         lines_str = "\n".join(list(text))
-        self.lines_text = Text(lines_str, **config)
+        self.lines_text = CairoText(lines_str, **config)
         lines_str_list = lines_str.split("\n")
         self.chars = self.gen_chars(lines_str_list)
 


### PR DESCRIPTION
## Motivation
In some instances, Pango and `Text` works in a weird way due to the fact that it does some things in a rather different way when compared to Cairo and `CairoText`. The class `Code` is one of those that relied on certain behavior of `CairoText` that changed when switching to Pango -- and has not yet been fixed. In order to have a working version of `Code` again, this PR makes `Paragraph` use `CairoText` instead of `Text` and thus restores the old behavior.

## Explanation for Changes
One thing that was changed in particular was how whitespace is counted: `Text` currently does not add invisible mobjects for spaces, which is why the coloring that `Code` applies to a given code snippet is off.

## Testing Status
With this PR, `Code("snippet.py", background="window", font="Roboto Mono")` renders as this:
![image](https://user-images.githubusercontent.com/11851593/100718438-a11f0e00-33bb-11eb-8104-148b9c91e3bf.png)


## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

