### PR TITLE
Move upcoming changelog to wiki

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,7 +43,6 @@ that might be useful for reviewers.. -->
 <!-- Do not modify the lines below. -->
 ## Reviewer Checklist
 - [ ] Newly added functions/classes are either private or have a docstring
-- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs.
+- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
 - [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
 - [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,7 @@ version of manim from this repository.
 -->
 
 ## Motivation
-<!-- Outline your motiviation: why do you feel that your
-changes are required? -->
+<!-- Outline your motivation: In what way do your changes improve the library? -->
 
 ## Overview / Explanation for Changes
 <!-- Give an overview of your changes and explain how they 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,3 +41,9 @@ changes warrant it!
 - [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
 
 <!-- Once again, thanks for helping out by contributing to manim! -->
+
+
+## Reviewer Checklist
+- [ ] Newly added functions/classes are either private or have a docstring
+- [ ] Documentation builds and adds no additional warnings
+- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,38 +1,38 @@
-<!---
-Thanks for contributing to manim!
-**Please ensure that your pull request works with the latest version of manim from this repository.**
-You should also include:
-  1. The motivation for making this change (or link the relevant issues)
-  2. How you tested the new behavior (e.g. a minimal working example, before/after
-     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
-     the goal is to show us how you know the pull request works as intended.
-If you don't need any of the optional sections, feel free to delete them to prevent clutter.
--->
+<!--
+Thank you for contributing to manim!
 
-## List of Changes
-<!-- List out your changes one by one like this:
-- Change 1
-- Change 2
-- and so on..
+Please ensure that your pull request works with the latest
+version of manim from this repository.
 -->
 
 ## Motivation
-<!-- Why you feel your changes are required. -->
+<!-- Outline your motiviation: why do you feel that your
+changes are required? -->
 
-## Explanation for Changes
-<!-- How do your changes solve aforementioned problems? -->
+## Overview / Explanation for Changes
+<!-- Give an overview of your changes and explain how they 
+resolve the situation described in the previous section.
+
+For PRs introducing new features, please provide code snippets
+using the newly introduced functionality and ideally even the
+expected rendered output. -->
 
 ## Oneline Summary of Changes
-<!-- Please update the lines below with a oneline summary of this PR for the list of upcoming changes at https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
+<!-- Please update the lines below with a oneline summary 
+for your changes. It will be included in the list of upcoming changes at 
+https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
 ```
 - Added new feature ... / Fixed bug ... / ... (:pr:`PR NUMBER HERE`)
 ```
 
 ## Testing Status
-<!-- Optional, but recommended, your computer specs and what tests you ran with their results, if any -->
+<!-- Optional (but recommended): your computer specs and
+what tests you ran with their results, if any. This section
+is also intended for other testing-related comments. -->
 
 ## Further Comments
-<!-- Optional, any edits/updates should preferably be written here. -->
+<!-- Optional, any further comments regarding your PR
+that might be useful for reviewers.. -->
 
 ## Acknowledgements
 - [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
@@ -40,7 +40,10 @@ If you don't need any of the optional sections, feel free to delete them to prev
 <!-- Once again, thanks for helping out by contributing to manim! -->
 
 
+<!-- Do not modify the lines below. -->
 ## Reviewer Checklist
 - [ ] Newly added functions/classes are either private or have a docstring
-- [ ] Documentation builds and adds no additional warnings
+- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
 - [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,12 @@ changes warrant it!
 ## Explanation for Changes
 <!-- How do your changes solve aforementioned problems? -->
 
+## Oneline Summary of Changes
+<!-- Please update the lines below with a oneline summary of this PR for the list of upcoming changes at https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
+```
+- Added new feature ... / Fixed bug ... / ... (:pr:`PR NUMBER HERE`)
+```
+
 ## Testing Status
 <!-- Optional, but recommended, your computer specs and what tests you ran with their results, if any -->
 
@@ -33,6 +39,5 @@ changes warrant it!
 
 ## Acknowledgements
 - [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
-- [ ] I have added an entry describing the changes from this PR to the [Changelog](https://docs.manim.community/en/latest/changelog.html) at `docs/source/changelog.rst`
 
 <!-- Once again, thanks for helping out by contributing to manim! -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,9 +14,6 @@ If you don't need any of the optional sections, feel free to delete them to prev
 - Change 1
 - Change 2
 - and so on..
-
-Be sure to note your changes in the [changelog](docs/source/changelog.rst) if your
-changes warrant it!
 -->
 
 ## Motivation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ version of manim from this repository.
 <!-- Outline your motivation: In what way do your changes improve the library? -->
 
 ## Overview / Explanation for Changes
-<!-- Give an overview of your changes and explain how they 
+<!-- Give an overview of your changes and explain how they
 resolve the situation described in the previous section.
 
 For PRs introducing new features, please provide code snippets
@@ -17,8 +17,8 @@ using the newly introduced functionality and ideally even the
 expected rendered output. -->
 
 ## Oneline Summary of Changes
-<!-- Please update the lines below with a oneline summary 
-for your changes. It will be included in the list of upcoming changes at 
+<!-- Please update the lines below with a oneline summary
+for your changes. It will be included in the list of upcoming changes at
 https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
 ```
 - Added new feature ... / Fixed bug ... / ... (:pr:`PR NUMBER HERE`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,7 +43,7 @@ that might be useful for reviewers.. -->
 <!-- Do not modify the lines below. -->
 ## Reviewer Checklist
 - [ ] Newly added functions/classes are either private or have a docstring
+- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs.
 - [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
 - [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
-
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!--- 
+<!---
 Thanks for contributing to manim!
 **Please ensure that your pull request works with the latest version of manim from this repository.**
 You should also include:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,22 +14,8 @@ Upcoming release
 
 :Date: TBD
 
-Changes since the latest released version.
+Changes for the upcoming release are tracked `in our GitHub wiki <https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release>`_.
 
-New Features
-============
-
-- Added a creation animation for our banner, :meth:`~.ManimBanner.create` (via :pr:`814`).
-
-Bugfixes
-========
-
-- There is nothing here yet, check back later.
-
-Other Changes
-=============
-
-#. Removed temp partial movie file from SceneFileWriter (ffmpeg directly renders partial movie files instead of temp files)
 
 ******
 v0.1.1


### PR DESCRIPTION
## List of Changes

- Move the upcoming changelog from `changelog.rst` to the wiki to avoid tons and tons of merge conflics
- Adapt the PR template accordingly
- Suggestion: add reviewer checklist to PR template (discuss?)

## Motivation
Asking people to update the same file in every PR is literally asking for trouble and will cause lots of merge conflicts, which is inconvenient.

## Oneline Summary
```
- Move upcoming changelog to the wiki on GitHub (:pr:`822`)
```

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->
