### PR TITLE
Docker: use local files when building an image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,16 @@
 FROM python:3.7-slim
 
-ARG MANIM_VERSION=stable
-
 RUN apt-get update -qq \
     && apt-get install --no-install-recommends -y \
         ffmpeg \
         gcc \
-        git \
         libcairo2-dev \
         libffi-dev \
         pkg-config \
         wget
 
 # setup a minimal texlive installation
-COPY ./texlive-profile.txt /tmp/
+COPY docker/texlive-profile.txt /tmp/
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 RUN wget -O /tmp/install-tl-unx.tar.gz http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz && \
     mkdir /tmp/install-tl && \
@@ -25,9 +22,12 @@ RUN wget -O /tmp/install-tl-unx.tar.gz http://mirror.ctan.org/systems/texlive/tl
         setspace standalone tipa wasy wasysym xcolor xkeyval
 
 # clone and build manim
-RUN git clone --depth 1 --branch ${MANIM_VERSION} https://github.com/ManimCommunity/manim.git /opt/manim
+COPY . /opt/manim
 WORKDIR /opt/manim
 RUN pip install --no-cache .
+
+# ensure that ffi bindings are generated
+RUN python -c "import pangocairocffi"
 
 # create working directory for user to mount local directory into
 WORKDIR /manim

--- a/playground/readme.md
+++ b/playground/readme.md
@@ -1,0 +1,47 @@
+# Quick reference
+- **Maintained by:** [the Manim Community developers](https://github.com/ManimCommunity/manim)
+- **Getting help:** [Manim Documentation](https://docs.manim.community) and [further helpful resources](https://manim.community)
+
+# Supported tags
+- `v0.1.0`, `latest` -- the latest released version
+- `stable` -- a more recent version corresponding to [the stable branch](https://github.com/ManimCommunity/manim/tree/stable)
+- `experimental` -- the most recent version corresponding to [the master branch](https://github.com/ManimCommunity/manim)
+
+# What is Manim?
+![logo](https://raw.githubusercontent.com/ManimCommunity/manim/master/logo/cropped.png)
+
+Manim is a Python library for creating mathematical animations [originally created](https://github.com/3b1b/manim) by Grant "3Blue1Brown" Sanderson. The images in this repository correspond to the [community-maintained version of Manim](https://github.com/ManimCommunity/manim).
+
+To get an impression what Manim can be used for, have a look at our [Example Gallery](https://docs.manim.community/en/stable/examples.html).
+
+# How to use this image
+## Quick Example
+To render a scene `CircleToSquare` in a file `test_scenes.py` contained in your current working directory while preserving your user and group ID, use
+```
+$ docker run --rm -it  --user="$(id -u):$(id -g)" -v "$(pwd)":/manim manimcommunity/manim manim test_scenes.py CircleToSquare -qm
+```
+
+## Running the image in the background
+Instead of using the "throwaway container" approach sketched above, you can also create a named container that you can also modify to your liking. First, run
+```
+$ docker run -it --name my-manim-container -v "$(pwd):/manim" manimcommunity/manim /bin/bash
+```
+to obtain an interactive shell inside your container allowing you to, e.g., install further dependencies (like texlive packages using `tlmgr`). Exit the container as soon as you are satisfied. Then, before using it, start the container by running
+```
+$ docker start my-manim-container
+```
+Then, to render a scene `CircleToSquare` in a file `test_scenes.py`, call
+```
+$ docker exec -it --user="$(id -u):$(id -g)" my-manim-container manim test.py CircleToSquare -qm
+```
+
+# Important notes
+When executing `manim` within a Docker container, several command line flags (in particular `-p` (preview file) and `-f` (show output file in the file browser)) are not supported.
+
+# Building the image
+The docker image corresponding to the checked out version of the git repository
+can be built by running
+```
+docker build -t manimcommunity/manim:TAG -f docker/Dockerfile .
+```
+from the root directory of the repository.


### PR DESCRIPTION
This PR moves our docker images further in the direction of being more customizable: this time, instead of using a branch or tag from our git repo, the source files are taken from the local checked out directory.

As a side effect, this enables automatic building of images (which was not possible before as I've learned in the meantime).

I've also added a README containing the content from https://hub.docker.com/r/manimcommunity/manim

## Testing Status
Building the image and using it works from the latest commit on master.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

