### PR TITLE
Bugfix: Make Matrix work with Lists again

### DIFF
--- a/manim/mobject/matrix.py
+++ b/manim/mobject/matrix.py
@@ -96,11 +96,11 @@ class Matrix(VMobject):
         self.left_bracket = left_bracket
         self.right_bracket = right_bracket
         VMobject.__init__(self, **kwargs)
+        matrix = np.array(matrix)
         if len(matrix.shape) < 2:
             raise ValueError(
                 f"{self.__str__()} class requires a two-dimensional array!"
             )
-        matrix = np.array(matrix)
         mob_matrix = self.matrix_to_mob_matrix(matrix)
         self.organize_mob_matrix(mob_matrix)
         self.elements = VGroup(*mob_matrix.flatten())


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
#929 introduced a bug that prevented a Matrix to be created with a 2-dim. list (only 'np.array' was working). This PR fixes it.

If there would've been a better way than making a new PR, please let me know. But since the last PR squashed the commit that introduced the bug, I think there is no way to just revert that single commit.
@leotrs 
## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Bugfix: Make Matrix work with Lists again (:pr:`933`)
```
## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
