### PR TITLE
Update the changelog for our latest release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,6 +33,6 @@ changes warrant it!
 
 ## Acknowledgements
 - [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
-- [ ] I have added an entry describing the changes from this PR to the [Changelog](https://docs.manim.community/en/latest/changelog.html)
+- [ ] I have added an entry describing the changes from this PR to the [Changelog](https://docs.manim.community/en/latest/changelog.html) at `docs/source/changelog.rst`
 
 <!-- Once again, thanks for helping out by contributing to manim! -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,8 @@ changes warrant it!
 ## Further Comments
 <!-- Optional, any edits/updates should preferably be written here. -->
 
-## Acknowledgement
-- [ ] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))
+## Acknowledgements
+- [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
+- [ ] I have added an entry describing the changes from this PR to the [Changelog](https://docs.manim.community/en/latest/changelog.html)
 
 <!-- Once again, thanks for helping out by contributing to manim! -->

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -51,11 +51,11 @@ Configuration
 
 #. Removed the ``skip_animations`` config option and added the
    ``Renderer.skip_animations`` attribute instead (via :pr:`696`).
-
 #. The global ``config`` dict has been replaced by a global ``config`` instance
    of the new class :class:`~.ManimConfig`.  This class has a dict-like API, so
    this should not break user code, only make it more robust.  See the
    Configuration tutorial for details.
+#. Added the option to configure a directory for external assets (via :pr:`649`).
 
 
 Documentation

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 #########
 
 .. contents:: Release history
-   :maxdepth: 1
+   :depth: 1
 
 
 ****************

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 #########
 
+.. contents:: Release history
+   :maxdepth: 1
+
 
 ****************
 Upcoming release

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -16,6 +16,14 @@ Upcoming release
 
 Changes since the latest released version.
 
+New Features
+============
+
+- There is nothing here yet, check back later.
+
+Bugfixes
+========
+
 - There is nothing here yet, check back later.
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 
 .. contents:: Release history
    :depth: 1
+   :local:
+   :backlinks: none
 
 
 ****************

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,11 +2,23 @@
 Changelog
 #########
 
-******
-v0.2.0
-******
+
+****************
+Upcoming release
+****************
 
 :Date: TBD
+
+Changes since the latest released version.
+
+- There is nothing here yet, check back later.
+
+
+******
+v0.1.1
+******
+
+:Date: December 1, 2020
 
 Changes since Manim Community release v0.1.0
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -39,6 +39,12 @@ Fixes
 =====
 
 #. JsRender is optional to install. (via :pr:`697`).
+#. Allow importing modules from the same directory as the input
+   file when using ``manim`` from the command line (via :pr:`724`).
+#. Remove some unnecessary or unpythonic methods from :class:`~.Scene`
+   (``get_mobjects``, ``add_mobjects_among``, ``get_mobject_copies``),
+   via :pr:`758`.
+#. Fix formatting of :class:`~.Code` (via :pr:`798`).
 
 Configuration
 =============
@@ -57,6 +63,8 @@ Documentation
 
 #. Add ``:issue:`` and ``:pr:`` directives for simplifying linking to issues and
    pull requests on GitHub (via :pr:`685`).
+#. Add a ``skip-manim`` tag for skipping the ``.. manim::`` directive when
+   building the documentation locally (via :pr:`796`).
 
 
 Mobjects, Scenes, and Animations
@@ -64,7 +72,7 @@ Mobjects, Scenes, and Animations
 
 #. The ``alignment`` attribute to Tex and MathTex has been removed in favour of ``tex_environment``.
 #. :class:`~.Text` now uses Pango for rendering. ``PangoText`` has been removed. The old implementation is still available as a fallback as :class:`~.CairoText`.
-#. **New**: Variations of :class:`~.Dot` have been added as :class:`~.AnnotationDot`
+#. Variations of :class:`~.Dot` have been added as :class:`~.AnnotationDot`
    (a bigger dot with bolder stroke) and :class:`~.LabeledDot` (a dot containing a
    label).
 #. Scene.set_variables_as_attrs has been removed (via :pr:`692`).
@@ -75,6 +83,10 @@ Mobjects, Scenes, and Animations
 #. Added BraceBetweenPoints (via :pr:`693`).
 #. Added ArcPolygon and ArcPolygonFromArcs (via :pr:`707`).
 #. Added Cutout (via :pr:`760`).
+#. Added :class:`~.ManimBanner` for a animated version of our logo and banner (via :pr:`729`)
+#. The background color of a scene can now be changed reliably by setting, e.g.,
+   ``self.camera.background_color = RED`` (via :pr:`716`).
+
 
 
 ******


### PR DESCRIPTION
The changelog was not updated for the `v0.1.1` release, this is fixed here. Also, a table of contents is added; we have to check how this looks in the rendered documentation.

## Acknowledgement
- [x] I have read the [Contributing Guidelines](https://github.com/ManimCommunity/manim/wiki/Documentation-guidelines-(WIP))

