### PR TITLE
Prepare new release: v0.2.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,7 +21,7 @@ Changes for the upcoming release are tracked `in our GitHub wiki <https://github
 v0.2.0
 ******
 
-:Date: January 1, 2020
+:Date: January 1, 2021
 
 The changes since Manim Community release v0.1.1 are listed below.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,100 @@ Changes for the upcoming release are tracked `in our GitHub wiki <https://github
 
 
 ******
+v0.2.0
+******
+
+:Date: January 1, 2020
+
+The changes since Manim Community release v0.1.1 are listed below.
+
+Breaking Changes
+================
+
+- Remove all CONFIG dictionaries and all calls to ``digest_config`` and allow
+  passing options directly to the constructor of the corresponding classes (:pr:`783`).
+
+  Practically, this means that old constructions using ``CONFIG`` like::
+
+      class SomeMobject(Thing):
+          CONFIG = {
+              "my_awesome_property": 42
+          }
+
+  where corresponding objects were then instantiated as ``my_mobject = SomeMobject()``
+  should now be created simply using ``my_mobject = SomeMobject(my_awesome_property=42)``.
+
+- Remove old syntax for animating mobject methods by passing the methods and arguments to ``self.play``,
+  and use a new syntax featuring the ``animate`` property (:pr:`881`).
+
+  For example: the old-style ``play`` call
+  ::
+
+      self.play(my_square.shift, LEFT)
+
+  should be replaced with the new following call using the ``animate`` property::
+
+      self.play(my_square.animate.shift(LEFT))
+
+New Features
+============
+
+- Added creation animation for :class:`~.ManimBanner` (:pr:`814`)
+- Added some documentation to :meth:`~.Scene.construct` (:pr:`753`)
+- Added a black and white monochromatic version of Manim's logo (:pr:`826`)
+- Added support for a plugin system (``manim plugin`` subcommand + documentation) (:pr:`784`)
+- Implemented ``__add__``, ``__iadd__``, ``__sub__``, and ``__isub__`` for :class:`~.Mobject` (allowing for notation like ``some_vgroup + some_mobject``) (:pr:`790`)
+- Added type hints to several files in the library (:pr:`835`)
+- Added some examples to :mod:`~.animation.creation` (:pr:`820`)
+- Added some examples to :class:`~.DashedLine` and :class:`~.CurvesAsSubmobjects` (:pr:`833`)
+- Added new implementation for text rendered with Pango, :class:`~.MarkupText`, which can be formatted with an HTML-like syntax (:pr:`855`)
+- Added Fading in and out examples and deprecation of ``FadeInFromDown`` and ``FadeOutAndShiftDown`` (:pr:`827`)
+- Added example for :class:`~.MoveAlongPath` to the docs (:pr:`873`)
+- Added ambient rotate for other angles - theta, phi, gamma (:pr:`660`)
+- Use custom bindings for Pango (:pr:`878`)
+- Added :class:`~.Graph`, a basic implementation for (graph theory) graphs (:pr:`861`)
+- Allow for chaining methods when using the new ``.animate`` syntax in :meth:`~.Scene.play` (:pr:`889`)
+
+Bugfixes
+========
+
+- Fix doctests in .rst files (:pr:`797`)
+- Fix failing doctest after adding ``manim plugin`` subcommand (:pr:`831`)
+- Normalize the direction vector in :meth:`~.mobject_update_utils.always_shift` (:pr:`839`)
+- Add ``disable_ligatures`` to :class:`~.Text` (via :pr:`804`)
+- Make scene caching aware of order of Mobjects (:pr:`845`)
+- Fix :class:`~.CairoText` to work with new config structure (:pr:`858`)
+- Added missing argument to classes inheriting from :class:`~.Matrix` (:pr:`859`)
+- Fixed: ``z_index`` of mobjects contained in others as submobjects is now properly respected (:pr:`872`)
+- Let :meth:`~.ParametricSurface.set_fill_by_checkboard` return the modified surface to allow method chaining (:pr:`883`)
+- Mobjects added during an updater are added to ``Scene.moving_mobjects`` (:pr:`838`)
+- Pass background color to JS renderer (:pr:`876`)
+- Small fixes to docstrings. Tiny cleanups. Remove ``digest_mobject_attrs``. (:pr:`834`)
+- Added closed shape detection in :class:`~.DashedVMobject` in order to achieve an even dash pattern (:pr:`884`)
+- Fix Spelling in docstrings and variables across the library (:pr:`890`)
+
+Other changes
+=============
+
+- Change library name to manim (:pr:`811`)
+- Docker: use local files when building an image (:pr:`803`)
+- Let ffmpeg render partial movie files directly instead of temp files (:pr:`817`)
+- ``manimce`` to ``manim`` & capitalizing Manim in readme (:pr:`794`)
+- Added flowchart for different docstring categories (:pr:`828`)
+- Improve example in module docstring of :mod:`~.animation.creation` + explicitly document buff parameter in :meth:`~.Mobject.arrange` (:pr:`825`)
+- Disable CI pipeline for Python 3.6 (:pr:`823`)
+- Update URLs in docs (:pr:`832`)
+- Move upcoming changelog to GitHub-wiki (:pr:`822`)
+- Change badges in readme (:pr:`854`)
+- Exclude generated gRPC files from source control (:pr:`868`)
+- Added linguist-generated attribute to ``.gitattributes`` (:pr:`877`)
+- Cleanup: removed inheritance from ``object`` for some classes, refactor some imports (:pr:`795`)
+- Change several ``str.format()`` to ``f``-strings (:pr:`867`)
+- Update javascript renderer (:pr:`830`)
+- Bump version number to 0.2.0, update changelog (:pr:`894`)
+
+
+******
 v0.1.1
 ******
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "manim"
-version = "0.1.1"
+version = "0.2.0"
 description = "Animation engine for explanatory math videos."
 authors = ["The Manim Community Developers","3b1b <grant@3blue1brown.com>"]
 license="MIT"


### PR DESCRIPTION
This PR prepares the upcoming release: it bumps the version number and includes the oneline summaries for all merged PRs (including a reference to them) in the changelog.