### PR TITLE
Add generic set method and compatibility layer between properties and get_*/set_* methods

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -262,6 +262,7 @@ class Mobject(Container):
         In addition to this method, there is a compatibility
         layer that allows ``get_*`` and ``set_*`` methods to
         get and set attributes. For instance::
+
             >>> mob = Mobject()
             >>> mob.set_foo(0)
             Mobject

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -35,6 +35,10 @@ from ..utils.space_ops import rotation_matrix
 class Mobject(Container):
     """Mathematical Object: base class for objects that can be displayed on screen.
 
+    There is a compatibility layer that allows for
+    getting and setting attributes with ``get_*`` and
+    ``set_*`` methods. See :meth:`set` for more details.
+
     Attributes
     ----------
     submobjects : :class:`list`
@@ -254,6 +258,28 @@ class Mobject(Container):
 
         Mainly to be used along with :attr:`animate` to
         animate setting attributes.
+
+        In addition to this method, there is a compatibility
+        layer that allows ``get_*`` and ``set_*`` methods to
+        get and set attributes. For instance::
+            >>> mob = Mobject()
+            >>> mob.set_foo(0)
+            Mobject
+            >>> mob.get_foo()
+            0
+            >>> mob.foo
+            0
+
+        This compatibility layer does not interfere with any
+        ``get_*`` or ``set_*`` methods that are explicitly
+        defined.
+
+        .. warning::
+
+            This compatibility layer is for backwards compatibility
+            and is not guaranteed to stay around. Where applicable,
+            please prefer getting/setting attributes normally or with
+            the :meth:`set` method.
 
         Parameters
         ----------

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -271,6 +271,7 @@ class Mobject(Container):
 
             >>> mob = Mobject()
             >>> mob.set(foo=0)
+            Mobject
             >>> mob.foo
             0
         """

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -11,6 +11,7 @@ import operator as op
 import random
 import sys
 import types
+import warnings
 
 from pathlib import Path
 from colour import Color
@@ -36,8 +37,8 @@ class Mobject(Container):
     """Mathematical Object: base class for objects that can be displayed on screen.
 
     There is a compatibility layer that allows for
-    getting and setting attributes with ``get_*`` and
-    ``set_*`` methods. See :meth:`set` for more details.
+    getting and setting generic attributes with ``get_*``
+    and ``set_*`` methods. See :meth:`set` for more details.
 
     Attributes
     ----------
@@ -261,7 +262,7 @@ class Mobject(Container):
 
         In addition to this method, there is a compatibility
         layer that allows ``get_*`` and ``set_*`` methods to
-        get and set attributes. For instance::
+        get and set generic attributes. For instance::
 
             >>> mob = Mobject()
             >>> mob.set_foo(0)
@@ -321,6 +322,12 @@ class Mobject(Container):
             to_get = attr[4:]
 
             def getter(self):
+                warnings.warn(
+                    "This method is not guaranteed to stay around. Please prefer getting the attribute normally.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
                 return getattr(self, to_get)
 
             # Return a bound method
@@ -331,6 +338,12 @@ class Mobject(Container):
             to_set = attr[4:]
 
             def setter(self, value):
+                warnings.warn(
+                    "This method is not guaranteed to stay around. Please prefer setting the attribute normally or with Mobject.set().",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
                 setattr(self, to_set, value)
 
                 return self

--- a/manim/utils/module_ops.py
+++ b/manim/utils/module_ops.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import sys
 import types
 import re
+import warnings
 
 
 def get_module(file_name: Path):
@@ -33,6 +34,11 @@ def get_module(file_name: Path):
             if ext != ".py":
                 raise ValueError(f"{file_name} is not a valid Manim python script.")
             module_name = ext.replace(os.sep, ".").split(".")[-1]
+
+            warnings.filterwarnings(
+                "default", category=DeprecationWarning, module=module_name
+            )
+
             spec = importlib.util.spec_from_file_location(module_name, file_name)
             module = importlib.util.module_from_spec(spec)
             sys.modules[module_name] = module

--- a/tests/test_get_set.py
+++ b/tests/test_get_set.py
@@ -11,6 +11,7 @@ def test_generic_set():
     assert m.test == 0
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_get_compat_layer():
     m = Mobject()
 
@@ -22,6 +23,7 @@ def test_get_compat_layer():
     assert m.get_test() == 0
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_set_compat_layer():
     m = Mobject()
 

--- a/tests/test_get_set.py
+++ b/tests/test_get_set.py
@@ -1,0 +1,36 @@
+import types
+import pytest
+
+from manim.mobject.mobject import Mobject
+
+
+def test_generic_set():
+    m = Mobject()
+    m.set(test=0)
+
+    assert m.test == 0
+
+
+def test_get_compat_layer():
+    m = Mobject()
+
+    assert isinstance(m.get_test, types.MethodType)
+    with pytest.raises(AttributeError):
+        m.get_test()
+
+    m.test = 0
+    assert m.get_test() == 0
+
+
+def test_set_compat_layer():
+    m = Mobject()
+    m.set_test(0)
+
+    assert m.test == 0
+
+
+def test_nonexistent_attr():
+    m = Mobject()
+
+    with pytest.raises(AttributeError):
+        m.test

--- a/tests/test_get_set.py
+++ b/tests/test_get_set.py
@@ -24,6 +24,8 @@ def test_get_compat_layer():
 
 def test_set_compat_layer():
     m = Mobject()
+
+    assert isinstance(m.set_test, types.MethodType)
     m.set_test(0)
 
     assert m.test == 0


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
A generic `set` method is useful for animating setting properties, as discussed in #787. The compatibility layer added also automatically maintains backwards compatibility with the `get_*` and `set_*` API for any added properties, which should leave code for added properties cleaner.

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.

For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->
The `set` method allows mobject attributes to be defined as properties instead of with `get_*` and `set_*` methods while allowing setting the properties to be animated with the `.animate` syntax, which is more pythonic and leads to less unintuitive code, like how `obj.color = BLUE` doesn't truly set the mobject's color to blue.

The automatic compatibility layer allows you to create a mobject like so:

```py
class MyMobject(Mobject):
    @property
    def blah(self):
        return self._blah

    @blah.setter
    def blah(self, value):
        self._blah = value
```

and still be able to use `get_blah` and `set_blah` without having to create a mobject like so:

```py
class MyMobject(Mobject):
    def get_blah(self):
        return self._blah

    def set_blah(self, value):
        self._blah  = value
        return self
    
    blah = property(get_blah, set_blah)
```

the last line of which seems particularly unpythonic/unconventional/less readable to me.

The compatibility layer is useful for at least as long as we're in the process of transitioning to using properties for mobject attributes, and then once that transition is complete we can decide whether we want to keep the compatibility layer and just deprecate the corresponding `get_*` and `set_*` methods, or if we want to remove them outright with a breaking change. The layer also does not interfere with `get_*` and `set_*` methods that are defined normally.

I've also added unit tests to ensure all this works.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Added generic set method and compatibility layer between properties and get_*/set_* methods (:pr:`995`)
```

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->
All tests pass locally.

## Further Comments
<!-- Optional, any further comments regarding your PR
that might be useful for reviewers.. -->
Currently unsure of where/how to document the compatibility layer, or if it needs to be documented at all.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
