### PR TITLE
Fix CairoText

### DIFF
--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -211,6 +211,7 @@ class CairoText(SVGMobject):
             fill_opacity=fill_opacity,
             stroke_width=stroke_width,
             should_center=should_center,
+            **kwargs,
         )
         self.text = text
         self.submobjects = [*self.gen_chars()]

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -210,7 +210,7 @@ class CairoText(SVGMobject):
             color=color,
             fill_opacity=fill_opacity,
             stroke_width=stroke_width,
-            should_center=should_center
+            should_center=should_center,
         )
         self.text = text
         self.submobjects = [*self.gen_chars()]

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -207,7 +207,10 @@ class CairoText(SVGMobject):
             height=height,
             width=width,
             unpack_groups=unpack_groups,
-            color=color ** config,
+            color=color,
+            fill_opacity=fill_opacity,
+            stroke_width=stroke_width,
+            should_center=should_center
         )
         self.text = text
         self.submobjects = [*self.gen_chars()]


### PR DESCRIPTION
## Overview / Explanation for Changes
CairoText is broken since #783. This PR fixes the problem.

1. Problem: ```color = color ** config``` results in an error
2. Problem: Parameters were missing which resulted in blurry output when scaling CairoText

To see the problems just run this snippet on master:
```python
class Test(Scene):
    def construct(self):
        t = CairoText("This is a test!")
        t.scale(0.3)
        self.add(t)
        self.wait(3)
```
You'll see an error, just remove ```** config```.
If you run it now, you'll see that the text is blurry. This is because arguments were missing. (I think they were just forgotten to include during the config refactor)

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Fixed CairoText to work with new config structure
```

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [x] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
