### PR TITLE
removed deprecated command-line arguments from the tutorials section of the documentation

### DIFF
--- a/docs/source/tutorials/a_deeper_look.rst
+++ b/docs/source/tutorials/a_deeper_look.rst
@@ -14,14 +14,14 @@ At this point, you have just executed the following command.
 
 .. code-block:: bash
 
-   $ manim scene.py SquareToCircle -pl
+   $ manim scene.py SquareToCircle -pql
 
 Let's dissect what just happened step by step.  First, this command executes
 manim on the file ``scene.py``, which contains our animation code.  Further,
 this command tells manim exactly which ``Scene`` to be rendered, in this case
 it is ``SquareToCircle``.  This is necessary because a single scene file may
 contain more than one scene.  Next, the flag `-p` tells manim to play the scene
-once it's rendered, and the `-l` flag tells manim to render the scene in low
+once it's rendered, and the `-ql` flag tells manim to render the scene in low
 quality.
 
 After the video is rendered, you will see that manim has generated some new
@@ -57,9 +57,9 @@ the following command,
 
 .. code-block:: bash
 
-   $ manim scene.py SquareToCircle -pe
+   $ manim scene.py SquareToCircle -pqh
 
-The ``-l`` flag (for low quality) has been replaced by the ``-e`` flag, for
+The ``-ql`` flag (for low quality) has been replaced by the ``-qh`` flag, for
 high quality.  Manim will take considerably longer to render this file, and it
 will play it once it's done since we are using the ``-p`` flag.  The output
 should look like this:
@@ -132,7 +132,7 @@ The corresponding folder structure looks like this:
      └─Tex
 
 Saving the last frame with ``-s`` can be combined with the flags for different
-resolutions, e.g. ``-s -l``, ``-s -e``
+resolutions, e.g. ``-s -ql``, ``-s -qh``
 
 
 
@@ -144,16 +144,16 @@ When executing the command
 
 .. code-block:: bash
 
-   $ manim scene.py SquareToCircle -pl
+   $ manim scene.py SquareToCircle -pql
 
 it was necessary to specify which ``Scene`` class to render.  This is because a
 single file can contain more than one ``Scene`` class.  If your file contains
 multiple ``Scene`` classes, and you want to render them all, you can use the
 ``-a`` flag.
 
-As discussed previously, the ``-l`` specifies low render quality.  This does
+As discussed previously, the ``-ql`` specifies low render quality.  This does
 not look very good, but is very useful for rapid prototyping and testing.  The
-other options that specify render quality are ``-m``, ``-e``, and ``-k`` for
+other options that specify render quality are ``-qm``, ``-qh``, and ``-qk`` for
 medium, high, and 4k quality, respectively.
 
 The ``-p`` flag plays the animation once it is rendered.  If you want to open

--- a/docs/source/tutorials/quickstart.rst
+++ b/docs/source/tutorials/quickstart.rst
@@ -51,7 +51,7 @@ the following command:
 
 .. code-block:: bash
 
-   $ manim scene.py SquareToCircle -pl
+   $ manim scene.py SquareToCircle -pql
 
 After showing some output, manim should render the scene into a .mp4 file,
 and open that file with the default movie player application.  You should see a
@@ -148,7 +148,7 @@ And render it using the following command:
 
 .. code-block:: bash
 
-   $ manim scene.py SquareToCircle -pl
+   $ manim scene.py SquareToCircle -pql
 
 The output should look as follows.
 


### PR DESCRIPTION
## Motivation
I tried out the latest version yesterday and saw that the documentation used some deprecated command-line arguments.

## Overview / Explanation for Changes
Changed `-pl` to `-pql` and `pe` to `pqh`. 

## Oneline Summary of Changes
Changed `-pl` to `-pql` and `pe` to `pqh`. 


## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
