### PR TITLE
Markup text

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,13 +20,11 @@ New Features
 ============
 
 - Added a creation animation for our banner, :meth:`~.ManimBanner.create` (via :pr:`814`).
-- Added a class :class:`MarkupText` (via :pr:`855`) for easier and more flexible text formatting
 
 Bugfixes
 ========
 
 - There is nothing here yet, check back later.
-- Take into account ``disable_ligatures`` when hashing a text in :class:`Text`
 
 Other Changes
 =============

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,11 +20,13 @@ New Features
 ============
 
 - Added a creation animation for our banner, :meth:`~.ManimBanner.create` (via :pr:`814`).
+- Added a class :class:`MarkupText` (via :pr:`855`) for easier and more flexible text formatting
 
 Bugfixes
 ========
 
 - There is nothing here yet, check back later.
+- Take into account ``disable_ligatures`` when hashing a text in :class:`Text`
 
 Other Changes
 =============

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -146,6 +146,14 @@ class PangoUtils:
         else:
             raise AttributeError("There is no Font Weight Called %s" % string)
 
+    @staticmethod
+    def remove_last_M(file_name: str) -> None:
+        with open(file_name, "r") as fpr:
+            content = fpr.read()
+        content = re.sub(r'Z M [^A-Za-z]*? "\/>', 'Z "/>', content)
+        with open(file_name, "w") as fpw:
+            fpw.write(content)
+
 
 class TextSetting(object):
     def __init__(self, start, end, font, slant, weight, line_num=-1):
@@ -246,7 +254,7 @@ class CairoText(SVGMobject):
         else:
             self.line_spacing = self.size + self.size * self.line_spacing
         file_name = self.text2svg()
-        self.remove_last_M(file_name)
+        PangoUtils.remove_last_M(file_name)
         SVGMobject.__init__(
             self,
             file_name,
@@ -310,13 +318,6 @@ class CairoText(SVGMobject):
                 chars.add(self.submobjects[submobjects_char_index])
                 submobjects_char_index += 1
         return chars
-
-    def remove_last_M(self, file_name):
-        with open(file_name, "r") as fpr:
-            content = fpr.read()
-        content = re.sub(r'Z M [^A-Za-z]*? "\/>', 'Z "/>', content)
-        with open(file_name, "w") as fpw:
-            fpw.write(content)
 
     def find_indexes(self, word, text):
         m = re.match(r"\[([0-9\-]{0,}):([0-9\-]{0,})\]", word)
@@ -829,7 +830,7 @@ class Text(SVGMobject):
         else:
             self.line_spacing = self.size + self.size * self.line_spacing
         file_name = self.text2svg()
-        self.remove_last_M(file_name)
+        PangoUtils.remove_last_M(file_name)
         SVGMobject.__init__(
             self,
             file_name,
@@ -894,14 +895,6 @@ class Text(SVGMobject):
                 chars.add(self.submobjects[submobjects_char_index])
                 submobjects_char_index += 1
         return chars
-
-    def remove_last_M(self, file_name: str):  # pylint: disable=invalid-name
-        """Internally used. Use to format the rendered SVG files."""
-        with open(file_name, "r") as fpr:
-            content = fpr.read()
-        content = re.sub(r'Z M [^A-Za-z]*? "\/>', 'Z "/>', content)
-        with open(file_name, "w") as fpw:
-            fpw.write(content)
 
     def find_indexes(self, word: str, text: str):
         """Internally used function. Finds the indexes of ``text`` in ``word``."""
@@ -1295,7 +1288,7 @@ class MarkupText(SVGMobject):
             self.line_spacing = self.size + self.size * self.line_spacing
 
         file_name = self.text2svg()
-        self.remove_last_M(file_name)
+        PangoUtils.remove_last_M(file_name)
         SVGMobject.__init__(
             self,
             file_name,
@@ -1494,10 +1487,3 @@ class MarkupText(SVGMobject):
 
     def __repr__(self):
         return f"MarkupText({repr(self.original_text)})"
-
-    def remove_last_M(self, file_name):
-        with open(file_name, "r") as fpr:
-            content = fpr.read()
-        content = re.sub(r'Z M [^A-Za-z]*? "\/>', 'Z "/>', content)
-        with open(file_name, "w") as fpw:
-            fpw.write(content)

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -172,13 +172,6 @@ class CairoText(SVGMobject):
     in the given text. In particular, slicing is possible.
 
 
-
-    .. WARNING::
-
-        Using a :class:`.Transform` on text with leading whitespace can look
-        `weird <https://github.com/3b1b/manim/issues/1067>`_. Consider using
-        :meth:`remove_invisible_chars` to resolve this issue.
-
     Tests
     -----
 
@@ -476,11 +469,6 @@ class Paragraph(VGroup):
     :class:`.VGroup` containing all the lines. In this context, every line is
     constructed as a :class:`.VGroup` of characters contained in the line.
 
-    .. WARNING::
-
-        Using a :class:`.Transform` on text with leading whitespace can look
-        `weird <https://github.com/3b1b/manim/issues/1067>`_. Consider using
-        :meth:`remove_invisible_chars` to resolve this issue.
 
     Parameters
     ----------

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1333,8 +1333,7 @@ class MarkupText(SVGMobject):
             self.scale(TEXT_MOB_SCALE_FACTOR)
 
     def text2hash(self):
-        """Internally used function.
-        Generates ``sha256`` hash for file name.
+        """Generates ``sha256`` hash for file name.
         """
         settings = (
             "MARKUPPANGO" + self.font + self.slant + self.weight
@@ -1347,8 +1346,7 @@ class MarkupText(SVGMobject):
         return hasher.hexdigest()[:16]
 
     def text2svg(self):
-        """Internally used function.
-        Convert the text to SVG using Pango
+        """Convert the text to SVG using Pango.
         """
         size = self.size * 10
         line_spacing = self.line_spacing * 10
@@ -1388,10 +1386,10 @@ class MarkupText(SVGMobject):
         return file_name
 
     def _count_real_chars(self, s):
-        """Internally used function.
-        Counts characters that will be displayed.
+        """Counts characters that will be displayed.
+
         This is needed for partial coloring or gradients, because space
-        counts to the text's `len`, but has no corresponding letter"""
+        counts to the text's `len`, but has no corresponding character."""
         count = 0
         level = 0
         # temporarily replace HTML entities by single char
@@ -1406,9 +1404,11 @@ class MarkupText(SVGMobject):
         return count
 
     def extract_gradient_tags(self):
-        """Internally used function.
-        Used to determine what parts (if any) of the string should be formatted with a gradient.
-        Removes the ``<gradient>`` tag, as it is not part of Pango's markup and would cause an error."""
+        """Used to determine which parts (if any) of the string should be formatted
+        with a gradient.
+
+        Removes the ``<gradient>`` tag, as it is not part of Pango's markup and would cause an error.
+        """
         tags = re.finditer(
             '<gradient\s+from="([^"]+)"\s+to="([^"]+)"(\s+offset="([^"]+)")?>(.+?)</gradient>',
             self.original_text,
@@ -1436,17 +1436,18 @@ class MarkupText(SVGMobject):
         return gradientmap
 
     def _parse_color(self, col):
-        """Internally used function.
-        Parse color given in ``<color>`` or ``<gradient>`` tags."""
+        """Parse color given in ``<color>`` or ``<gradient>`` tags."""
         if re.match("#[0-9a-f]{6}", col):
             return col
         else:
             return Colors[col.lower()].value
 
     def extract_color_tags(self):
-        """Internally used function.
-        Used to determine what parts (if any) of the string should be formatted with a custom color.
-        Removes the ``<color>`` tag, as it is not part of Pango's markup and would cause an error."""
+        """Used to determine which parts (if any) of the string should be formatted
+        with a custom color.
+
+        Removes the ``<color>`` tag, as it is not part of Pango's markup and would cause an error.
+        """
         tags = re.finditer(
             '<color\s+col="([^"]+)"(\s+offset="([^"]+)")?>(.+?)</color>',
             self.original_text,

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1077,42 +1077,41 @@ class MarkupText(SVGMobject):
     in the given text. In particular, slicing is possible. Text can be formatted
     using different tags:
 
-    - `<b>bold</b>`, `<i>italic</i>` and `<b><i>bold+italic</i></b>`
-    - `<ul>underline</ul>` and `<s>strike through</s>`
-    - `<tt>typewriter font</tt>`
-    - `<big>bigger font</big>` and `<small>smaller font</small>`
-    - `<sup>superscript</sup>` and `<sub>subscript</sub>`
-    - `<span underline="double">double underline</span>`
-    - `<span underline="error">error underline</span>`
-    - `<span font_family="sans">temporary change of font</span>`
-    - `<color col="RED">temporary change of color</color>`;
-       colors can be specified as Manim constants like `RED` or `YELLOW`
-    - `<gradient from="YELLOW" to="RED">temporary gradient</gradient>`;
-       colors specified as above
+    - ``<b>bold</b>``, ``<i>italic</i>`` and ``<b><i>bold+italic</i></b>``
+    - ``<ul>underline</ul>`` and ``<s>strike through</s>``
+    - ``<tt>typewriter font</tt>``
+    - ``<big>bigger font</big>`` and ``<small>smaller font</small>``
+    - ``<sup>superscript</sup>`` and ``<sub>subscript</sub>``
+    - ``<span underline="double">double underline</span>``
+    - ``<span underline="error">error underline</span>``
+    - ``<span font_family="sans">temporary change of font</span>``
+    - ``<color col="RED">temporary change of color</color>``; colors can be specified as Manim constants like ``RED`` or ``YELLOW``
+    - ``<gradient from="YELLOW" to="RED">temporary gradient</gradient>``; colors specified as above
 
-    When your text contains ligatures, the `MarkupText` class may incorrectly determine
-    the first and last letter to be colored. This is due to the fact that e.g. `fl`
-    are two characters, but will be set as one single glyph. If your language does
-    not depend on ligatures, consider setting `disable_ligatures=True`. If you cannot
-    or do not want to do without ligatures, the `gradient` and `color` tag support
-    an optional attribute `offset` which can be used to compensate for that error.
+    If your text contains ligatures, the :class:`MarkupText` class may incorrectly determine
+    the first and last letter to be colored. This is due to the fact that e.g. ``fl``
+    are two characters, but can be set as one single glyph, a ligature. If your language does
+    not depend on ligatures, consider setting ``disable_ligatures=True``. If you cannot
+    or do not want to do without ligatures, the ``gradient`` and ``color`` tag support
+    an optional attribute ``offset`` which can be used to compensate for that error.
     Usage is as follows:
-    - `<color col="RED" offset="1">red text</color>` to *start* coloring one letter earlier
-    - `<color col="RED" offset=",1">red text</color>` to *end* coloring one letter earlier
-    - `<color colr="RED" offset="2,1">red text</color>` to *start* coloring two letters earlier and *end* one letter earlier
+
+    - ``<color col="RED" offset="1">red text</color>`` to *start* coloring one letter earlier
+    - ``<color col="RED" offset=",1">red text</color>`` to *end* coloring one letter earlier
+    - ``<color col="RED" offset="2,1">red text</color>`` to *start* coloring two letters earlier and *end* one letter earlier
 
     Specifying a second offset may be necessary if the text to be colored does
     itself contain ligatures. The same can happen when using HTML entities for
     special chars.
 
-    Escaping of special characters: `>` *should* be written as `&gt;` whereas `<` and
-    `&` *must* to be written as `&lt;` and `&amp;`.
+    Escaping of special characters: ``>`` *should* be written as ``&gt;`` whereas ``<`` and
+    ``&`` *must* be written as ``&lt;`` and ``&amp;``.
 
     You can find more information about Pango markup formatting at the
     corresponding documentation page:
     `Pango Markup <https://developer.gnome.org/pango/stable/pango-Markup.html>`_.
     Please be aware that not all features are supported by this class and that
-    the `<color>` and `<gradient>` tags are not official ones.
+    the ``<color>`` and ``<gradient>`` tags mentioned above are not supported by Pango.
 
     Parameters
     ----------
@@ -1140,7 +1139,7 @@ class MarkupText(SVGMobject):
 
     Returns
     -------
-    :class:`Text`
+    :class:`MarkupText`
         The mobject like :class:`.VGroup`.
 
     Examples
@@ -1224,18 +1223,16 @@ class MarkupText(SVGMobject):
 
         class MultiLanguage(Scene):
             def construct(self):
-                morning = Text("வணக்கம்", font="sans-serif")
-                chin = Text(
-                    "見 角 言 谷  辛 辰 辵 邑 酉 釆 里!", t2c={"見 角 言": BLUE}
-                )  # works as in  ``Text``
-                mess = Text("Multi-Language", style=BOLD)
-                russ = Text("Здравствуйте मस नम म ", font="sans-serif")
-                hin = Text("नमस्ते", font="sans-serif")
-                japanese = Text("臂猿「黛比」帶著孩子", font="sans-serif")
-                self.add(morning,chin,mess,russ,hin,japanese)
-                for i,mobj in enumerate(self.mobjects):
-                    mobj.shift(DOWN*(i-3))
-
+                morning = MarkupText("வணக்கம்", font="sans-serif")
+                chin = MarkupText(
+                    '見 角 言 谷  辛 <color col="BLUE">辰 辵 邑</color> 酉 釆 里!'
+                )  # works as in ``Text``.
+                mess = MarkupText("Multi-Language", style=BOLD)
+                russ = MarkupText("Здравствуйте मस नम म ", font="sans-serif")
+                hin = MarkupText("नमस्ते", font="sans-serif")
+                japanese = MarkupText("臂猿「黛比」帶著孩子", font="sans-serif")
+                group = VGroup(morning, chin, mess, russ, hin, japanese).arrange(DOWN)
+                self.add(group)
 
 
     Tests
@@ -1438,7 +1435,7 @@ class MarkupText(SVGMobject):
     def extract_gradient_tags(self):
         """Internally used function.
         Used to determine what parts (if any) of the string should be formatted with a gradient.
-        Removes the `<gradient>` tag, as it is not part of Pango's markup and would cause an error."""
+        Removes the ``<gradient>`` tag, as it is not part of Pango's markup and would cause an error."""
         tags = re.finditer(
             '<gradient\s+from="([^"]+)"\s+to="([^"]+)"(\s+offset="([^"]+)")?>(.+?)</gradient>',
             self.original_text,
@@ -1467,7 +1464,7 @@ class MarkupText(SVGMobject):
     def extract_color_tags(self):
         """Internally used function.
         Used to determine what parts (if any) of the string should be formatted with a custom color.
-        Removes the `<color>` tag, as it is not part of Pango's markup and would cause an error."""
+        Removes the ``<color>`` tag, as it is not part of Pango's markup and would cause an error."""
         tags = re.finditer(
             '<color\s+col="([^"]+)"(\s+offset="([^"]+)")?>(.+?)</color>',
             self.original_text,

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -103,6 +103,50 @@ def remove_invisible_chars(mobject):
     return mobject_without_dots
 
 
+class PangoUtils(object):
+    @staticmethod
+    def str2style(string):
+        """Internally used function. Converts text to Pango Understandable Styles."""
+        if string == NORMAL:
+            return pangocffi.Style.NORMAL
+        elif string == ITALIC:
+            return pangocffi.Style.ITALIC
+        elif string == OBLIQUE:
+            return pangocffi.Style.OBLIQUE
+        else:
+            raise AttributeError("There is no Style Called %s" % string)
+
+    @staticmethod
+    def str2weight(string):
+        """Internally used function. Convert text to Pango Understandable Weight"""
+        if string == NORMAL:
+            return pangocffi.Weight.NORMAL
+        elif string == BOLD:
+            return pangocffi.Weight.BOLD
+        elif string == THIN:
+            return pangocffi.Weight.THIN
+        elif string == ULTRALIGHT:
+            return pangocffi.Weight.ULTRALIGHT
+        elif string == LIGHT:
+            return pangocffi.Weight.LIGHT
+        elif string == SEMILIGHT:
+            return pangocffi.Weight.SEMILIGHT
+        elif string == BOOK:
+            return pangocffi.Weight.BOOK
+        elif string == MEDIUM:
+            return pangocffi.Weight.MEDIUM
+        elif string == SEMIBOLD:
+            return pangocffi.Weight.SEMIBOLD
+        elif string == ULTRABOLD:
+            return pangocffi.Weight.ULTRABOLD
+        elif string == HEAVY:
+            return pangocffi.Weight.HEAVY
+        elif string == ULTRAHEAVY:
+            return pangocffi.Weight.ULTRAHEAVY
+        else:
+            raise AttributeError("There is no Font Weight Called %s" % string)
+
+
 class TextSetting(object):
     def __init__(self, start, end, font, slant, weight, line_num=-1):
         self.start = start
@@ -915,46 +959,6 @@ class Text(SVGMobject):
             for start, end in self.find_indexes(word, self.original_text):
                 self.chars[start:end].set_color_by_gradient(*gradient)
 
-    def str2style(self, string):
-        """Internally used function. Converts text to Pango Understandable Styles."""
-        if string == NORMAL:
-            return pangocffi.Style.NORMAL
-        elif string == ITALIC:
-            return pangocffi.Style.ITALIC
-        elif string == OBLIQUE:
-            return pangocffi.Style.OBLIQUE
-        else:
-            raise AttributeError("There is no Style Called %s" % string)
-
-    def str2weight(self, string):
-        """Internally used function. Convert text to Pango Understandable Weight"""
-        if string == NORMAL:
-            return pangocffi.Weight.NORMAL
-        elif string == BOLD:
-            return pangocffi.Weight.BOLD
-        elif string == THIN:
-            return pangocffi.Weight.THIN
-        elif string == ULTRALIGHT:
-            return pangocffi.Weight.ULTRALIGHT
-        elif string == LIGHT:
-            return pangocffi.Weight.LIGHT
-        elif string == SEMILIGHT:
-            return pangocffi.Weight.SEMILIGHT
-        elif string == BOOK:
-            return pangocffi.Weight.BOOK
-        elif string == MEDIUM:
-            return pangocffi.Weight.MEDIUM
-        elif string == SEMIBOLD:
-            return pangocffi.Weight.SEMIBOLD
-        elif string == ULTRABOLD:
-            return pangocffi.Weight.ULTRABOLD
-        elif string == HEAVY:
-            return pangocffi.Weight.HEAVY
-        elif string == ULTRAHEAVY:
-            return pangocffi.Weight.ULTRAHEAVY
-        else:
-            raise AttributeError("There is no Font Weight Called %s" % string)
-
     def text2hash(self):
         """Internally used function.
         Generates ``sha256`` hash for file name.
@@ -1039,8 +1043,8 @@ class Text(SVGMobject):
         layout.set_width(pangocffi.units_from_double(600))
         for setting in settings:
             family = setting.font
-            style = self.str2style(setting.slant)
-            weight = self.str2weight(setting.weight)
+            style = PangoUtils.str2style(setting.slant)
+            weight = PangoUtils.str2weight(setting.weight)
             text = self.text[setting.start : setting.end].replace("\n", " ")
             fontdesc = pangocffi.FontDescription()
             fontdesc.set_size(pangocffi.units_from_double(size))
@@ -1397,8 +1401,8 @@ class MarkupText(SVGMobject):
         fontdesc.set_size(pangocffi.units_from_double(size))
         if self.font:
             fontdesc.set_family(self.font)
-        fontdesc.set_style(self.str2style(self.slant))
-        fontdesc.set_weight(self.str2weight(self.weight))
+        fontdesc.set_style(PangoUtils.str2style(self.slant))
+        fontdesc.set_weight(PangoUtils.str2weight(self.weight))
         layout.set_font_description(fontdesc)
 
         context.move_to(START_X, START_Y)
@@ -1502,46 +1506,6 @@ class MarkupText(SVGMobject):
 
     def __repr__(self):
         return f"MarkupText({repr(self.original_text)})"
-
-    def str2style(self, string):
-        """Internally used function. Converts text to Pango Understandable Styles."""
-        if string == NORMAL:
-            return pangocffi.Style.NORMAL
-        elif string == ITALIC:
-            return pangocffi.Style.ITALIC
-        elif string == OBLIQUE:
-            return pangocffi.Style.OBLIQUE
-        else:
-            raise AttributeError("There is no Style Called %s" % string)
-
-    def str2weight(self, string):
-        """Internally used function. Convert text to Pango Understandable Weight"""
-        if string == NORMAL:
-            return pangocffi.Weight.NORMAL
-        elif string == BOLD:
-            return pangocffi.Weight.BOLD
-        elif string == THIN:
-            return pangocffi.Weight.THIN
-        elif string == ULTRALIGHT:
-            return pangocffi.Weight.ULTRALIGHT
-        elif string == LIGHT:
-            return pangocffi.Weight.LIGHT
-        elif string == SEMILIGHT:
-            return pangocffi.Weight.SEMILIGHT
-        elif string == BOOK:
-            return pangocffi.Weight.BOOK
-        elif string == MEDIUM:
-            return pangocffi.Weight.MEDIUM
-        elif string == SEMIBOLD:
-            return pangocffi.Weight.SEMIBOLD
-        elif string == ULTRABOLD:
-            return pangocffi.Weight.ULTRABOLD
-        elif string == HEAVY:
-            return pangocffi.Weight.HEAVY
-        elif string == ULTRAHEAVY:
-            return pangocffi.Weight.ULTRAHEAVY
-        else:
-            raise AttributeError("There is no Font Weight Called %s" % string)
 
     def remove_last_M(self, file_name):
         with open(file_name, "r") as fpr:

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1097,12 +1097,10 @@ class MarkupText(SVGMobject):
     or do not want to do without ligatures, the `gradient` and `color` tag support
     an optional attribute `offset` which can be used to compensate for that error.
     Usage is as follows:
-    - `<color col="RED" offset="1">red text</color>`
-      to *start* coloring one letter earlier
-    - `<color col="RED" offset=",1">red text</color>`
-      to *end* coloring one letter earlier
-    - `<color colr="RED" offset="2,1">red text</color>`
-      to *start* coloring two letters earlier and *end* one letter earlier
+    - `<color col="RED" offset="1">red text</color>` to *start* coloring one letter earlier
+    - `<color col="RED" offset=",1">red text</color>` to *end* coloring one letter earlier
+    - `<color colr="RED" offset="2,1">red text</color>` to *start* coloring two letters earlier and *end* one letter earlier
+
     Specifying a second offset may be necessary if the text to be colored does
     itself contain ligatures. The same can happen when using HTML entities for
     special chars.
@@ -1213,7 +1211,7 @@ class MarkupText(SVGMobject):
         class NoLigaturesExample(Scene):
             def construct(self):
                 text1 = MarkupText("floating")
-                #text2 = MarkupText("floating", disable_ligatures=True)
+                text2 = MarkupText("floating", disable_ligatures=True)
                 group = VGroup(text1, text2).arrange(DOWN)
                 self.add(group)
 
@@ -1366,6 +1364,7 @@ class MarkupText(SVGMobject):
             "MARKUPPANGO" + self.font + self.slant + self.weight
         )  # to differentiate from classical Pango Text
         settings += str(self.line_spacing) + str(self.size)
+        settings += str(self.disable_ligatures)
         id_str = self.text + settings
         hasher = hashlib.sha256()
         hasher.update(id_str.encode())

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -964,6 +964,7 @@ class Text(SVGMobject):
         )  # to differentiate Text and CairoText
         settings += str(self.t2f) + str(self.t2s) + str(self.t2w)
         settings += str(self.line_spacing) + str(self.size)
+        settings += str(self.disable_ligatures)
         id_str = self.text + settings
         hasher = hashlib.sha256()
         hasher.update(id_str.encode())

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1097,7 +1097,7 @@ class MarkupText(SVGMobject):
     text : :class:`str`
         The text that need to created as mobject.
     fill_opacity : :class:`int`
-        The fill opacity with 1 meaning opaque and 0 meaning transparent
+        The fill opacity with 1 meaning opaque and 0 meaning transparent.
     stroke_width : :class:`int`
         Stroke width.
     color : :class:`str`
@@ -1119,7 +1119,7 @@ class MarkupText(SVGMobject):
     Returns
     -------
     :class:`MarkupText`
-        The mobject like :class:`.VGroup`.
+        The text displayed in form of a :class:`.VGroup`-like mobject.
 
     Examples
     ---------
@@ -1136,7 +1136,7 @@ class MarkupText(SVGMobject):
                 text5 = MarkupText(
                     '<span underline="double">foo</span> <span underline="error">bar</span>'
                 )
-                group = VGroup(text1,text2,text3,text4,text5).arrange(DOWN)
+                group = VGroup(text1, text2, text3, text4, text5).arrange(DOWN)
                 self.add(group)
 
     .. manim:: ColorExample

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1333,8 +1333,7 @@ class MarkupText(SVGMobject):
             self.scale(TEXT_MOB_SCALE_FACTOR)
 
     def text2hash(self):
-        """Generates ``sha256`` hash for file name.
-        """
+        """Generates ``sha256`` hash for file name."""
         settings = (
             "MARKUPPANGO" + self.font + self.slant + self.weight
         )  # to differentiate from classical Pango Text
@@ -1346,8 +1345,7 @@ class MarkupText(SVGMobject):
         return hasher.hexdigest()[:16]
 
     def text2svg(self):
-        """Convert the text to SVG using Pango.
-        """
+        """Convert the text to SVG using Pango."""
         size = self.size * 10
         line_spacing = self.line_spacing * 10
         dir_name = config.get_dir("text_dir")

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1094,7 +1094,7 @@ class MarkupText(SVGMobject):
 
     If your text contains ligatures, the :class:`MarkupText` class may incorrectly determine
     the first and last letter to be colored. This is due to the fact that e.g. ``fl``
-    are two characters, but can be set as one single glyph, a ligature. If your language does
+    are two characters, but might be set as one single glyph, a ligature. If your language does
     not depend on ligatures, consider setting ``disable_ligatures=True``. If you cannot
     or do not want to do without ligatures, the ``gradient`` and ``color`` tag support
     an optional attribute ``offset`` which can be used to compensate for that error.

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1,5 +1,3 @@
-from manim.utils.color import Colors
-
 """Mobjects used for displaying (non-LaTeX) text.
 
 The simplest way to add text to your animations is to use the :class:`~.Text` class. It uses the Pango library to render text.
@@ -65,6 +63,8 @@ from ...mobject.geometry import Dot
 from ...mobject.svg.svg_mobject import SVGMobject
 from ...mobject.types.vectorized_mobject import VGroup
 from ...utils.color import WHITE
+from ...utils.color import Colors
+
 
 TEXT_MOB_SCALE_FACTOR = 0.05
 
@@ -1073,7 +1073,7 @@ class Text(SVGMobject):
 # <span underline="..."> single,double,error
 # <color col="..."> with #xxxxxx or manim constant
 # <gradient from="..." to="...">
-class MarkupText(Text):
+class MarkupText(SVGMobject):
     def __init__(
         self,
         text: str,
@@ -1267,3 +1267,35 @@ class MarkupText(Text):
             colormap.append({"start": start, "end": end, "color": tag.group(1)})
         self.text = re.sub('<color col="([^"]+)">(.+?)</color>', r"\2", self.text)
         return colormap
+
+    def __repr__(self):
+        return f"MarkupText({repr(self.original_text)})"
+
+    def gen_chars(self):
+        chars = VGroup()
+        submobjects_char_index = 0
+        for char_index in range(self.text.__len__()):
+            if (
+                self.text[char_index] == " "
+                or self.text[char_index] == "\t"
+                or self.text[char_index] == "\n"
+            ):
+                space = Dot(radius=0, fill_opacity=0, stroke_opacity=0)
+                if char_index == 0:
+                    space.move_to(self.submobjects[submobjects_char_index].get_center())
+                else:
+                    space.move_to(
+                        self.submobjects[submobjects_char_index - 1].get_center()
+                    )
+                chars.add(space)
+            else:
+                chars.add(self.submobjects[submobjects_char_index])
+                submobjects_char_index += 1
+        return chars
+
+    def remove_last_M(self, file_name):
+        with open(file_name, "r") as fpr:
+            content = fpr.read()
+        content = re.sub(r'Z M [^A-Za-z]*? "\/>', 'Z "/>', content)
+        with open(file_name, "w") as fpw:
+            fpw.write(content)

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1204,6 +1204,14 @@ class MarkupText(SVGMobject):
                 group = VGroup(text1, text2, text3, text4).arrange(DOWN)
                 self.add(group)
 
+    .. manim:: NewlineExample
+        :save_last_frame:
+
+        class NewlineExample(Scene):
+            def construct(self):
+                text = MarkupText('foooo<color col="RED">oo\nbaa</color>aar')
+                self.add(text)
+
     .. manim:: NoLigaturesExample
         :save_last_frame:
 
@@ -1465,7 +1473,6 @@ class MarkupText(SVGMobject):
             self.original_text,
             re.S,
         )
-        print("tags", tags)
 
         colormap = []
         for tag in tags:

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -609,7 +609,6 @@ class Paragraph(VGroup):
             )
 
 
-            
 class Text(SVGMobject):
     r"""Display (non-LaTeX) text rendered using `Pango <https://pango.gnome.org/>`_.
 
@@ -1076,24 +1075,24 @@ class Text(SVGMobject):
 # <gradient from="..." to="...">
 class MarkupText(Text):
     def __init__(
-            self,
-            text: str,
-            fill_opacity: int = 1,
-            stroke_width: int = 0,
-            color: str = WHITE,
-            size: int = 1,
-            line_spacing: int = -1,
-            font: str = "",
-            slant = NORMAL,
-            weight = NORMAL,
-            gradient: tuple = None,
-            tab_width: int = 4,
-            height: int = None,
-            width: int = None,
-            should_center: bool = True,
-            unpack_groups: bool = True,
-            disable_ligatures: bool = False,
-            **kwargs,
+        self,
+        text: str,
+        fill_opacity: int = 1,
+        stroke_width: int = 0,
+        color: str = WHITE,
+        size: int = 1,
+        line_spacing: int = -1,
+        font: str = "",
+        slant=NORMAL,
+        weight=NORMAL,
+        gradient: tuple = None,
+        tab_width: int = 4,
+        height: int = None,
+        width: int = None,
+        should_center: bool = True,
+        unpack_groups: bool = True,
+        disable_ligatures: bool = False,
+        **kwargs,
     ):
         self.text = text
         self.size = size
@@ -1103,15 +1102,15 @@ class MarkupText(Text):
         self.weight = weight
         self.gradient = gradient
         self.tab_width = tab_width
-        
+
         self.original_text = text
         self.disable_ligatures = disable_ligatures
         text_without_tabs = text
         if text.find("\t") != -1:
             text_without_tabs = text.replace("\t", " " * self.tab_width)
 
-        colormap=self.extract_color_tags()
-        gradientmap=self.extract_gradient_tags()
+        colormap = self.extract_color_tags()
+        gradientmap = self.extract_gradient_tags()
 
         if self.line_spacing == -1:
             self.line_spacing = self.size + self.size * 0.3
@@ -1154,23 +1153,21 @@ class MarkupText(Text):
                     each.add_line_to(last)
                     last = points[index + 1]
             each.add_line_to(last)
-        
+
         if self.gradient:
             self.set_color_by_gradient(*self.gradient)
         for col in colormap:
-            self.chars[col["start"]:col["end"]].set_color(
+            self.chars[col["start"] : col["end"]].set_color(
                 Colors[col["color"].lower()].value
             )
         for grad in gradientmap:
-            self.chars[grad["start"]:grad["end"]]\
-                .set_color_by_gradient(*(
-                    Colors[grad["from"].lower()].value,
-                    Colors[grad["to"].lower()].value
-                ))
+            self.chars[grad["start"] : grad["end"]].set_color_by_gradient(
+                *(Colors[grad["from"].lower()].value, Colors[grad["to"].lower()].value)
+            )
         # anti-aliasing
         if self.height is None and self.width is None:
             self.scale(TEXT_MOB_SCALE_FACTOR)
-        
+
     def text2hash(self):
         """Internally used function.
         Generates ``sha256`` hash for file name.
@@ -1183,7 +1180,7 @@ class MarkupText(Text):
         hasher = hashlib.sha256()
         hasher.update(id_str.encode())
         return hasher.hexdigest()[:16]
-        
+
     def text2svg(self):
         """Internally used function.
         Convert the text to SVG using Pango
@@ -1213,11 +1210,9 @@ class MarkupText(Text):
         fontdesc.set_style(self.str2style(self.slant))
         fontdesc.set_weight(self.str2weight(self.weight))
         layout.set_font_description(fontdesc)
-            
+
         text = self.text.replace("\n", " ")
-        context.move_to(
-            START_X, START_Y
-        )
+        context.move_to(START_X, START_Y)
         pangocairocffi.update_layout(context, layout)
         if disable_liga:
             layout.set_markup(f"<span font_features='liga=0'>{text}</span>")
@@ -1225,55 +1220,50 @@ class MarkupText(Text):
             layout.set_markup(text)
         logger.debug(f"Setting Text {text}")
         pangocairocffi.show_layout(context, layout)
-        #offset_x += pangocffi.units_to_double(layout.get_size()[0])
+        # offset_x += pangocffi.units_to_double(layout.get_size()[0])
         surface.finish()
         return file_name
 
     # FIXME: doc
     # FIXME: counting of ligatures is off
     def _count_true_chars(self, s):
-        count=0
-        level=0 
+        count = 0
+        level = 0
         for c in s:
-            if c=="<": 
-                level+=1
-            if c==">" and level>0:
-                level-=1
-            elif c!=" " and level==0:
-                count+=1
+            if c == "<":
+                level += 1
+            if c == ">" and level > 0:
+                level -= 1
+            elif c != " " and level == 0:
+                count += 1
         return count
 
     # FIXME: doc
     def extract_gradient_tags(self):
         """Internally used function."""
-        tags=re.finditer('<gradient from="([^"]+)" to="([^"]+)">(.+?)</gradient>',self.original_text)
-        gradientmap=[]
+        tags = re.finditer(
+            '<gradient from="([^"]+)" to="([^"]+)">(.+?)</gradient>', self.original_text
+        )
+        gradientmap = []
         for tag in tags:
-            start=self._count_true_chars(self.original_text[:tag.start(0)])
-            end=start+self._count_true_chars(tag.group(3))
+            start = self._count_true_chars(self.original_text[: tag.start(0)])
+            end = start + self._count_true_chars(tag.group(3))
             gradientmap.append(
-                {"start": start,
-                 "end": end,
-                 "from": tag.group(1),
-                 "to": tag.group(2)
-                }
+                {"start": start, "end": end, "from": tag.group(1), "to": tag.group(2)}
             )
-        self.text = re.sub('<gradient from="([^"]+)" to="([^"]+)">(.+?)</gradient>',r"\3",self.text)
+        self.text = re.sub(
+            '<gradient from="([^"]+)" to="([^"]+)">(.+?)</gradient>', r"\3", self.text
+        )
         return gradientmap
 
     # FIXME: doc
     def extract_color_tags(self):
         """Internally used function."""
-        tags=re.finditer('<color col="([^"]+)">(.+?)</color>',self.original_text)
-        colormap=[]
+        tags = re.finditer('<color col="([^"]+)">(.+?)</color>', self.original_text)
+        colormap = []
         for tag in tags:
-            start=self._count_true_chars(self.original_text[:tag.start(0)])
-            end=start+self._count_true_chars(tag.group(2))
-            colormap.append(
-                {"start": start,
-                 "end": end,
-                 "color": tag.group(1)}
-            )
-        self.text = re.sub('<color col="([^"]+)">(.+?)</color>',r"\2",self.text)
+            start = self._count_true_chars(self.original_text[: tag.start(0)])
+            end = start + self._count_true_chars(tag.group(2))
+            colormap.append({"start": start, "end": end, "color": tag.group(1)})
+        self.text = re.sub('<color col="([^"]+)">(.+?)</color>', r"\2", self.text)
         return colormap
-

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1221,8 +1221,8 @@ class MarkupText(SVGMobject):
 
         class NoLigaturesExample(Scene):
             def construct(self):
-                text1 = MarkupText("floating")
-                text2 = MarkupText("floating", disable_ligatures=True)
+                text1 = MarkupText('fl<color col="RED">oat</color>ing')
+                text2 = MarkupText('fl<color col="RED">oat</color>ing', disable_ligatures=True)
                 group = VGroup(text1, text2).arrange(DOWN)
                 self.add(group)
 

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1057,7 +1057,7 @@ class Text(SVGMobject):
             pangocairocffi.update_layout(context, layout)
             if disable_liga:
                 text = escape(text)
-                layout.set_markup(f"<span font_features='liga=0'>{text}</span>")
+                layout.set_markup(f"<span font_features='liga=0,dlig=0,clig=0,hlig=0'>{text}</span>")
             else:
                 layout.set_text(text)
             logger.debug(f"Setting Text {text}")
@@ -1225,7 +1225,7 @@ class MarkupText(SVGMobject):
         context.move_to(START_X, START_Y)
         pangocairocffi.update_layout(context, layout)
         if disable_liga:
-            layout.set_markup(f"<span font_features='liga=0'>{text}</span>")
+            layout.set_markup(f"<span font_features='liga=0,dlig=0,clig=0,hlig=0'>{text}</span>")
         else:
             layout.set_markup(text)
         logger.debug(f"Setting Text {text}")

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -153,8 +153,8 @@ class CairoText(SVGMobject):
         gradient=None,
         line_spacing=-1,
         size=1,
-        slant=NORMAL,
-        weight=NORMAL,
+        slant: str = NORMAL,
+        weight: str = NORMAL,
         t2c=None,
         t2f=None,
         t2g=None,
@@ -729,8 +729,8 @@ class Text(SVGMobject):
         size: int = 1,
         line_spacing: int = -1,
         font: str = "",
-        slant=NORMAL,
-        weight=NORMAL,
+        slant: str = NORMAL,
+        weight: str = NORMAL,
         t2c: Dict[str, str] = None,
         t2f: Dict[str, str] = None,
         t2g: Dict[str, tuple] = None,
@@ -1085,7 +1085,7 @@ class MarkupText(SVGMobject):
     - ``<span underline="double">double underline</span>``
     - ``<span underline="error">error underline</span>``
     - ``<span font_family="sans">temporary change of font</span>``
-    - ``<color col="RED">temporary change of color</color>``; colors can be specified as Manim constants like ``RED`` or ``YELLOW``
+    - ``<color col="RED">temporary change of color</color>``; colors can be specified as Manim constants like ``RED`` or ``YELLOW`` or as hex triples like ``#aabbaa``
     - ``<gradient from="YELLOW" to="RED">temporary gradient</gradient>``; colors specified as above
 
     If your text contains ligatures, the :class:`MarkupText` class may incorrectly determine
@@ -1174,10 +1174,10 @@ class MarkupText(SVGMobject):
                     gradient=(BLUE, GREEN),
                 )
                 text4 = MarkupText(
-                    'fl ligature <color col="GREEN">causing trouble</color> here'
+                    'fl ligature <color col="#00ff00">causing trouble</color> here'
                 )
                 text5 = MarkupText(
-                    'fl ligature <color col="GREEN" offset="1">defeated</color> with offset'
+                    'fl ligature <color col="#00ff00" offset="1">defeated</color> with offset'
                 )
                 text6 = MarkupText(
                     'fl ligature <color col="GREEN" offset="1">floating</color> inside'
@@ -1268,8 +1268,8 @@ class MarkupText(SVGMobject):
         size: int = 1,
         line_spacing: int = -1,
         font: str = "",
-        slant=NORMAL,
-        weight=NORMAL,
+        slant: str = NORMAL,
+        weight: str = NORMAL,
         gradient: tuple = None,
         tab_width: int = 4,
         height: int = None,
@@ -1347,7 +1347,7 @@ class MarkupText(SVGMobject):
                 - col["start_offset"] : col["end"]
                 - col["start_offset"]
                 - col["end_offset"]
-            ].set_color(Colors[col["color"].lower()].value)
+            ].set_color(self._parse_color(col["color"]))
         for grad in gradientmap:
             self.chars[
                 grad["start"]
@@ -1355,7 +1355,7 @@ class MarkupText(SVGMobject):
                 - grad["start_offset"]
                 - grad["end_offset"]
             ].set_color_by_gradient(
-                *(Colors[grad["from"].lower()].value, Colors[grad["to"].lower()].value)
+                *(self._parse_color(grad["from"]), self._parse_color(grad["to"]))
             )
         # anti-aliasing
         if self.height is None and self.width is None:
@@ -1463,6 +1463,14 @@ class MarkupText(SVGMobject):
             )
         self.text = re.sub("<gradient[^>]+>(.+?)</gradient>", r"\1", self.text, 0, re.S)
         return gradientmap
+
+    def _parse_color(self, col):
+        """Internally used function.
+        Parse color given in ``<color>`` or ``<gradient>`` tags."""
+        if re.match("#[0-9a-f]{6}", col):
+            return col
+        else:
+            return Colors[col.lower()].value
 
     def extract_color_tags(self):
         """Internally used function.

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1316,8 +1316,6 @@ class MarkupText(SVGMobject):
             unpack_groups=unpack_groups,
             **kwargs,
         )
-        if self.disable_ligatures:
-            self.submobjects = [*self.gen_chars()]
         self.chars = VGroup(*self.submobjects)
         self.text = text_without_tabs.replace(" ", "").replace("\n", "")
 
@@ -1504,28 +1502,6 @@ class MarkupText(SVGMobject):
 
     def __repr__(self):
         return f"MarkupText({repr(self.original_text)})"
-
-    def gen_chars(self):
-        chars = VGroup()
-        submobjects_char_index = 0
-        for char_index in range(self.text.__len__()):
-            if (
-                self.text[char_index] == " "
-                or self.text[char_index] == "\t"
-                or self.text[char_index] == "\n"
-            ):
-                space = Dot(radius=0, fill_opacity=0, stroke_opacity=0)
-                if char_index == 0:
-                    space.move_to(self.submobjects[submobjects_char_index].get_center())
-                else:
-                    space.move_to(
-                        self.submobjects[submobjects_char_index - 1].get_center()
-                    )
-                chars.add(space)
-            else:
-                chars.add(self.submobjects[submobjects_char_index])
-                submobjects_char_index += 1
-        return chars
 
     def str2style(self, string):
         """Internally used function. Converts text to Pango Understandable Styles."""

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1212,7 +1212,7 @@ class MarkupText(SVGMobject):
         class NoLigaturesExample(Scene):
             def construct(self):
                 text1 = MarkupText("floating")
-                text2 = MarkupText("floating", disable_ligatures=True)
+                #text2 = MarkupText("floating", disable_ligatures=True)
                 group = VGroup(text1, text2).arrange(DOWN)
                 self.add(group)
 

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1069,13 +1069,192 @@ class Text(SVGMobject):
         return file_name
 
 
-# FIXME: documentation
-# <b>, <i>, <tt>, <big>, <small>, <s>, <sub>, <sup>, <u>
-# <span font_family="...">
-# <span underline="..."> single,double,error
-# <color col="..." offset="..."> with #xxxxxx or manim constant
-# <gradient from="..." to="..." offset="...">
 class MarkupText(SVGMobject):
+    r"""Display (non-LaTeX) text rendered using `Pango <https://pango.gnome.org/>`_.
+
+    Text objects behave like a :class:`.VGroup`-like iterable of all characters
+    in the given text. In particular, slicing is possible. Text can be formatted
+    using different tags:
+
+    - `<b>bold</b>`, `<i>italic</i>` and `<b><i>bold+italic</i></b>`
+    - `<ul>underline</ul>` and `<s>strike through</s>`
+    - `<tt>typewriter font</tt>`
+    - `<big>bigger font</big>` and `<small>smaller font</small>`
+    - `<sup>superscript</sup>` and `<sub>subscript</sub>`
+    - `<span underline="double">double underline</span>`
+    - `<span underline="error">error underline</span>`
+    - `<span font_family="sans">temporary change of font</span>`
+    - `<color col="RED">temporary change of color</color>`;
+       colors can be specified as Manim constants like `RED` or `YELLOW`
+    - `<gradient from="YELLOW" to="RED">temporary gradient</gradient>`;
+       colors specified as above
+
+    When your text contains ligatures, the `MarkupText` class may incorrectly determine
+    the first and last letter to be colored. This is due to the fact that e.g. `fl`
+    are two characters, but will be set as one single glyph. If your language does
+    not depend on ligatures, consider setting `disable_ligatures=True`. If you cannot
+    or do not want to do without ligatures, the `gradient` and `color` tag support
+    an optional attribute `offset` which can be used to compensate for that error.
+    Usage is as follows:
+    - `<color col="RED" offset="1">red text</color>`
+      to *start* coloring one letter earlier
+    - `<color col="RED" offset=",1">red text</color>`
+      to *end* coloring one letter earlier
+    - `<color colr="RED" offset="2,1">red text</color>`
+      to *start* coloring two letters earlier and *end* one letter earlier
+    Specifying a second offset may be necessary if the text to be colored does
+    itself contain ligatures. The same can happen when using HTML entities for
+    special chars.
+
+    Escaping of special characters: `>` *should* be written as `&gt;` whereas `<` and
+    `&` *must* to be written as `&lt;` and `&amp;`.
+
+    You can find more information about Pango markup formatting at the
+    corresponding documentation page:
+    `Pango Markup <https://developer.gnome.org/pango/stable/pango-Markup.html>`_.
+    Please be aware that not all features are supported by this class and that
+    the `<color>` and `<gradient>` tags are not official ones.
+
+    Parameters
+    ----------
+    text : :class:`str`
+        The text that need to created as mobject.
+    fill_opacity : :class:`int`
+        The fill opacity with 1 meaning opaque and 0 meaning transparent
+    stroke_width : :class:`int`
+        Stroke width.
+    color : :class:`str`
+        Global color setting for the entire text. Local overrides are possible.
+    size : :class:`int`
+        Font size.
+    line_spacing : :class:`int`
+        Line spacing.
+    font : :class:`str`
+        Global font setting for the entire text. Local overrides are possible.
+    slant : :class:`str`
+        Global slant setting, e.g. `NORMAL` or `ITALIC`. Local overrides are possible.
+    weight : :class:`str`
+        Global weight setting, e.g. `NORMAL` or `BOLD`. Local overrides are possible.
+    gradient: :class:`tuple`
+        Global gradient setting. Local overrides are possible.
+
+
+    Returns
+    -------
+    :class:`Text`
+        The mobject like :class:`.VGroup`.
+
+    Examples
+    ---------
+
+    .. manim:: BasicMarkupExample
+        :save_last_frame:
+
+        class BasicMarkupExample(Scene):
+            def construct(self):
+                text1 = MarkupText("<b>foo</b> <i>bar</i> <b><i>foobar</i></b>")
+                text2 = MarkupText("<s>foo</s> <u>bar</u> <big>big</big> <small>small</small>")
+                text3 = MarkupText("H<sub>2</sub>O and H<sub>3</sub>O<sup>+</sup>")
+                text4 = MarkupText("type <tt>help</tt> for help")
+                text5 = MarkupText(
+                    '<span underline="double">foo</span> <span underline="error">bar</span>'
+                )
+                group = VGroup(text1,text2,text3,text4,text5).arrange(DOWN)
+                self.add(group)
+
+    .. manim:: ColorExample
+        :save_last_frame:
+
+        class ColorExample(Scene):
+            def construct(self):
+                text1 = MarkupText(
+                    'all in red <color col="YELLOW">except this</color>', color=RED
+                )
+                text2 = MarkupText("nice gradient", gradient=(BLUE, GREEN))
+                text3 = MarkupText(
+                    'nice <gradient from="RED" to="YELLOW">intermediate</gradient> gradient',
+                    gradient=(BLUE, GREEN),
+                )
+                text4 = MarkupText(
+                    'fl ligature <color col="GREEN">causing trouble</color> here'
+                )
+                text5 = MarkupText(
+                    'fl ligature <color col="GREEN" offset="1">defeated</color> with offset'
+                )
+                text6 = MarkupText(
+                    'fl ligature <color col="GREEN" offset="1">floating</color> inside'
+                )
+                text7 = MarkupText(
+                    'fl ligature <color col="GREEN" offset="1,1">floating</color> inside'
+                )
+                group = VGroup(text1, text2, text3, text4, text5, text6, text7).arrange(DOWN)
+                self.add(group)
+
+    .. manim:: FontExample
+        :save_last_frame:
+
+        class FontExample(Scene):
+            def construct(self):
+                text1 = MarkupText(
+                    'all in sans <span font_family="serif">except this</span>', font="sans"
+                )
+                text2 = MarkupText(
+                    '<span font_family="serif">mixing</span> <span font_family="sans">fonts</span> <span font_family="monospace">is ugly</span>'
+                )
+                text3 = MarkupText("special char > or &gt;")
+                text4 = MarkupText("special char &lt; and &amp;")
+                group = VGroup(text1, text2, text3, text4).arrange(DOWN)
+                self.add(group)
+
+    .. manim:: NoLigaturesExample
+        :save_last_frame:
+
+        class NoLigaturesExample(Scene):
+            def construct(self):
+                text1 = MarkupText("floating")
+                text2 = MarkupText("floating", disable_ligatures=True)
+                group = VGroup(text1, text2).arrange(DOWN)
+                self.add(group)
+
+
+    As :class:`MarkupText` uses Pango to render text, rendering non-English
+    characters is easily possible:
+
+    .. manim:: MultiLanguage
+        :save_last_frame:
+
+        class MultiLanguage(Scene):
+            def construct(self):
+                morning = Text("வணக்கம்", font="sans-serif")
+                chin = Text(
+                    "見 角 言 谷  辛 辰 辵 邑 酉 釆 里!", t2c={"見 角 言": BLUE}
+                )  # works as in  ``Text``
+                mess = Text("Multi-Language", style=BOLD)
+                russ = Text("Здравствуйте मस नम म ", font="sans-serif")
+                hin = Text("नमस्ते", font="sans-serif")
+                japanese = Text("臂猿「黛比」帶著孩子", font="sans-serif")
+                self.add(morning,chin,mess,russ,hin,japanese)
+                for i,mobj in enumerate(self.mobjects):
+                    mobj.shift(DOWN*(i-3))
+
+
+
+    Tests
+    -----
+
+    Check that the creation of :class:`~.MarkupText` works::
+
+        >>> MarkupText('The horse does not eat cucumber salad.')
+        MarkupText('The horse does not eat cucumber salad.')
+
+    .. WARNING::
+
+        Using a :class:`.Transform` on text with leading whitespace can look
+        `weird <https://github.com/3b1b/manim/issues/1067>`_. Consider using
+        :meth:`remove_invisible_chars` to resolve this issue.
+
+    """
+
     def __init__(
         self,
         text: str,
@@ -1159,20 +1338,18 @@ class MarkupText(SVGMobject):
         if self.gradient:
             self.set_color_by_gradient(*self.gradient)
         for col in colormap:
-            if col["offset"]:
-                offset = int(col["offset"])
-            else:
-                offset = 0
-            self.chars[col["start"] - offset : col["end"] - offset].set_color(
-                Colors[col["color"].lower()].value
-            )
-        for grad in gradientmap:
-            if grad["offset"]:
-                offset = int(grad["offset"])
-            else:
-                offset = 0
             self.chars[
-                grad["start"] - offset : grad["end"] - offset
+                col["start"]
+                - col["start_offset"] : col["end"]
+                - col["start_offset"]
+                - col["end_offset"]
+            ].set_color(Colors[col["color"].lower()].value)
+        for grad in gradientmap:
+            self.chars[
+                grad["start"]
+                - grad["start_offset"] : grad["end"]
+                - grad["start_offset"]
+                - grad["end_offset"]
             ].set_color_by_gradient(
                 *(Colors[grad["from"].lower()].value, Colors[grad["to"].lower()].value)
             )
@@ -1212,6 +1389,7 @@ class MarkupText(SVGMobject):
         context.move_to(START_X, START_Y)
         offset_x = 0
         last_line_num = 0
+        # FIXME: do like in Text class
         layout = pangocairocffi.create_layout(context)
         layout.set_width(pangocffi.units_from_double(600))
 
@@ -1238,23 +1416,29 @@ class MarkupText(SVGMobject):
         surface.finish()
         return file_name
 
-    # FIXME: doc
-    # FIXME: counting of ligatures is off
+    # FIXME: special chars &lt; &gt; &amp; --> take into account
     def _count_real_chars(self, s):
+        """Internally used function.
+        Counts characters that will be displayed.
+        This is needed for partial coloring or gradients, because space
+        counts to the text's `len`, but has no corresponding letter"""
         count = 0
         level = 0
+        # temporarily replace HTML entities by single char
+        s = re.sub("&[^;]+;", "x", s)
         for c in s:
             if c == "<":
                 level += 1
             if c == ">" and level > 0:
                 level -= 1
-            elif c != " " and level == 0:
+            elif c != " " and c != "\t" and level == 0:
                 count += 1
         return count
 
-    # FIXME: doc
     def extract_gradient_tags(self):
-        """Internally used function."""
+        """Internally used function.
+        Used to determine what parts (if any) of the string should be formatted with a gradient.
+        Removes the `<gradient>` tag, as it is not part of Pango's markup and would cause an error."""
         tags = re.finditer(
             '<gradient\s+from="([^"]+)"\s+to="([^"]+)"(\s+offset="([^"]+)")?>(.+?)</gradient>',
             self.original_text,
@@ -1263,35 +1447,47 @@ class MarkupText(SVGMobject):
         for tag in tags:
             start = self._count_real_chars(self.original_text[: tag.start(0)])
             end = start + self._count_real_chars(tag.group(5))
+            offsets = tag.group(4).split(",") if tag.group(4) else [0]
+            start_offset = int(offsets[0]) if offsets[0] else 0
+            end_offset = int(offsets[1]) if len(offsets) == 2 and offsets[1] else 0
+
             gradientmap.append(
                 {
                     "start": start,
                     "end": end,
                     "from": tag.group(1),
                     "to": tag.group(2),
-                    "offset": tag.group(4),
+                    "start_offset": start_offset,
+                    "end_offset": end_offset,
                 }
             )
         self.text = re.sub("<gradient[^>]+>(.+?)</gradient>", r"\1", self.text)
         return gradientmap
 
-    # FIXME: doc
     def extract_color_tags(self):
-        """Internally used function."""
+        """Internally used function.
+        Used to determine what parts (if any) of the string should be formatted with a custom color.
+        Removes the `<color>` tag, as it is not part of Pango's markup and would cause an error."""
         tags = re.finditer(
             '<color\s+col="([^"]+)"(\s+offset="([^"]+)")?>(.+?)</color>',
             self.original_text,
         )
+
         colormap = []
         for tag in tags:
             start = self._count_real_chars(self.original_text[: tag.start(0)])
             end = start + self._count_real_chars(tag.group(4))
+            offsets = tag.group(3).split(",") if tag.group(3) else [0]
+            start_offset = int(offsets[0]) if offsets[0] else 0
+            end_offset = int(offsets[1]) if len(offsets) == 2 and offsets[1] else 0
+
             colormap.append(
                 {
                     "start": start,
                     "end": end,
                     "color": tag.group(1),
-                    "offset": tag.group(3),
+                    "start_offset": start_offset,
+                    "end_offset": end_offset,
                 }
             )
         self.text = re.sub("<color[^>]+>(.+?)</color>", r"\1", self.text)

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -1057,7 +1057,9 @@ class Text(SVGMobject):
             pangocairocffi.update_layout(context, layout)
             if disable_liga:
                 text = escape(text)
-                layout.set_markup(f"<span font_features='liga=0,dlig=0,clig=0,hlig=0'>{text}</span>")
+                layout.set_markup(
+                    f"<span font_features='liga=0,dlig=0,clig=0,hlig=0'>{text}</span>"
+                )
             else:
                 layout.set_text(text)
             logger.debug(f"Setting Text {text}")
@@ -1225,7 +1227,9 @@ class MarkupText(SVGMobject):
         context.move_to(START_X, START_Y)
         pangocairocffi.update_layout(context, layout)
         if disable_liga:
-            layout.set_markup(f"<span font_features='liga=0,dlig=0,clig=0,hlig=0'>{text}</span>")
+            layout.set_markup(
+                f"<span font_features='liga=0,dlig=0,clig=0,hlig=0'>{text}</span>"
+            )
         else:
             layout.set_markup(text)
         logger.debug(f"Setting Text {text}")

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -252,7 +252,7 @@ class CairoText(SVGMobject):
                 or self.text[char_index] == "\t"
                 or self.text[char_index] == "\n"
             ):
-                space = Dot(redius=0, fill_opacity=0, stroke_opacity=0)
+                space = Dot(radius=0, fill_opacity=0, stroke_opacity=0)
                 if char_index == 0:
                     space.move_to(self.submobjects[submobjects_char_index].get_center())
                 else:
@@ -806,7 +806,6 @@ class Text(SVGMobject):
         if self.disable_ligatures:
             self.submobjects = [*self.gen_chars()]
         self.chars = VGroup(*self.submobjects)
-        self.chars = VGroup(*self.submobjects)
         self.text = text_without_tabs.replace(" ", "").replace("\n", "")
         nppc = self.n_points_per_cubic_curve
         for each in self:
@@ -843,7 +842,7 @@ class Text(SVGMobject):
         submobjects_char_index = 0
         for char_index in range(self.text.__len__()):
             if self.text[char_index] in (" ", "\t", "\n"):
-                space = Dot(redius=0, fill_opacity=0, stroke_opacity=0)
+                space = Dot(radius=0, fill_opacity=0, stroke_opacity=0)
                 if char_index == 0:
                     space.move_to(self.submobjects[submobjects_char_index].get_center())
                 else:

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -103,9 +103,9 @@ def remove_invisible_chars(mobject):
     return mobject_without_dots
 
 
-class PangoUtils(object):
+class PangoUtils:
     @staticmethod
-    def str2style(string):
+    def str2style(string: str) -> pangocffi.Style:
         """Internally used function. Converts text to Pango Understandable Styles."""
         if string == NORMAL:
             return pangocffi.Style.NORMAL
@@ -117,7 +117,7 @@ class PangoUtils(object):
             raise AttributeError("There is no Style Called %s" % string)
 
     @staticmethod
-    def str2weight(string):
+    def str2weight(string: str) -> pangocffi.Weight:
         """Internally used function. Convert text to Pango Understandable Weight"""
         if string == NORMAL:
             return pangocffi.Weight.NORMAL
@@ -1295,7 +1295,7 @@ class MarkupText(SVGMobject):
         self.original_text = text
         self.disable_ligatures = disable_ligatures
         text_without_tabs = text
-        if text.find("\t") != -1:
+        if "\t" in text:
             text_without_tabs = text.replace("\t", " " * self.tab_width)
 
         colormap = self.extract_color_tags()

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -756,12 +756,6 @@ class Text(SVGMobject):
         >>> Text('The horse does not eat cucumber salad.')
         Text('The horse does not eat cucumber salad.')
 
-    .. WARNING::
-
-        Using a :class:`.Transform` on text with leading whitespace can look
-        `weird <https://github.com/3b1b/manim/issues/1067>`_. Consider using
-        :meth:`remove_invisible_chars` to resolve this issue.
-
     """
 
     def __init__(
@@ -1254,12 +1248,6 @@ class MarkupText(SVGMobject):
 
         >>> MarkupText('The horse does not eat cucumber salad.')
         MarkupText('The horse does not eat cucumber salad.')
-
-    .. WARNING::
-
-        Using a :class:`.Transform` on text with leading whitespace can look
-        `weird <https://github.com/3b1b/manim/issues/1067>`_. Consider using
-        :meth:`remove_invisible_chars` to resolve this issue.
 
     """
 


### PR DESCRIPTION
##  Changes

Add a new class `MarkupText` allowing us to use most of the Pango markup features described in https://developer.gnome.org/pango/stable/pango-Markup.html 

Text set with this class can use the following formatting:
* bold, italic and bold+italic (by combining both)
* superscript, subscript
* smaller or bigger font
* monotype or general change of font inside a text mobject
* underline (single, double, wave) and strikethrough
* gradient for parts of a string
* color for parts of a string
 
The last two do not come from Pango. For the sake of simplicity, I added two custom tags `<color>` and `<gradient>`, because this is far easier to parse with just regex. (Nested spans can lead to trouble.)

Also, while passing by, I fixed two typos and removed a double line in `text_mobject.py`.

## Motivation
Currently, we have to use `t2c`, `t2f` and `t2s` in order to format parts of a text. Unfortunately, these act independetnly of each other. For every option, one `TextSetting` is created and then those `setting`s are treated one by one and for every `setting` the corresponding part of the string is added. This leads to the following problem:
```python
        text=Text("what is wrong?",t2s={"what": "ITALIC"}, t2w={"what": "BOLD"})
        self.add(text)
```
![image](https://user-images.githubusercontent.com/52650214/101917204-44e09900-3bc8-11eb-8596-3e6b900acc9d.png)

Also, I personally find the current interface rather complicated to use. Using HTML-like tags inside the string seems far more straightforward to me.

## Testing Status

<details><summary>Local testing is OK:</summary>

```python
        text1 = MarkupText(
            r"<tt><b>foo</b></tt> <b>foo</b> <i>bar</i> <b><i>foobar</i></b> <s>foo</s><u>bar</u> <big>big</big> <small>small</small>"
        )
        text2 = MarkupText(
            r'H<sub>2</sub>O <span underline="double">and</span> <sup>210</sup>Po'
        )
        text3 = MarkupText(
            r'foo<gradient from="RED" to="YELLOW">bar</gradient>ish <span font_family="sans">bla</span>',
            font="serif",
        )
        text4 = MarkupText(
            r'all green> &amp; &lt; &gt; <span underline="error">error</span>',
            color=GREEN,
        )
        text5 = MarkupText(
            r'almost whole <color col="RED">string</color> in gradient',
            font="frutiger lt com",
            weight=BOLD,
            gradient=(BLUE, GREEN),
        )
        text6 = MarkupText(r'offset to deal with fl <color col="GREEN" offset="1">ligatures</color> ')
        text7 = MarkupText(
            r'same fl  <gradient from="GREEN" to="YELLOW" offset="1">for gradients</gradient> :-)'
        )

        g = VGroup(text1, text2, text3, text4, text5, text6, text7).arrange(DOWN)
        self.add(g))
```

gives</details>

![image](https://user-images.githubusercontent.com/52650214/101985900-0a8c0000-3c8b-11eb-9be8-6640a6601b8c.png)

Ligatures are causing trouble and probably always will, as there is no reliable way to know how many glyphs are created from the text. From our end, we can only count chars of the string, but we are coloring paths from the SVG object. The easiest way to workaround this is to have an `offset="..."` attribute in colors and gradients. This way, the user can manually correct any errors.


## Further Comments

I'd like to give credit to @naveen521kk, because the code is heavily based his work. (And it was also him who pointed me to the markup funtionality of Pango.)

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)


## Entry for changelog

> Added a class :class:`MarkupText` (via :pr:`855`) for easier and more flexible text formatting