### PR TITLE
Match "brand" styling

### DIFF
--- a/docs/source/installation/plugins.rst
+++ b/docs/source/installation/plugins.rst
@@ -43,7 +43,7 @@ your available plugins, see the following help output:
     -h, --help    show this help message and exit
     -l, --list    Lists all available plugins
 
-    Made with <3 by the manim community devs
+    Made with <3 by the ManimCommunity devs
 
 You can list plugins as such:
 

--- a/docs/source/tutorials/configuration.rst
+++ b/docs/source/tutorials/configuration.rst
@@ -440,4 +440,4 @@ A list of all CLI flags
      --progress_bar True/False
                            Display the progress bar
 
-   Made with <3 by the manim community devs
+   Made with <3 by the ManimCommunity devs

--- a/manim/_config/main_utils.py
+++ b/manim/_config/main_utils.py
@@ -120,7 +120,7 @@ def _parse_args_cfg_subcmd(args: list) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Animation engine for explanatory math videos",
         prog="manim cfg",
-        epilog="Made with <3 by the manim community devs",
+        epilog="Made with <3 by the ManimCommunity devs",
     )
     subparsers = parser.add_subparsers(help="subcommand", dest="subcmd")
 
@@ -158,7 +158,7 @@ def _parse_args_plugins(args: list) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Utility command for managing plugins",
         prog="manim plugins",
-        epilog="Made with <3 by the manim community devs",
+        epilog="Made with <3 by the ManimCommunity devs",
         usage=("%(prog)s -h -l"),
     )
 
@@ -182,7 +182,7 @@ def _parse_args_no_subcmd(args: list) -> argparse.Namespace:
             "%(prog)s file [flags] [scene [scene ...]]\n"
             "       %(prog)s {cfg,init,plugins} [opts]\n"
         ),
-        epilog="Made with <3 by the manim community devs",
+        epilog="Made with <3 by the ManimCommunity devs",
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Motivation
There seems to be three ways Manim Community Edition is styled:
* The ManimCommunity org (and work related to the org)
* Manim Community Edition (describing which version of Manim)
* ManimCE (shortening of Manim Community Edition that seems to be becoming less common)

It does make sense to differentiate ManimCommunity and Manim Community Edition, as one is describing Manim and one is an entity. However, none of these help messages follow any of the three consistently used styles.

## Overview / Explanation for Changes
Edits the messages to follow the 1st style, as "devs" falls appropriately under the org styling

## Oneline Summary of Changes
```
- Updated styling of "ManimCommunity" in help messages (:pr:`PR NUMBER HERE`)
```

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [x] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
