### PR TITLE
Tiny grammar improvements in documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,12 +6,12 @@
 Manim Community Overview
 ========================
 
-Animating technical concepts is traditionally pretty tedious, since it can be
+Animating technical concepts is traditionally pretty tedious since it can be
 difficult to make the animations precise enough to convey them accurately.
-``Manim`` uses Python to generate animations programmatically, which makes it
+``Manim`` uses Python to generate animations programmatically, making it
 possible to specify exactly how each one should run.
 
-This project is still very much a work in progress, but I hope that the
+This project is still very much a work in progress, but we hope that the
 information here will make it easier for newcomers to get started using
 ``Manim``.
 


### PR DESCRIPTION
## Motivation
Improved some grammar I came across while browsing the docs.

## Oneline Summary of Changes
```
- Tiny grammar improvements (:pr:`PR NUMBER HERE`)
```

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
