### PR TITLE
Edit message in --version for consistency

### DIFF
--- a/manim/_config/main_utils.py
+++ b/manim/_config/main_utils.py
@@ -111,7 +111,7 @@ def parse_args(args: list) -> argparse.Namespace:
     elif subcmd == "plugins":
         return _parse_args_plugins(args)
     elif args[1] == "--version":
-        print(f"Manim Community Edition v{ __version__ }")
+        print(f"Manim Community v{ __version__ }")
         sys.exit()
     # elif subcmd == some_other_future_subcmd:
     #     return _parse_args_some_other_subcmd(args)


### PR DESCRIPTION
## Motivation
For consistency with #984, "Edition" has been removed from the message.

## Overview / Explanation for Changes
Edited message.

## Oneline Summary of Changes
```
- Changed --version flag message (:pr:`PR NUMBER HERE`)
```

## Further Comments
I would really like if we could create a consistent style and adhere to it. With or without "Edition" and with or without a space between "Manim" and "Community"

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
