### PR TITLE
Multipartite graph column layout

### DIFF
--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -176,7 +176,7 @@ class Graph(VMobject):
                 G = nx.Graph()
                 G.add_nodes_from([0, 1, 2, 3])
                 G.add_edges_from([(0, 2), (0,3), (1, 2)])
-                graph = Graph(list(G.nodes), list(G.edges), layout="bipartite", partitions=[[0, 1]])
+                graph = Graph(list(G.nodes), list(G.edges), layout="partite", partitions=[[0, 1]])
                 self.play(ShowCreation(graph))
 
     """

--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -49,7 +49,7 @@ class Graph(VMobject):
         is set to ``True``. Has no effect for other values of ``labels``.
     layout
         Either one of ``"spring"`` (the default), ``"circular"``, ``"kamada_kawai"``,
-        ``"planar"``, ``"random"``, ``"shell"``, ``"spectral"``, and ``"spiral"``
+        ``"planar"``, ``"random"``, ``"shell"``, ``"spectral"``, ``"spiral"``, and ``"partite"``
         for automatic vertex positioning using ``networkx``
         (see `their documentation <https://networkx.org/documentation/stable/reference/drawing.html#module-networkx.drawing.layout>`_
         for more details), or a dictionary specifying a coordinate (value)

--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -168,6 +168,7 @@ class Graph(VMobject):
 
     .. manim:: PartiteGraph
         :save_last_frame:
+        import networkx as nx
 
         class PartiteGraph(Scene):
             def construct(self):

--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -163,11 +163,12 @@ class Graph(VMobject):
 
     .. note::
 
-        All of the vertices which are not in one of the sides you provide
-        will be put into another column.
+        All vertices in your graph which are not listed in any of the partitions
+        are collected in their own partition and rendered in the rightmost column.
 
     .. manim:: PartiteGraph
         :save_last_frame:
+
         import networkx as nx
 
         class PartiteGraph(Scene):


### PR DESCRIPTION
## Motivation
Add the multipartite column layout for graphs, e.g.

https://user-images.githubusercontent.com/63877260/104088910-e106ca00-5272-11eb-98e9-73ef5f301651.mp4


## Overview / Explanation for Changes
Added the option for networkx multipartite automatic layout (similar to planar, spectral, etc.)

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Added new layout 'partite' for Graph mobject (:pr:`PR NUMBER HERE`)
```

## Testing Status
The following code
```python
from manim import *
import networkx as nx

G = nx.Graph()
G.add_nodes_from([0, 1, 2, 3], bipartite=0)
G.add_nodes_from([4, 5, 6, 7], bipartite=1)
G.add_edges_from([(0, 4), (0, 6), (1, 6), (2, 5), (3, 7)])

T = nx.Graph()
T.add_nodes_from([0, 1, 2, 3, 4, 5, 6, 7])
T.add_edges_from([(0, 2), (0, 3), (3, 6), (1, 2), (5, 7)])


class Test(Scene):
    def construct(self):
        graph = Graph(list(G.nodes), list(G.edges), layout="partite", partitions=[
                      [0, 1, 2, 3]])
        self.play(ShowCreation(graph))
        self.play(FadeOut(graph))

        graph = Graph(list(T.nodes), list(T.edges), layout="partite",
                      partitions=[[0, 1], [2, 3], [4, 5], [6, 7]])
        self.play(ShowCreation(graph))
        self.play(FadeOut(graph))

        # Doesn't specify the remaining side
        graph = Graph(list(T.nodes), list(T.edges), layout="partite",
                      partitions=[[0, 1], [2, 3], [4, 5]])
        self.play(ShowCreation(graph))
        self.play(FadeOut(graph))

        # Fails (should it put everything on one side? seems worthless...)
        # graph = Graph(list(T.nodes), list(T.edges), layout="partite")
        # Also fails
        # graph = Graph(list(T.nodes), list(T.edges),
        #               layout="partite", partitions=[])
        graph = Graph(list(T.nodes), list(T.edges),
                      layout="partite", partitions=[[0, 1]])
        self.play(ShowCreation(graph))
        self.play(FadeOut(graph))
```
outputs the following video

https://user-images.githubusercontent.com/63877260/104088926-098ec400-5273-11eb-9a33-c0796d539eea.mp4


## Further Comments
Also discussed in #913

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
