### PR TITLE
Fixes #840

### DIFF
--- a/manim/mobject/coordinate_systems.py
+++ b/manim/mobject/coordinate_systems.py
@@ -159,35 +159,25 @@ class Axes(VGroup, CoordinateSystem):
         self.y_axis_config = y_axis_config
         self.center_point = center_point
 
-        for entry in ["x_min", "x_max", "y_min", "y_max"]:
-            if entry.startswith("x"):
-                # entries in kwargs takes precedence over config entries
-                if kwargs.get(entry, None) is None:
-                    # If kwargs does not contain the key, search the x_axis_config
-                    if (
-                        self.x_axis_config.get(entry, None) is None
-                    ):  # if the key is not present, create one with value None
-                        self.x_axis_config[entry] = None
-                else:
-                    self.x_axis_config[entry] = kwargs.pop(entry)
-            else:
-                if kwargs.get(entry, None) is None:
-                    if self.y_axis_config.get(entry, None) is None:
-                        self.y_axis_config[entry] = None
-                else:
-                    self.y_axis_config[entry] = kwargs.pop(entry)
-
-        x_min, x_max = self.x_axis_config.get("x_min"), self.x_axis_config.get("x_max")
-        y_min, y_max = self.y_axis_config.get("y_min"), self.y_axis_config.get("y_max")
+        x_min = kwargs.pop("x_min", self.x_axis_config.pop("x_min", None))
+        x_max = kwargs.pop("x_max", self.x_axis_config.pop("x_max", None))
+        y_min = kwargs.pop("y_min", self.y_axis_config.pop("y_min", None))
+        y_max = kwargs.pop("y_max", self.y_axis_config.pop("y_max", None))
 
         CoordinateSystem.__init__(
             self, x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max
         )
         VGroup.__init__(self, **kwargs)
-        self.x_axis_config["x_min"] = self.x_min
-        self.x_axis_config["x_max"] = self.x_max
-        self.y_axis_config["y_min"] = self.y_min
-        self.y_axis_config["y_max"] = self.y_max
+        
+        self.x_axis_config["x_min"], self.x_axis_config["x_max"] = (
+            self.x_min,
+            self.x_max,
+        )
+        self.y_axis_config["y_min"], self.y_axis_config["y_max"] = (
+            self.y_min,
+            self.y_max,
+        )
+
         self.x_axis = self.create_axis(self.x_min, self.x_max, self.x_axis_config)
         self.y_axis = self.create_axis(self.y_min, self.y_max, self.y_axis_config)
         self.y_axis.rotate(90 * DEGREES, about_point=ORIGIN)


### PR DESCRIPTION

Fixed an issue where the  keyword arguments ``x_min``,``x_max``,``y_min`` and ``y_max`` passed in ``Axes`` call were not set to ``self.x_min``,``self.x_max``,``self.y_min`` and ``self.y_max``.

Fixes https://github.com/ManimCommunity/manim/issues/840
<!--- 
Thanks for contributing to manim!
**Please ensure that your pull request works with the latest version of manim from this repository.**
You should also include:
  1. The motivation for making this change (or link the relevant issues)
  2. How you tested the new behavior (e.g. a minimal working example, before/after
     screenshots, gifs, commands, etc.) This is rather informal at the moment, but
     the goal is to show us how you know the pull request works as intended.
If you don't need any of the optional sections, feel free to delete them to prevent clutter.
-->

## List of Changes
<!-- List out your changes one by one like this:
- Change 1
- Change 2
- and so on..

Be sure to note your changes in the [changelog](docs/source/changelog.rst) if your
changes warrant it!
-->

- The ``CoordinateSystem`` class now accepts ``x_min``,``x_max``,``y_min`` and ``y_max`` as keyword arguments and sets these values to ``self.x_min``,``self.x_max``,``self.y_min`` and ``self.y_max``.

- ``x_min``,``x_max``,``y_min`` and ``y_max`` passed either directly into ``Axes()`` class or in ``x_axis_config`` and ``y_axis_config`` are now extracted and passed upstairs.

## Motivation
<!-- Why you feel your changes are required. -->
Fix for https://github.com/ManimCommunity/manim/issues/840
<!-- Once again, thanks for helping out by contributing to manim! -->