### PR TITLE
Pass background color to JS renderer

### DIFF
--- a/manim/grpc/gen/frameserver_pb2.py
+++ b/manim/grpc/gen/frameserver_pb2.py
@@ -18,7 +18,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     syntax="proto3",
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
-    serialized_pb=b'\n\x11\x66rameserver.proto\x12\x0b\x66rameserver";\n\x16\x46\x65tchSceneDataResponse\x12!\n\x05scene\x18\x01 \x01(\x0b\x32\x12.frameserver.Scene"A\n\x05Scene\x12\x0c\n\x04name\x18\x01 \x01(\t\x12*\n\nanimations\x18\x02 \x03(\x0b\x32\x16.frameserver.Animation"+\n\tAnimation\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x10\n\x08\x64uration\x18\x02 \x01(\x02"\xd5\x01\n\x0c\x46rameRequest\x12\x13\n\x0btime_offset\x18\x01 \x01(\x02\x12\x13\n\x0bstart_index\x18\x02 \x01(\x05\x12\x11\n\tend_index\x18\x03 \x01(\x05\x12\x13\n\x0bimage_index\x18\x04 \x01(\x05\x12;\n\x0cpreview_mode\x18\x05 \x01(\x0e\x32%.frameserver.FrameRequest.PreviewMode"6\n\x0bPreviewMode\x12\x07\n\x03\x41LL\x10\x00\x12\x13\n\x0f\x41NIMATION_RANGE\x10\x01\x12\t\n\x05IMAGE\x10\x02"u\n\x05Style\x12\x12\n\nfill_color\x18\x01 \x01(\t\x12\x14\n\x0c\x66ill_opacity\x18\x02 \x01(\x02\x12\x14\n\x0cstroke_color\x18\x03 \x01(\t\x12\x16\n\x0estroke_opacity\x18\x04 \x01(\x02\x12\x14\n\x0cstroke_width\x18\x05 \x01(\x02"(\n\x05Point\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02"\x97\x02\n\x0bMobjectData\x12\n\n\x02id\x18\x01 \x01(\x03\x12!\n\x05style\x18\x02 \x01(\x0b\x32\x12.frameserver.Style\x12\x32\n\x04type\x18\x03 \x01(\x0e\x32$.frameserver.MobjectData.MobjectType\x12:\n\x17vectorized_mobject_data\x18\x04 \x01(\x0b\x32\x19.frameserver.VMobjectData\x12\x39\n\x12image_mobject_data\x18\x05 \x01(\x0b\x32\x1d.frameserver.ImageMobjectData".\n\x0bMobjectType\x12\x0c\n\x08VMOBJECT\x10\x00\x12\x11\n\rIMAGE_MOBJECT\x10\x01"H\n\x0cVMobjectData\x12"\n\x06points\x18\x01 \x03(\x0b\x32\x12.frameserver.Point\x12\x14\n\x0cneeds_redraw\x18\x02 \x01(\x08"c\n\x10ImageMobjectData\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06height\x18\x02 \x01(\x02\x12\r\n\x05width\x18\x03 \x01(\x02\x12"\n\x06\x63\x65nter\x18\x04 \x01(\x0b\x32\x12.frameserver.Point"\xdf\x01\n\rFrameResponse\x12*\n\x08mobjects\x18\x01 \x03(\x0b\x32\x18.frameserver.MobjectData\x12\x15\n\rframe_pending\x18\x02 \x01(\x08\x12\x1a\n\x12\x61nimation_finished\x18\x03 \x01(\x08\x12\x16\n\x0escene_finished\x18\x04 \x01(\x08\x12\x10\n\x08\x64uration\x18\x05 \x01(\x02\x12\x12\n\nanimations\x18\x06 \x03(\t\x12\x17\n\x0f\x61nimation_index\x18\x07 \x01(\x05\x12\x18\n\x10\x61nimation_offset\x18\x08 \x01(\x02"\x0e\n\x0c\x45mptyRequest"\x0f\n\rEmptyResponse2\xa8\x01\n\x0b\x46rameServer\x12G\n\x0eGetFrameAtTime\x12\x19.frameserver.FrameRequest\x1a\x1a.frameserver.FrameResponse\x12P\n\x0e\x46\x65tchSceneData\x12\x19.frameserver.EmptyRequest\x1a#.frameserver.FetchSceneDataResponseb\x06proto3',
+    serialized_pb=b'\n\x11\x66rameserver.proto\x12\x0b\x66rameserver";\n\x16\x46\x65tchSceneDataResponse\x12!\n\x05scene\x18\x01 \x01(\x0b\x32\x12.frameserver.Scene"[\n\x05Scene\x12\x0c\n\x04name\x18\x01 \x01(\t\x12*\n\nanimations\x18\x02 \x03(\x0b\x32\x16.frameserver.Animation\x12\x18\n\x10\x62\x61\x63kground_color\x18\x03 \x01(\t"+\n\tAnimation\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x10\n\x08\x64uration\x18\x02 \x01(\x02"\xd5\x01\n\x0c\x46rameRequest\x12\x13\n\x0btime_offset\x18\x01 \x01(\x02\x12\x13\n\x0bstart_index\x18\x02 \x01(\x05\x12\x11\n\tend_index\x18\x03 \x01(\x05\x12\x13\n\x0bimage_index\x18\x04 \x01(\x05\x12;\n\x0cpreview_mode\x18\x05 \x01(\x0e\x32%.frameserver.FrameRequest.PreviewMode"6\n\x0bPreviewMode\x12\x07\n\x03\x41LL\x10\x00\x12\x13\n\x0f\x41NIMATION_RANGE\x10\x01\x12\t\n\x05IMAGE\x10\x02"u\n\x05Style\x12\x12\n\nfill_color\x18\x01 \x01(\t\x12\x14\n\x0c\x66ill_opacity\x18\x02 \x01(\x02\x12\x14\n\x0cstroke_color\x18\x03 \x01(\t\x12\x16\n\x0estroke_opacity\x18\x04 \x01(\x02\x12\x14\n\x0cstroke_width\x18\x05 \x01(\x02"(\n\x05Point\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02"\x97\x02\n\x0bMobjectData\x12\n\n\x02id\x18\x01 \x01(\x03\x12!\n\x05style\x18\x02 \x01(\x0b\x32\x12.frameserver.Style\x12\x32\n\x04type\x18\x03 \x01(\x0e\x32$.frameserver.MobjectData.MobjectType\x12:\n\x17vectorized_mobject_data\x18\x04 \x01(\x0b\x32\x19.frameserver.VMobjectData\x12\x39\n\x12image_mobject_data\x18\x05 \x01(\x0b\x32\x1d.frameserver.ImageMobjectData".\n\x0bMobjectType\x12\x0c\n\x08VMOBJECT\x10\x00\x12\x11\n\rIMAGE_MOBJECT\x10\x01"H\n\x0cVMobjectData\x12"\n\x06points\x18\x01 \x03(\x0b\x32\x12.frameserver.Point\x12\x14\n\x0cneeds_redraw\x18\x02 \x01(\x08"c\n\x10ImageMobjectData\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06height\x18\x02 \x01(\x02\x12\r\n\x05width\x18\x03 \x01(\x02\x12"\n\x06\x63\x65nter\x18\x04 \x01(\x0b\x32\x12.frameserver.Point"\xdf\x01\n\rFrameResponse\x12*\n\x08mobjects\x18\x01 \x03(\x0b\x32\x18.frameserver.MobjectData\x12\x15\n\rframe_pending\x18\x02 \x01(\x08\x12\x1a\n\x12\x61nimation_finished\x18\x03 \x01(\x08\x12\x16\n\x0escene_finished\x18\x04 \x01(\x08\x12\x10\n\x08\x64uration\x18\x05 \x01(\x02\x12\x12\n\nanimations\x18\x06 \x03(\t\x12\x17\n\x0f\x61nimation_index\x18\x07 \x01(\x05\x12\x18\n\x10\x61nimation_offset\x18\x08 \x01(\x02"\x0e\n\x0c\x45mptyRequest"\x0f\n\rEmptyResponse2\xa8\x01\n\x0b\x46rameServer\x12G\n\x0eGetFrameAtTime\x12\x19.frameserver.FrameRequest\x1a\x1a.frameserver.FrameResponse\x12P\n\x0e\x46\x65tchSceneData\x12\x19.frameserver.EmptyRequest\x1a#.frameserver.FetchSceneDataResponseb\x06proto3',
 )
 
 
@@ -56,8 +56,8 @@ _FRAMEREQUEST_PREVIEWMODE = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=None,
-    serialized_start=367,
-    serialized_end=421,
+    serialized_start=393,
+    serialized_end=447,
 )
 _sym_db.RegisterEnumDescriptor(_FRAMEREQUEST_PREVIEWMODE)
 
@@ -87,8 +87,8 @@ _MOBJECTDATA_MOBJECTTYPE = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=None,
-    serialized_start=818,
-    serialized_end=864,
+    serialized_start=844,
+    serialized_end=890,
 )
 _sym_db.RegisterEnumDescriptor(_MOBJECTDATA_MOBJECTTYPE)
 
@@ -180,6 +180,25 @@ _SCENE = _descriptor.Descriptor(
             file=DESCRIPTOR,
             create_key=_descriptor._internal_create_key,
         ),
+        _descriptor.FieldDescriptor(
+            name="background_color",
+            full_name="frameserver.Scene.background_color",
+            index=2,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
     ],
     extensions=[],
     nested_types=[],
@@ -190,7 +209,7 @@ _SCENE = _descriptor.Descriptor(
     extension_ranges=[],
     oneofs=[],
     serialized_start=95,
-    serialized_end=160,
+    serialized_end=186,
 )
 
 
@@ -249,8 +268,8 @@ _ANIMATION = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=162,
-    serialized_end=205,
+    serialized_start=188,
+    serialized_end=231,
 )
 
 
@@ -368,8 +387,8 @@ _FRAMEREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=208,
-    serialized_end=421,
+    serialized_start=234,
+    serialized_end=447,
 )
 
 
@@ -485,8 +504,8 @@ _STYLE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=423,
-    serialized_end=540,
+    serialized_start=449,
+    serialized_end=566,
 )
 
 
@@ -564,8 +583,8 @@ _POINT = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=542,
-    serialized_end=582,
+    serialized_start=568,
+    serialized_end=608,
 )
 
 
@@ -683,8 +702,8 @@ _MOBJECTDATA = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=585,
-    serialized_end=864,
+    serialized_start=611,
+    serialized_end=890,
 )
 
 
@@ -743,8 +762,8 @@ _VMOBJECTDATA = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=866,
-    serialized_end=938,
+    serialized_start=892,
+    serialized_end=964,
 )
 
 
@@ -841,8 +860,8 @@ _IMAGEMOBJECTDATA = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=940,
-    serialized_end=1039,
+    serialized_start=966,
+    serialized_end=1065,
 )
 
 
@@ -1015,8 +1034,8 @@ _FRAMERESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1042,
-    serialized_end=1265,
+    serialized_start=1068,
+    serialized_end=1291,
 )
 
 
@@ -1036,8 +1055,8 @@ _EMPTYREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1267,
-    serialized_end=1281,
+    serialized_start=1293,
+    serialized_end=1307,
 )
 
 
@@ -1057,8 +1076,8 @@ _EMPTYRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1283,
-    serialized_end=1298,
+    serialized_start=1309,
+    serialized_end=1324,
 )
 
 _FETCHSCENEDATARESPONSE.fields_by_name["scene"].message_type = _SCENE
@@ -1227,8 +1246,8 @@ _FRAMESERVER = _descriptor.ServiceDescriptor(
     index=0,
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
-    serialized_start=1301,
-    serialized_end=1469,
+    serialized_start=1327,
+    serialized_end=1495,
     methods=[
         _descriptor.MethodDescriptor(
             name="GetFrameAtTime",

--- a/manim/grpc/gen/renderserver_pb2.py
+++ b/manim/grpc/gen/renderserver_pb2.py
@@ -18,7 +18,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     syntax="proto3",
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
-    serialized_pb=b'\n\x12renderserver.proto\x12\x0crenderserver"f\n\x16UpdateSceneDataRequest\x12"\n\x05scene\x18\x01 \x01(\x0b\x32\x13.renderserver.Scene\x12\x11\n\texception\x18\x02 \x01(\t\x12\x15\n\rhas_exception\x18\x03 \x01(\x08"B\n\x05Scene\x12\x0c\n\x04name\x18\x01 \x01(\t\x12+\n\nanimations\x18\x02 \x03(\x0b\x32\x17.renderserver.Animation"+\n\tAnimation\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x10\n\x08\x64uration\x18\x02 \x01(\x02"\x0e\n\x0c\x45mptyRequest"\x0f\n\rEmptyResponse2d\n\x0cRenderServer\x12T\n\x0fUpdateSceneData\x12$.renderserver.UpdateSceneDataRequest\x1a\x1b.renderserver.EmptyResponseb\x06proto3',
+    serialized_pb=b'\n\x12renderserver.proto\x12\x0crenderserver"f\n\x16UpdateSceneDataRequest\x12"\n\x05scene\x18\x01 \x01(\x0b\x32\x13.renderserver.Scene\x12\x11\n\texception\x18\x02 \x01(\t\x12\x15\n\rhas_exception\x18\x03 \x01(\x08"\\\n\x05Scene\x12\x0c\n\x04name\x18\x01 \x01(\t\x12+\n\nanimations\x18\x02 \x03(\x0b\x32\x17.renderserver.Animation\x12\x18\n\x10\x62\x61\x63kground_color\x18\x03 \x01(\t"+\n\tAnimation\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x10\n\x08\x64uration\x18\x02 \x01(\x02"\x0e\n\x0c\x45mptyRequest"\x0f\n\rEmptyResponse2d\n\x0cRenderServer\x12T\n\x0fUpdateSceneData\x12$.renderserver.UpdateSceneDataRequest\x1a\x1b.renderserver.EmptyResponseb\x06proto3',
 )
 
 
@@ -147,6 +147,25 @@ _SCENE = _descriptor.Descriptor(
             file=DESCRIPTOR,
             create_key=_descriptor._internal_create_key,
         ),
+        _descriptor.FieldDescriptor(
+            name="background_color",
+            full_name="renderserver.Scene.background_color",
+            index=2,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
     ],
     extensions=[],
     nested_types=[],
@@ -157,7 +176,7 @@ _SCENE = _descriptor.Descriptor(
     extension_ranges=[],
     oneofs=[],
     serialized_start=140,
-    serialized_end=206,
+    serialized_end=232,
 )
 
 
@@ -216,8 +235,8 @@ _ANIMATION = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=208,
-    serialized_end=251,
+    serialized_start=234,
+    serialized_end=277,
 )
 
 
@@ -237,8 +256,8 @@ _EMPTYREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=253,
-    serialized_end=267,
+    serialized_start=279,
+    serialized_end=293,
 )
 
 
@@ -258,8 +277,8 @@ _EMPTYRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=269,
-    serialized_end=284,
+    serialized_start=295,
+    serialized_end=310,
 )
 
 _UPDATESCENEDATAREQUEST.fields_by_name["scene"].message_type = _SCENE
@@ -334,8 +353,8 @@ _RENDERSERVER = _descriptor.ServiceDescriptor(
     index=0,
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
-    serialized_start=286,
-    serialized_end=386,
+    serialized_start=312,
+    serialized_end=412,
     methods=[
         _descriptor.MethodDescriptor(
             name="UpdateSceneData",

--- a/manim/grpc/impl/frame_server_impl.py
+++ b/manim/grpc/impl/frame_server_impl.py
@@ -165,7 +165,7 @@ class FrameServer(frameserver_pb2_grpc.FrameServerServicer):
 
     def FetchSceneData(self, request, context):
         try:
-            return frameserver_pb2.FetchSceneDataResponse(
+            request = frameserver_pb2.FetchSceneDataResponse(
                 scene=frameserver_pb2.Scene(
                     name=str(self.scene),
                     animations=[
@@ -175,9 +175,13 @@ class FrameServer(frameserver_pb2_grpc.FrameServerServicer):
                         )
                         for scene in self.keyframes
                     ],
-                    background_color=self.scene.camera.background_color,
                 ),
             )
+            if hasattr(self.scene.camera, "background_color"):
+                request.scene.background_color = self.scene.camera.background_color
+            else:
+                request.scene.background_color = "#000000"
+            return request
         except Exception as e:
             traceback.print_exc()
 

--- a/manim/grpc/impl/frame_server_impl.py
+++ b/manim/grpc/impl/frame_server_impl.py
@@ -215,7 +215,6 @@ class FrameServer(frameserver_pb2_grpc.FrameServerServicer):
                             )
                             for scene in self.keyframes
                         ],
-                        background_color=self.scene.camera.background_color,
                     ),
                 )
                 if hasattr(self.scene.camera, "background_color"):

--- a/manim/grpc/impl/frame_server_impl.py
+++ b/manim/grpc/impl/frame_server_impl.py
@@ -175,6 +175,7 @@ class FrameServer(frameserver_pb2_grpc.FrameServerServicer):
                         )
                         for scene in self.keyframes
                     ],
+                    background_color=self.scene.camera.background_color,
                 ),
             )
         except Exception as e:
@@ -214,6 +215,7 @@ class FrameServer(frameserver_pb2_grpc.FrameServerServicer):
                             )
                             for scene in self.keyframes
                         ],
+                        background_color=self.scene.camera.background_color,
                     ),
                 )
             else:

--- a/manim/grpc/impl/frame_server_impl.py
+++ b/manim/grpc/impl/frame_server_impl.py
@@ -215,9 +215,12 @@ class FrameServer(frameserver_pb2_grpc.FrameServerServicer):
                             )
                             for scene in self.keyframes
                         ],
-                        background_color=self.scene.camera.background_color,
                     ),
                 )
+                if hasattr(self.scene.camera, "background_color"):
+                    request.scene.background_color = self.scene.camera.background_color
+                else:
+                    request.scene.background_color = "#000000"
             else:
                 lines = traceback.format_exception(
                     None, self.exception, self.exception.__traceback__

--- a/manim/grpc/proto/frameserver.proto
+++ b/manim/grpc/proto/frameserver.proto
@@ -17,6 +17,7 @@ message FetchSceneDataResponse {
 message Scene {
     string name = 1;
     repeated Animation animations = 2;
+    string background_color = 3;
 }
 
 message Animation {

--- a/manim/grpc/proto/renderserver.proto
+++ b/manim/grpc/proto/renderserver.proto
@@ -16,6 +16,7 @@ message UpdateSceneDataRequest {
 message Scene {
     string name = 1;
     repeated Animation animations = 2;
+    string background_color = 3;
 }
 
 message Animation {

--- a/manim/mobject/types/image_mobject.py
+++ b/manim/mobject/types/image_mobject.py
@@ -93,7 +93,8 @@ class ImageMobject(AbstractImageMobject):
         image_mode="RGBA",
         **kwargs,
     ):
-        self.opacity = 0
+        self.fill_opacity = 1
+        self.stroke_opacity = 1
         self.invert = invert
         self.image_mode = image_mode
         if isinstance(filename_or_array, (str, pathlib.PurePath)):
@@ -147,7 +148,8 @@ class ImageMobject(AbstractImageMobject):
             transparent.
         """
         self.pixel_array[:, :, 3] = int(255 * alpha)
-        self.opacity = alpha
+        self.fill_opacity = alpha
+        self.stroke_opacity = alpha
         return self
 
     def fade(self, darkness=0.5, family=True):
@@ -185,6 +187,12 @@ class ImageMobject(AbstractImageMobject):
             f"Mobject 1 ({mobject1}) : {mobject1.pixel_array.shape}\n"
             f"Mobject 2 ({mobject2}) : {mobject2.pixel_array.shape}"
         )
+        self.fill_opacity = interpolate(
+            mobject1.fill_opacity, mobject2.fill_opacity, alpha
+        )
+        self.stroke_opacity = interpolate(
+            mobject1.stroke_opacity, mobject2.stroke_opacity, alpha
+        )
         self.pixel_array = interpolate(
             mobject1.pixel_array, mobject2.pixel_array, alpha
         ).astype(self.pixel_array_dtype)
@@ -192,7 +200,7 @@ class ImageMobject(AbstractImageMobject):
     def get_style(self):
         return {
             "fill_color": colour.rgb2hex(self.color.get_rgb()),
-            "fill_opacity": self.opacity,
+            "fill_opacity": self.fill_opacity,
         }
 
 


### PR DESCRIPTION
Passes the background data so it can be used with the JS renderer after https://github.com/ManimCommunity/manim-renderer/commit/c09a5e5a5663ddc618c9f47f74d6d5cc326248aa.

Also sets and updates the `fill_opacity` and `stroke_opacity` attributes for ImageMobjects, so that their opacity will be sent to the JS renderer https://github.com/ManimCommunity/manim-renderer/commit/8e89884ac74f87e6b60e0d4a58c60c161bec9d2b.