### PR TITLE
Magnitude of NumberLine's unit vector should be unit_size, not 1

### DIFF
--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -172,6 +172,9 @@ class NumberLine(Line):
     def get_unit_size(self):
         return self.get_length() / (self.x_max - self.x_min)
 
+    def get_unit_vector(self):
+        return super().get_unit_vector() * self.unit_size
+
     def default_numbers_to_display(self):
         if self.numbers_to_show is not None:
             return self.numbers_to_show


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
`NumberPlane` object doesn't return the desired plane when the `unit_size`s of their axes are set to a value other than one. 
[This bug](https://discord.com/channels/581738731934056449/582403919754297363/803100913380098068) was originally reported by the user Brian.Amedee in the discord.

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.-->

https://github.com/ManimCommunity/manim/blob/8d3619e8022839ef547017d8c56b0a7e02acc2b5/manim/mobject/coordinate_systems.py#L402 The above vector used to position the background lines of the plane is always of magnitude 1, no matter what values we pass for the `unit_size`s of `NumberPlane`'s axes. So the solution would be to multiply this unit vector with the `unit_size` of that axis, or to override the `get_unit_vector` method in `NumberLine` such that it returns a vector of length `unit_size` by default.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
-  Bugfix: NumberLine's unit vector should have a magnitude of unit_size (:pr:`PR NUMBER HERE`)
```

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->
Code to reproduce the bug: 
```py
class RespectUnitSize(Scene):
    def construct(self):
        plane_config = dict(
            x_axis_config = {
                "x_min" : -5, "x_max" : 6, "unit_size": 0.4, 
            },
            y_axis_config = {
                "x_min" : -3, "x_max" : 5, "unit_size": 0.4, 
            },
            center_point = 2*DL 
        )
        self.add(NumberPlane(**plane_config))
```
Bug and its fix:
![before](https://user-images.githubusercontent.com/73361366/105722775-07ec1e00-5f4c-11eb-8925-f283d11017ce.png)
![after](https://user-images.githubusercontent.com/73361366/105722786-0ae70e80-5f4c-11eb-8dc2-3c7f07226132.png)

## Further Comments
<!-- Optional, any further comments regarding your PR
that might be useful for reviewers.. -->
I preferred to override the [get_unit_vector](https://github.com/Pragyaan-6988/ManimCE/blob/30baf929a4a68028e2149dadac07f3d687fa6ec8/manim/mobject/geometry.py#L687-L688 ) method of `NumberLine`, so that `NumberLine().get_unit_vector()` by default returns a vector with magnitude `unit_size`. Another way to fix this would be to change https://github.com/ManimCommunity/manim/blob/8d3619e8022839ef547017d8c56b0a7e02acc2b5/manim/mobject/coordinate_systems.py#L402 to `unit_vector_axis_perp_to = axis_perpendicular_to.get_unit_vector() * axis_perpendicular_to.unit_size`. I'd prefer the former approach because one would expect that the `get_unit_vector` method of an axis would be of length `unit_size` by default. I'll update the PR if you guys vote for the latter approach.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
