### PR TITLE
convenience method for creating a graph from a networkx graph

### DIFF
--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -303,3 +303,36 @@ class Graph(VMobject):
 
     def __repr__(self: "Graph") -> str:
         return f"Graph on {len(self.vertices)} vertices and {len(self.edges)} edges"
+
+    @staticmethod
+    def from_networkx(nxgraph: nx.classes.graph.Graph, **kwargs) -> "Graph":
+        """Build a :class:`~.Graph` from a given ``networkx`` graph.
+
+        Parameters
+        ----------
+
+        nxgraph
+            A ``networkx`` graph.
+        **kwargs
+            Keywords to be passed to the constructor of :class:`~.Graph`.
+
+        Examples
+        --------
+
+        .. manim:: ImportNetworkxGraph
+
+            import networkx as nx
+
+            nxgraph = nx.erdos_renyi_graph(14, 0.5)
+
+            class ImportNetworkxGraph(Scene):
+                def construct(self):
+                    G = Graph.from_networkx(nxgraph, layout="spring", layout_scale=3.5)
+                    self.play(ShowCreation(G))
+                    self.play(*[G[v].animate.move_to(5*RIGHT*np.cos(ind/7 * PI) +
+                                                     3*UP*np.sin(ind/7 * PI))
+                                for ind, v in enumerate(G.vertices)])
+                    self.play(Uncreate(G))
+
+        """
+        return Graph(list(nxgraph.nodes), list(nxgraph.edges), **kwargs)


### PR DESCRIPTION
## Motivation
For people working with graphs, allowing to create a manim-`Graph` directly from the `networkx`-Graph is a useful shortcut.

## Overview / Explanation for Changes
Adds a static method `Graph.from_networkx`.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Added option to create graphs from ``networkx`` directly (:pr:`893`)
```

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->

Added one example to the documentation, which builds successfully locally.


## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [x] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
