### PR TITLE
Small fixes to docstrings. Tiny cleanups. Remove an old unused function.

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -137,7 +137,7 @@ class Mobject(Container):
 
     def add_to_back(self, *mobjects):
         """Adds (or moves) all passed mobjects to the back of the scene.
-        
+
         .. note::
 
             Technically, this is done by adding (or moving) the mobjects to

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -171,7 +171,6 @@ class Mobject(Container):
     def get_array_attrs(self):
         return ["points"]
 
-
     def apply_over_attr_arrays(self, func):
         for attr in self.get_array_attrs():
             setattr(self, attr, func(getattr(self, attr)))

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -171,17 +171,6 @@ class Mobject(Container):
     def get_array_attrs(self):
         return ["points"]
 
-    # This does not seem to be in use any more:
-    # def digest_mobject_attrs(self):
-    #     """
-    #     Ensures all attributes which are mobjects are included
-    #     in the submobjects list.
-    #     """
-    #     mobject_attrs = [
-    #         x for x in list(self.__dict__.values()) if isinstance(x, Mobject)
-    #     ]
-    #     self.submobjects = list_update(self.submobjects, mobject_attrs)
-    #     return self
 
     def apply_over_attr_arrays(self, func):
         for attr in self.get_array_attrs():

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -136,8 +136,14 @@ class Mobject(Container):
         return self
 
     def add_to_back(self, *mobjects):
-        """Adds (or moves) all *mobjects to the head of the self.submobjects list.
-        The head of the list is rendered first - i.e. at the back of the scene.
+        """Adds (or moves) all passed mobjects to the back of the scene.
+        
+        .. note::
+
+            Technically, this is done by adding (or moving) the mobjects to
+            the head of ``self.submobjects``. The head of this list is rendered
+            first, which places the corresponding mobjects behind the
+            subsequent list members.
         """
         self.remove(*mobjects)
         self.submobjects = list(mobjects) + self.submobjects

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -43,14 +43,13 @@ class Mobject(Container):
     """
 
     def __init__(self, color=WHITE, name=None, dim=3, target=None, z_index=0, **kwargs):
-        self.color = color
+        self.color = Color(color)
         self.name = self.__class__.__name__ if name is None else name
         self.dim = dim
         self.target = target
         self.z_index = z_index
         self.point_hash = None
         self.submobjects = []
-        self.color = Color(self.color)
         self.updaters = []
         self.updating_suspended = False
         self.reset_points()
@@ -137,6 +136,9 @@ class Mobject(Container):
         return self
 
     def add_to_back(self, *mobjects):
+        """Adds (or moves) all *mobjects to the head of the self.submobjects list.
+        The head of the list is rendered first - i.e. at the back of the scene.
+        """
         self.remove(*mobjects)
         self.submobjects = list(mobjects) + self.submobjects
         return self
@@ -169,16 +171,17 @@ class Mobject(Container):
     def get_array_attrs(self):
         return ["points"]
 
-    def digest_mobject_attrs(self):
-        """
-        Ensures all attributes which are mobjects are included
-        in the submobjects list.
-        """
-        mobject_attrs = [
-            x for x in list(self.__dict__.values()) if isinstance(x, Mobject)
-        ]
-        self.submobjects = list_update(self.submobjects, mobject_attrs)
-        return self
+    # This does not seem to be in use any more:
+    # def digest_mobject_attrs(self):
+    #     """
+    #     Ensures all attributes which are mobjects are included
+    #     in the submobjects list.
+    #     """
+    #     mobject_attrs = [
+    #         x for x in list(self.__dict__.values()) if isinstance(x, Mobject)
+    #     ]
+    #     self.submobjects = list_update(self.submobjects, mobject_attrs)
+    #     return self
 
     def apply_over_attr_arrays(self, func):
         for attr in self.get_array_attrs():
@@ -207,7 +210,7 @@ class Mobject(Container):
         return copy.deepcopy(self)
 
     def generate_target(self, use_deepcopy=False):
-        self.target = None  # Prevent exponential explosion
+        self.target = None  # Prevent unbounded linear recursion
         if use_deepcopy:
             self.target = copy.deepcopy(self)
         else:
@@ -584,7 +587,7 @@ class Mobject(Container):
         return self.rescale_to_fit(height, 1, stretch=True, **kwargs)
 
     def stretch_to_fit_depth(self, depth, **kwargs):
-        return self.rescale_to_fit(depth, 1, stretch=True, **kwargs)
+        return self.rescale_to_fit(depth, 2, stretch=True, **kwargs)
 
     def set_width(self, width, stretch=False, **kwargs):
         return self.rescale_to_fit(width, 0, stretch=stretch, **kwargs)

--- a/manim/mobject/svg/tex_mobject.py
+++ b/manim/mobject/svg/tex_mobject.py
@@ -217,12 +217,6 @@ class SingleStringMathTex(SVGMobject):
         tex_template=None,
         **kwargs,
     ):
-        self.stroke_width = stroke_width
-        self.fill_opacity = fill_opacity
-        self.background_stroke_width = background_stroke_width
-        self.background_stroke_color = background_stroke_color
-        self.should_center = should_center
-        self.height = height
         self.organize_left_to_right = organize_left_to_right
         self.tex_environment = tex_environment
         if tex_template is None:
@@ -239,12 +233,12 @@ class SingleStringMathTex(SVGMobject):
         SVGMobject.__init__(
             self,
             file_name=file_name,
-            should_center=self.should_center,
-            stroke_width=self.stroke_width,
-            height=self.height,
-            fill_opacity=self.fill_opacity,
-            background_stroke_width=self.background_stroke_width,
-            background_stroke_color=self.background_stroke_color,
+            should_center=should_center,
+            stroke_width=stroke_width,
+            height=height,
+            fill_opacity=fill_opacity,
+            background_stroke_width=background_stroke_width,
+            background_stroke_color=background_stroke_color,
             **kwargs,
         )
         if self.height is None:
@@ -311,9 +305,11 @@ class SingleStringMathTex(SVGMobject):
         return tex
 
     def remove_stray_braces(self, tex):
+        r"""
+        Makes MathTex resilient to unmatched braces '{'. This is important when the braces in the
+        tex code are spread over multiple agruments eg. MathTex(r"e^{i", "\tau} =1")
         """
-        Makes MathTex resilient to unmatched { at start
-        """
+
         # "\{" does not count (it's a brace literal), but "\\{" counts (it's a new line and then brace)
         num_lefts = tex.count("{") - tex.count("\\{") + tex.count("\\\\{")
         num_rights = tex.count("}") - tex.count("\\}") + tex.count("\\\\}")

--- a/manim/mobject/svg/tex_mobject.py
+++ b/manim/mobject/svg/tex_mobject.py
@@ -306,8 +306,10 @@ class SingleStringMathTex(SVGMobject):
 
     def remove_stray_braces(self, tex):
         r"""
-        Makes MathTex resilient to unmatched braces '{'. This is important when the braces in the
-        tex code are spread over multiple agruments eg. MathTex(r"e^{i", "\tau} =1")
+        Makes :class:`~.MathTex` resilient to unmatched braces.
+        
+        This is important when the braces in the TeX code are spread over 
+        multiple arguments as in, e.g., ``MathTex(r"e^{i", r"\tau} = 1")``.
         """
 
         # "\{" does not count (it's a brace literal), but "\\{" counts (it's a new line and then brace)

--- a/manim/mobject/svg/tex_mobject.py
+++ b/manim/mobject/svg/tex_mobject.py
@@ -307,8 +307,8 @@ class SingleStringMathTex(SVGMobject):
     def remove_stray_braces(self, tex):
         r"""
         Makes :class:`~.MathTex` resilient to unmatched braces.
-        
-        This is important when the braces in the TeX code are spread over 
+
+        This is important when the braces in the TeX code are spread over
         multiple arguments as in, e.g., ``MathTex(r"e^{i", r"\tau} = 1")``.
         """
 


### PR DESCRIPTION
tex_mobject.py - better docstring for remove_stray_braces
mobject.py - fix: "depth" is index 2, not 1
mobject.py - docstring comment correction
mobject.py - digest_mobject_attrs is never used (thankfully)
tex_mobject.py - don't set partent class attributes in child init()
