### PR TITLE
Bugfix: fix edges lagging behind vertices in animations involving graphs

### DIFF
--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -431,14 +431,11 @@ class Graph(VMobject):
         self.add(*self.vertices.values())
         self.add(*self.edges.values())
 
-        for (u, v), edge in self.edges.items():
+        def update_edges(graph):
+            for (u, v), edge in graph.edges.items():
+                edge.put_start_and_end_on(graph[u].get_center(), graph[v].get_center())
 
-            def update_edge(e, u=u, v=v):
-                e.set_start_and_end_attrs(self[u].get_center(), self[v].get_center())
-                e.generate_points()
-
-            update_edge(edge)
-            edge.add_updater(update_edge)
+        self.add_updater(update_edges)
 
     def __getitem__(self: "Graph", v: Hashable) -> "Mobject":
         return self.vertices[v]


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->

See, for example, the animation of the graph in the video in https://twitter.com/manim_community/status/1345677420913897473 -- edges are currently lagging behind vertices by one frame. This PR fixes it.

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.

For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->

The underlying issue is difficult to explain, and I'm not absolutely sure of why it leads to the lagged animation, but well: the issue is mainly caused by what I want the updater to do; namely to move some Mobject to the position of another one. The way I've written my updaters so far causes a problem when there is some animation involved which interpolates between two states. (So, in particular, all of the default `.animate` syntax animations.)

Internally, Manim runs these animations by copying the Mobject(s) to be animated, in particular one for the start of the animation, and one for the end. The animation is then constructed by interpolating between these two. Now, think of vertices connected by edges, with updaters that move the edges to connect the vertices.

A badly written updater will now move, in the language of this example, the edges from the copies to the vertices of the "original" mobject (which is shown on the screen); the vertices are then updated and interpolated between the new positions -- but the edges from the starting end ending mobjects now coincide (and are located at the position of the "old" frame), and interpolation thus again yields the same mobject.

TL;DR: The solution is to write update functions in such a way that they don't break or do unintended things when the mobject is copied.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Bugfix: fix edges lagging behind vertices in animations involving graphs (:pr:`PR NUMBER HERE`)
```

## Testing Status
We still can't test animations, but here is the the scene given by
```py
class LagTestGraph(Scene):
    def construct(self):
        g = Graph([1, 2, 3], [(1, 2), (2, 3)], layout_scale=3)
        self.add(g)
        self.play(g.animate.scale(0.5))
```
rendered in low quality (to make the one-frame-lagging more obvious) with and without the change. You can guess which is which. :-)


https://user-images.githubusercontent.com/11851593/105639711-18cc5f00-5e7a-11eb-8f94-9d7025ebacfd.mp4


https://user-images.githubusercontent.com/11851593/105639727-34376a00-5e7a-11eb-89fd-d49d4cf67b73.mp4


## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
