### PR TITLE
Added blank line between imports and class example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Manim is an extremely versatile package. The following is an example `Scene` you
 ```python
 from manim import *
 
+
 class SquareToCircle(Scene):
     def construct(self):
         circle = Circle()


### PR DESCRIPTION
Check PEP 8: E302

## Motivation
Just a small change in the Hello World example which ensures code quality standards

## Overview / Explanation for Changes
I have just added a blank line because PEP 8 says it shold be done like that

## Oneline Summary of Changes
- Added a blank line because PEP 8 says it shold be done like that
 (:pr:`904`)

<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
