### PR TITLE
fixed test

### DIFF
--- a/docs/source/tutorials/configuration.rst
+++ b/docs/source/tutorials/configuration.rst
@@ -370,7 +370,7 @@ A list of all CLI flags
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
    usage: manim file [flags] [scene [scene ...]]
-          manim {cfg,init} [opts]
+          manim {cfg,init,plugins} [opts]
 
    Animation engine for explanatory math videos
 


### PR DESCRIPTION
## List of Changes
- Minor fix to doctest

## Motivation
doctest fails under #784 merge

## Explanation for Changes
Updated tutorials/configuration.rst to reflect the intended output of `manim -h`

```
Document: tutorials/configuration
---------------------------------
1 items passed all tests:
   2 tests in default
2 tests in 1 items.
2 passed and 0 failed.
Test passed.

Doctest summary
===============
    2 tests
    0 failures in tests
    0 failures in setup code
    0 failures in cleanup code
build succeeded, 44 warnings.
```

## Acknowledgements
- [x ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [ ] I have added an entry describing the changes from this PR to the [Changelog](https://docs.manim.community/en/latest/changelog.html) at `docs/source/changelog.rst`
