### PR TITLE
Removing z_index

### DIFF
--- a/manim/camera/camera.py
+++ b/manim/camera/camera.py
@@ -55,7 +55,6 @@ class Camera(object):
         pixel_array_dtype="uint8",
         z_buff_func=lambda m: np.round(m.get_center()[2], 2),
         cairo_line_width_multiple=0.01,
-        use_z_index=True,
         background=None,
         pixel_height=None,
         pixel_width=None,
@@ -80,7 +79,6 @@ class Camera(object):
         self.pixel_array_dtype = pixel_array_dtype
         self.z_buff_func = z_buff_func
         self.cairo_line_width_multiple = cairo_line_width_multiple
-        self.use_z_index = use_z_index
         self.background = background
 
         if pixel_height is None:
@@ -416,12 +414,10 @@ class Camera(object):
         """
         if include_submobjects:
             mobjects = extract_mobject_family_members(
-                mobjects, use_z_index=self.use_z_index, only_those_with_points=True
+                mobjects, only_those_with_points=True
             )
             if excluded_mobjects:
-                all_excluded = extract_mobject_family_members(
-                    excluded_mobjects, use_z_index=self.use_z_index
-                )
+                all_excluded = extract_mobject_family_members(excluded_mobjects)
                 mobjects = list_difference_update(mobjects, all_excluded)
         return mobjects
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -42,12 +42,11 @@ class Mobject(Container):
 
     """
 
-    def __init__(self, color=WHITE, name=None, dim=3, target=None, z_index=0, **kwargs):
+    def __init__(self, color=WHITE, name=None, dim=3, target=None, **kwargs):
         self.color = Color(color)
         self.name = self.__class__.__name__ if name is None else name
         self.dim = dim
         self.target = target
-        self.z_index = z_index
         self.point_hash = None
         self.submobjects = []
         self.updaters = []
@@ -946,11 +945,6 @@ class Mobject(Container):
             ]
         )
 
-    def get_z_index_reference_point(self):
-        # TODO, better place to define default z_index_group?
-        z_index_group = getattr(self, "z_index_group", self)
-        return z_index_group.get_center()
-
     def has_points(self):
         return len(self.points) > 0
 
@@ -1257,35 +1251,6 @@ class Mobject(Container):
             message = "Cannot call Mobject.{} " + "for a Mobject with no points"
             caller_name = sys._getframe(1).f_code.co_name
             raise Exception(message.format(caller_name))
-
-    # About z-index
-    def set_z_index(self, z_index_value):
-        """Sets the mobject's :attr:`z_index` to the value specified in `z_index_value`.
-
-        Parameters
-        ----------
-        z_index_value : Union[:class:`int`, :class:`float`]
-            The new value of :attr:`z_index` set.
-
-        Returns
-        -------
-        :class:`Mobject`
-            The Mobject itself, after :attr:`z_index` is set. (Returns `self`.)
-        """
-        self.z_index = z_index_value
-        return self
-
-    def set_z_index_by_z_coordinate(self):
-        """Sets the mobject's z coordinate to the value of :attr:`z_index`.
-
-        Returns
-        -------
-        :class:`Mobject`
-            The Mobject itself, after :attr:`z_index` is set. (Returns `self`.)
-        """
-        z_coord = self.get_center()[-1]
-        self.set_z_index(z_coord)
-        return self
 
 
 class Group(Mobject):

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -418,11 +418,9 @@ class VMobject(Mobject):
         self.color_using_background_image(vmobject.get_background_image_file())
         return self
 
-    def set_shade_in_3d(self, value=True, z_index_as_group=False):
+    def set_shade_in_3d(self, value=True):
         for submob in self.get_family():
             submob.shade_in_3d = value
-            if z_index_as_group:
-                submob.z_index_group = self
         return self
 
     # Points

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -229,9 +229,7 @@ class Scene(Container):
         list
             List of mobject family members.
         """
-        return extract_mobject_family_members(
-            self.mobjects, use_z_index=self.renderer.camera.use_z_index
-        )
+        return extract_mobject_family_members(self.mobjects)
 
     def add(self, *mobjects):
         """
@@ -311,9 +309,7 @@ class Scene(Container):
             The Scene mobject with restructured Mobjects.
         """
         if extract_families:
-            to_remove = extract_mobject_family_members(
-                to_remove, use_z_index=self.renderer.camera.use_z_index
-            )
+            to_remove = extract_mobject_family_members(to_remove)
         _list = getattr(self, mobject_list_name)
         new_list = self.get_restructured_mobject_list(_list, to_remove)
         setattr(self, mobject_list_name, new_list)
@@ -517,14 +513,10 @@ class Scene(Container):
         all_mobjects = list_update(self.mobjects, self.foreground_mobjects)
         all_mobject_families = extract_mobject_family_members(
             all_mobjects,
-            use_z_index=self.renderer.camera.use_z_index,
             only_those_with_points=True,
         )
         moving_mobjects = self.get_moving_mobjects(*animations)
-        all_moving_mobject_families = extract_mobject_family_members(
-            moving_mobjects,
-            use_z_index=self.renderer.camera.use_z_index,
-        )
+        all_moving_mobject_families = extract_mobject_family_members(moving_mobjects)
         stationary_mobjects = list_difference_update(
             all_mobject_families, all_moving_mobject_families
         )

--- a/manim/utils/family.py
+++ b/manim/utils/family.py
@@ -4,9 +4,7 @@ from ..mobject.mobject import Mobject
 from ..utils.iterables import remove_list_redundancies
 
 
-def extract_mobject_family_members(
-    mobjects, use_z_index=False, only_those_with_points=False
-):
+def extract_mobject_family_members(mobjects, only_those_with_points=False):
     """Returns a list of the types of mobjects and their family members present.
     A "family" in this context refers to a mobject, its submobjects, and their
     submobjects, recursively.
@@ -28,6 +26,4 @@ def extract_mobject_family_members(
         method = Mobject.family_members_with_points
     else:
         method = Mobject.get_family
-    if use_z_index:
-        mobjects = sorted(mobjects, key=lambda m: m.z_index)
     return remove_list_redundancies(list(it.chain(*[method(m) for m in mobjects])))


### PR DESCRIPTION
## Motivation
https://github.com/ManimCommunity/manim/pull/122 introduced the z_index feature.
As this turned out to not be very robust in animations (https://github.com/ManimCommunity/manim/issues/327), this pr will remove this feature again.
## Overview / Explanation for Changes
Removed z_index code in Mobject, in camera, and some other files
## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
