### PR TITLE
Fix error using #hex colors with 3 characters

### DIFF
--- a/manim/utils/color.py
+++ b/manim/utils/color.py
@@ -289,7 +289,7 @@ def rgb_to_hex(rgb):
 def hex_to_rgb(hex_code):
     hex_part = hex_code[1:]
     if len(hex_part) == 3:
-        "".join([2 * c for c in hex_part])
+        hex_part = "".join([2 * c for c in hex_part])
     return np.array([int(hex_part[i : i + 2], 16) / 255 for i in range(0, 6, 2)])
 
 

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -20,6 +20,10 @@ def test_background_color():
     S.renderer.update_frame(S)
     assert np.all(S.renderer.get_frame()[0, 0] == np.array([67, 111, 128, 255]))
 
+    S.camera.background_color = "#fff"
+    S.renderer.update_frame(S)
+    assert np.all(S.renderer.get_frame()[0, 0] == np.array([255, 255, 255, 255]))
+
     S.camera.background_color = "#bbffbb"
     S.camera.background_opacity = 0.5
     S.renderer.update_frame(S)


### PR DESCRIPTION
## Motivation
I'm trying to use the color `#fff` as background but manim raises next error:

<details>
  <summary>Code</summary>

```python
codestring = \
"""
from manim import *
print("Welcome To Manim")
"""

class CodeString(Scene):
    def construct(self):
        self.camera.background_color = "#fff"
        code = Code(
            code=codestring,
            tab_width=4,
            background="window",
            language="Python",
            font="Monospace"
        )
        self.add(code)
```

</details>

<details>
  <summary>Error #fff background</summary>

```
~/files/code/manim/manim/camera/camera.py in background_color(self, color)
    137     def background_color(self, color):
    138         self._background_color = color
--> 139         self.init_background()
    140 
    141     @property

~/files/code/manim/manim/camera/camera.py in init_background(self)
    248             self.background = self.background.astype(self.pixel_array_dtype)
    249         else:
--> 250             background_rgba = color_to_int_rgba(
    251                 self.background_color, self.background_opacity
    252             )

~/files/code/manim/manim/utils/color.py in color_to_int_rgba(color, opacity)
    304 def color_to_int_rgba(color, opacity=1.0):
    305     alpha = int(255 * opacity)
--> 306     return np.append(color_to_int_rgb(color), alpha)
    307 
    308 

~/files/code/manim/manim/utils/color.py in color_to_int_rgb(color)
    299 
    300 def color_to_int_rgb(color):
--> 301     return (255 * color_to_rgb(color)).astype("uint8")
    302 
    303 

~/files/code/manim/manim/utils/color.py in color_to_rgb(color)
    261 def color_to_rgb(color):
    262     if isinstance(color, str):
--> 263         return hex_to_rgb(color)
    264     elif isinstance(color, Color):
    265         return np.array(color.get_rgb())

~/files/code/manim/manim/utils/color.py in hex_to_rgb(hex_code)
    291     if len(hex_part) == 3:
    292         "".join([2 * c for c in hex_part])
--> 293     return np.array([int(hex_part[i : i + 2], 16) / 255 for i in range(0, 6, 2)])
    294 
    295 

~/files/code/manim/manim/utils/color.py in <listcomp>(.0)
    291     if len(hex_part) == 3:
    292         "".join([2 * c for c in hex_part])
--> 293     return np.array([int(hex_part[i : i + 2], 16) / 255 for i in range(0, 6, 2)])
    294 
    295 
```

</details>

## Overview / Explanation for Changes
The error comes from the original implementation of manim, `hex_to_rgb` function has not been changed since https://github.com/ManimCommunity/manim/commit/039f7ffe585b3267d77bbb9c6a572198146727dd

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Fixed bug using hex colors with 3 characters (:pr:`998`)
```

## Testing Status
Nothing about color utils has been tested, I'm not sure if its worth add test for this small functions.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
