### PR TITLE
Bugfix: Fix possible_paths not printing in code_mobject

### DIFF
--- a/manim/mobject/svg/code_mobject.py
+++ b/manim/mobject/svg/code_mobject.py
@@ -292,7 +292,7 @@ class Code(VGroup):
                 return
         error = (
             f"From: {os.getcwd()}, could not find {self.file_name} at either "
-            + "of these locations: {possible_paths}"
+            + f"of these locations: {possible_paths}"
         )
         raise IOError(error)
 


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->

When supplying an invalid filename to a `code_monbject`, the error would not print the `possible_paths`

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.

For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->

The string was missing an fstring after a linebreak.

```diff
   f"From: {os.getcwd()}, could not find {self.file_name} at either "
-  + "of these locations: {possible_paths}"
+  + f"of these locations: {possible_paths}"
```

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Fixed bug: possible_paths in code_mobject not printing when supplying an invalid filename
```

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->

The error prints fine with that change.

Windows, Anaconda, Python 3.6

## Further Comments
<!-- Optional, any further comments regarding your PR
that might be useful for reviewers.. -->

## Acknowledgements
- [ x ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
