### PR TITLE
Set stroke opacity in FadeIn

### DIFF
--- a/manim/animation/fading.py
+++ b/manim/animation/fading.py
@@ -117,7 +117,7 @@ class FadeIn(Transform):
         start = super().create_starting_mobject()
         start.fade(1)
         if isinstance(start, VMobject):
-            start.set_stroke(width=0)
+            start.set_stroke(opacity=0)
             start.set_fill(opacity=0)
         return start
 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -171,6 +171,8 @@ class VMobject(Mobject):
             for submobject in self.submobjects:
                 submobject.set_fill(color, opacity, family)
         self.update_rgbas_array("fill_rgbas", color, opacity)
+        if opacity is not None:
+            self.fill_opacity = opacity
         return self
 
     def set_stroke(
@@ -188,6 +190,8 @@ class VMobject(Mobject):
         self.update_rgbas_array(array_name, color, opacity)
         if width is not None:
             setattr(self, width_name, width)
+        if opacity is not None:
+            self.stroke_opacity = opacity
         return self
 
     def set_background_stroke(self, **kwargs):


### PR DESCRIPTION
## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
The FadeIn animation currently interpolates stroke width for vectorized mobjects rather than opacity. This changes it to interpolate only opacity.

`VMobject.set_stroke` and `VMobject.set_fill` don't update the `.stroke_opacity` and `.fill_opacity` attributes of the mobject they're called on, which causes problems with the JS renderer which depends on this information.

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.

For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->
Both of these are unexpected behavior. If the user wants to interpolate stroke width with opacity they should to so explicitly, e.g. with `mobject.animate.set_stroke_width(1)`, and the opacity attributes are meant to reflect the mobject's opacities.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Interpolate stroke opacity in FadeIn and update stroke_opacity and fill_opacity in VMobject.set_stroke and VMobject.set_fill
```

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->
Ran tests.

## Further Comments
<!-- Optional, any further comments regarding your PR
that might be useful for reviewers.. -->

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
