### PR TITLE
Add linguist-generated attribute to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-manim/grpc/gen/*
+manim/grpc/gen/* linguist-generated=true


### PR DESCRIPTION
Add the linguist-generated attribute to .gitattributes so that (hopefully) generated files are ignored in diffs.