### PR TITLE
ci: disable test for python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.7, 3.8, 3.9]
 
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
## List of Changes
I think it is time to remove python 3.6 from testing and soon remove support for it. This is done because running CI takes longer than expected and testing three major python version seem satisfying. This is not depreciating it but just not running the tests in CI.
- Don't test python 3.6

## Motivation
CI takes a lot of time to run and has pending.

## Explanation for Changes
Remove testing for python 3.6.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have added an entry describing the changes from this PR to the [Changelog](https://docs.manim.community/en/latest/changelog.html) at `docs/source/changelog.rst`