### PR TITLE
Normalize the direction vector in always_shift()

### DIFF
--- a/manim/mobject/mobject_update_utils.py
+++ b/manim/mobject/mobject_update_utils.py
@@ -59,7 +59,13 @@ def always_redraw(func):
 
 
 def always_shift(mobject, direction=RIGHT, rate=0.1):
-    mobject.add_updater(lambda m, dt: m.shift(dt * rate * direction))
+    def normalize(v):
+        norm = np.linalg.norm(v)
+        if norm == 0:
+            return v
+        return v / norm
+
+    mobject.add_updater(lambda m, dt: m.shift(dt * rate * normalize(direction)))
     return mobject
 
 


### PR DESCRIPTION
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
Normalize the direction vector in `always_shift()`.

## Motivation
<!-- Why you feel your changes are required. -->
The function is clearly trying to allow the user to shift a mobject at a constant rate, but since the direction vector is never normalized this may not always happen.

## Explanation for Changes
<!-- How do your changes solve aforementioned problems? -->
Normalizing the direction vector.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [ ] I have added an entry describing the changes from this PR to the [Changelog](https://docs.manim.community/en/latest/changelog.html) at `docs/source/changelog.rst`

<!-- Once again, thanks for helping out by contributing to manim! -->
