### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,9 @@ jobs:
       run: poetry config http-basic.pypi __token__ "$PYPI_API_TOKEN"
 
     - name: Publish release to pypi
-      run: poetry publish --build
+      run: |
+        poetry publish --build
+        poetry build
 
     - name: Get Upload URL
       id: create_release


### PR DESCRIPTION
## Overview / Explanation for Changes
Running poetry publish doesn't create the `.tar.gz` sadly. So running `poetry build` will create that. This should fix the previous release workflow.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Fix release GitHub Action (:pr:`898`)
```

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [x] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
