### PR TITLE
Fix 'manim cfg export' subcommand

### DIFF
--- a/manim/_config/cfg_subcmds.py
+++ b/manim/_config/cfg_subcmds.py
@@ -238,11 +238,12 @@ Are you sure you want to continue? (y/n)""",
     else:
         proceed = True
     if proceed:
+        parser = make_config_parser()
         if not os.path.isdir(path):
             console.print(f"Creating folder: {path}.", style="red bold")
             os.mkdir(path)
         with open(os.path.join(path, "manim.cfg"), "w") as outpath:
-            config.write(outpath)
+            parser.write(outpath)
             from_path = os.path.join(os.getcwd(), "manim.cfg")
             to_path = os.path.join(path, "manim.cfg")
         console.print(f"Exported final Config at {from_path} to {to_path}.")


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
Fixes #973

## Overview / Explanation for Changes
The error comes from [this removal](https://github.com/ManimCommunity/manim/commit/504ac73859f972d13b68bd9315755a80ae5f06e3#diff-82bdf7da77a98a5e00e5b07b44849929ae75773b55eb01bf18c3520d39ba65e3L230) 4 months ago.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Fixed bug in `manim cfg export` command (:pr:`989`)
```

## Testing Status
Although I don't know so much about the code, I think that subcommands are not tested in manim. 

## Further Comments
Perhaphs the original implementation was capable of export the comments of the configuration? I don't know.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
