### PR TITLE
Bugfix: make Scene.add_sound work again (when running with --disable_caching)

### DIFF
--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -880,5 +880,5 @@ class Scene(Container):
         """
         if self.renderer.skip_animations:
             return
-        time = self.time + time_offset
+        time = self.renderer.time + time_offset
         self.renderer.file_writer.add_sound(sound_file, time, gain, **kwargs)

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1,23 +1,20 @@
 import os, struct, wave
 
-
 from manim import Scene
 
 
 def test_add_sound():
     # create sound file
-    f = wave.open('noise.wav', 'w')
-    f.setparams((2, 2, 44100, 0, 'NONE', 'not compressed'))
+    f = wave.open("noise.wav", "w")
+    f.setparams((2, 2, 44100, 0, "NONE", "not compressed"))
     for _ in range(22050):  # half a second of sound
-        packed_value = struct.pack('h', 14242)
+        packed_value = struct.pack("h", 14242)
         f.writeframes(packed_value)
         f.writeframes(packed_value)
 
     f.close()
 
     scene = Scene()
-    scene.add_sound('noise.wav')
+    scene.add_sound("noise.wav")
 
-    os.remove('noise.wav')
-
-
+    os.remove("noise.wav")

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1,0 +1,23 @@
+import os, struct, wave
+
+
+from manim import Scene
+
+
+def test_add_sound():
+    # create sound file
+    f = wave.open('noise.wav', 'w')
+    f.setparams((2, 2, 44100, 0, 'NONE', 'not compressed'))
+    for _ in range(22050):  # half a second of sound
+        packed_value = struct.pack('h', 14242)
+        f.writeframes(packed_value)
+        f.writeframes(packed_value)
+
+    f.close()
+
+    scene = Scene()
+    scene.add_sound('noise.wav')
+
+    os.remove('noise.wav')
+
+


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
`Scene.add_sound` is currently broken.

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.

For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->
The reference to `self.time` has to be changed to `self.renderer.time`. Closes #902, #816.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Bugfix: make Scene.add_sound work again when running with --disable_caching (:pr:`PR NUMBER HERE`)
```

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->
Tested this change locally, and it works. We don't have a sample audio file in the library to test this with, so I can't really add a unit test for it.

## Further Comments
See https://github.com/ManimCommunity/manim/issues/851#issuecomment-748120731 for an excellent and very thorough report on the problems of `add_sound` without `--disable_caching`.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
