### PR TITLE
Added flowchart for Docs overview

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -223,5 +223,20 @@ Further useful guidelines
 #. Please do as much as possible to keep issues, PRs, and development in
    general as tidy as possible.
 
+URL = `https://app.diagrams.net/#G1aKyJTloYB97IhrzwqEENOu-WQyuVWMjM`
+
+
+Docs workflow chart:
+<div class="mxgraph" style="max-width:100%;border:1px solid transparent;" data-mxgraph="{&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;resize&quot;:true,&quot;toolbar&quot;:&quot;zoom layers lightbox&quot;,&quot;edit&quot;:&quot;_blank&quot;,&quot;url&quot;:&quot;https://drive.google.com/uc?id=1aKyJTloYB97IhrzwqEENOu-WQyuVWMjM&amp;export=download&quot;}"></div>
+<script type="text/javascript" src="https://viewer.diagrams.net/embed2.js?&fetch=https%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1aKyJTloYB97IhrzwqEENOu-WQyuVWMjM%26export%3Ddownload"></script>
+
+And as a test:
+
+.. raw:: html
+
+    <div class="mxgraph" style="max-width:100%;border:1px solid transparent;" data-mxgraph="{&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;resize&quot;:true,&quot;toolbar&quot;:&quot;zoom layers lightbox&quot;,&quot;edit&quot;:&quot;_blank&quot;,&quot;url&quot;:&quot;https://drive.google.com/uc?id=1aKyJTloYB97IhrzwqEENOu-WQyuVWMjM&amp;export=download&quot;}"></div>
+    <script type="text/javascript" src="https://viewer.diagrams.net/embed2.js?&fetch=https%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1aKyJTloYB97IhrzwqEENOu-WQyuVWMjM%26export%3Ddownload"></script>
+
 
 **Thank you for contributing!**
+

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -223,20 +223,15 @@ Further useful guidelines
 #. Please do as much as possible to keep issues, PRs, and development in
    general as tidy as possible.
 
-URL = `https://app.diagrams.net/#G1aKyJTloYB97IhrzwqEENOu-WQyuVWMjM`
 
-
-Docs workflow chart:
-<div class="mxgraph" style="max-width:100%;border:1px solid transparent;" data-mxgraph="{&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;resize&quot;:true,&quot;toolbar&quot;:&quot;zoom layers lightbox&quot;,&quot;edit&quot;:&quot;_blank&quot;,&quot;url&quot;:&quot;https://drive.google.com/uc?id=1aKyJTloYB97IhrzwqEENOu-WQyuVWMjM&amp;export=download&quot;}"></div>
-<script type="text/javascript" src="https://viewer.diagrams.net/embed2.js?&fetch=https%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1aKyJTloYB97IhrzwqEENOu-WQyuVWMjM%26export%3Ddownload"></script>
-
-And as a test:
+You can find examples for the ``docs`` in many places:
+In ``Example Gallery`` , ``Tutorials`` , ``Reference Classes`` and ``Reference Modules``.
+In case you are contributing, please have a look at this flowchart:
 
 .. raw:: html
 
     <div class="mxgraph" style="max-width:100%;border:1px solid transparent;" data-mxgraph="{&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;resize&quot;:true,&quot;toolbar&quot;:&quot;zoom layers lightbox&quot;,&quot;edit&quot;:&quot;_blank&quot;,&quot;url&quot;:&quot;https://drive.google.com/uc?id=1aKyJTloYB97IhrzwqEENOu-WQyuVWMjM&amp;export=download&quot;}"></div>
     <script type="text/javascript" src="https://viewer.diagrams.net/embed2.js?&fetch=https%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1aKyJTloYB97IhrzwqEENOu-WQyuVWMjM%26export%3Ddownload"></script>
-
 
 **Thank you for contributing!**
 

--- a/docs/source/tutorials/configuration.rst
+++ b/docs/source/tutorials/configuration.rst
@@ -284,6 +284,13 @@ config file system.
 Order of operations
 *******************
 
+.. raw:: html
+
+    <div class="mxgraph" style="max-width:100%;border:1px solid transparent;" data-mxgraph="{&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;resize&quot;:true,&quot;toolbar&quot;:&quot;zoom layers lightbox&quot;,&quot;edit&quot;:&quot;_blank&quot;,&quot;url&quot;:&quot;https://drive.google.com/uc?id=1WYVKKoRbXrumHEcyQKQ9s1yCnBvfU2Ui&amp;export=download&quot;}"></div>
+    <script type="text/javascript" src="https://viewer.diagrams.net/embed2.js?&fetch=https%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1WYVKKoRbXrumHEcyQKQ9s1yCnBvfU2Ui%26export%3Ddownload"></script>
+
+
+
 With so many different ways of configuring manim, it can be difficult to know
 when each config option is being set.  In fact, this will depend on how manim
 is being used.


### PR DESCRIPTION
This flowchart, made by @leotrs provides an overview of what and where to find things in the docs.

In the flowchart there was the option "embed as HTML".
I will try this first, but if that does not work, we can include this as an png.
EDIT: 
Link to the flowchart: ``https://app.diagrams.net/#G1aKyJTloYB97IhrzwqEENOu-WQyuVWMjM``