### PR TITLE
Add missing argument for classes inheriting from class 'Matrix'

### DIFF
--- a/manim/mobject/matrix.py
+++ b/manim/mobject/matrix.py
@@ -195,12 +195,14 @@ class Matrix(VMobject):
 class DecimalMatrix(Matrix):
     def __init__(
         self,
+        matrix,
         element_to_mobject=DecimalNumber,
         element_to_mobject_config={"num_decimal_places": 1},
         **kwargs
     ):
         Matrix.__init__(
             self,
+            matrix,
             element_to_mobject=element_to_mobject,
             element_to_mobject_config=element_to_mobject_config,
             **kwargs
@@ -208,13 +210,13 @@ class DecimalMatrix(Matrix):
 
 
 class IntegerMatrix(Matrix):
-    def __init__(self, element_to_mobject=Integer, **kwargs):
-        Matrix.__init__(self, element_to_mobject=element_to_mobject, **kwargs)
+    def __init__(self, matrix, element_to_mobject=Integer, **kwargs):
+        Matrix.__init__(self, matrix, element_to_mobject=element_to_mobject, **kwargs)
 
 
 class MobjectMatrix(Matrix):
-    def __init__(self, element_to_mobject=lambda m: m, **kwargs):
-        Matrix.__init__(self, element_to_mobject=element_to_mobject, **kwargs)
+    def __init__(self, matrix, element_to_mobject=lambda m: m, **kwargs):
+        Matrix.__init__(self, matrix, element_to_mobject=element_to_mobject, **kwargs)
 
 
 def get_det_text(


### PR DESCRIPTION
## Overview / Explanation for Changes
All classes inheriting from Matrix seem to miss the 'matrix' argument. This results in an error:
```python
TypeError: __init__() missing 1 required positional argument: 'matrix'
```

Error can be reproduced via:
```python
class Test(Scene):
    def construct(self):
        m = DecimalMatrix([[0.1, 0.1], [0.2, 0.2]])
        self.add(m)
        self.wait(3)
```

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
Added missing argument to classes inheriting the class 'Matrix'
```

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [x] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
