### PR TITLE
Fix - as filename feature

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -605,7 +605,7 @@ class ManimConfig(MutableMapping):
         if args.config_file:
             self.digest_file(args.config_file)
 
-        self.input_file = Path(args.file).absolute()
+        self.input_file = Path(args.file).absolute() if args.file != "-" else args.file
         self.scene_names = args.scene_names if args.scene_names is not None else []
         self.output_file = args.output_file
 

--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -605,6 +605,8 @@ class ManimConfig(MutableMapping):
         if args.config_file:
             self.digest_file(args.config_file)
 
+        # If args.file is `-`, the animation code has to be taken from STDIN, so the
+        # input file path shouldn't to be absolute, since that file won't be read.
         self.input_file = Path(args.file).absolute() if args.file != "-" else args.file
         self.scene_names = args.scene_names if args.scene_names is not None else []
         self.output_file = args.output_file

--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -606,7 +606,7 @@ class ManimConfig(MutableMapping):
             self.digest_file(args.config_file)
 
         # If args.file is `-`, the animation code has to be taken from STDIN, so the
-        # input file path shouldn't to be absolute, since that file won't be read.
+        # input file path shouldn't be absolute, since that file won't be read.
         self.input_file = Path(args.file).absolute() if args.file != "-" else args.file
         self.scene_names = args.scene_names if args.scene_names is not None else []
         self.output_file = args.output_file

--- a/tests/test_scene_rendering/test_cli_flags.py
+++ b/tests/test_scene_rendering/test_cli_flags.py
@@ -169,7 +169,7 @@ def test_custom_folders(tmp_path, manim_cfg_file, simple_scenes_path):
 @pytest.mark.slow
 def test_dash_as_filename(tmp_path):
     code = "class Test(Scene):\n    def construct(self):\n        self.add(Circle())\n        self.wait(1)"
-    command =[
+    command = [
         "python",
         "-m",
         "manim",
@@ -178,8 +178,8 @@ def test_dash_as_filename(tmp_path):
         "--media_dir",
         str(tmp_path),
         "-",
-        ]
-    out, err, exit_code = capture(command,command_input=code)
+    ]
+    out, err, exit_code = capture(command, command_input=code)
     assert exit_code == 0, err
     exists = (tmp_path / "images" / "-" / "Test.png").exists()
     assert exists, out

--- a/tests/test_scene_rendering/test_cli_flags.py
+++ b/tests/test_scene_rendering/test_cli_flags.py
@@ -169,22 +169,17 @@ def test_custom_folders(tmp_path, manim_cfg_file, simple_scenes_path):
 @pytest.mark.slow
 def test_dash_as_filename(tmp_path):
     code = "class Test(Scene):\n    def construct(self):\n        self.add(Circle())\n        self.wait(1)"
-    command = " ".join(
-        [
-            "echo",
-            f'"{code}"',
-            "|",
-            "python",
-            "-m",
-            "manim",
-            "-ql",
-            "-s",
-            "--media_dir",
-            str(tmp_path),
-            "-",
+    command =[
+        "python",
+        "-m",
+        "manim",
+        "-ql",
+        "-s",
+        "--media_dir",
+        str(tmp_path),
+        "-",
         ]
-    )
-    out, err, exit_code = capture(command, shell=True)
+    out, err, exit_code = capture(command,command_input=code)
     assert exit_code == 0, err
     exists = (tmp_path / "images" / "-" / "Test.png").exists()
-    assert exists, "Output was not found at expected location."
+    assert exists, out

--- a/tests/test_scene_rendering/test_cli_flags.py
+++ b/tests/test_scene_rendering/test_cli_flags.py
@@ -164,3 +164,27 @@ def test_custom_folders(tmp_path, manim_cfg_file, simple_scenes_path):
 
     exists = (tmp_path / "SquareToCircle.png").exists()
     assert exists, "--custom_folders did not produce the output file"
+
+
+@pytest.mark.slow
+def test_dash_as_filename(tmp_path):
+    code = "class Test(Scene):\n    def construct(self):\n        self.add(Circle())\n        self.wait(1)"
+    command = " ".join(
+        [
+            "echo",
+            f'"{code}"',
+            "|",
+            "python",
+            "-m",
+            "manim",
+            "-ql",
+            "-s",
+            "--media_dir",
+            str(tmp_path),
+            "-",
+        ]
+    )
+    out, err, exit_code = capture(command, shell=True)
+    assert exit_code == 0, err
+    exists = (tmp_path / "images" / "-" / "Test.png").exists()
+    assert exists, "Output was not found at expected location."

--- a/tests/utils/commands.py
+++ b/tests/utils/commands.py
@@ -1,13 +1,14 @@
 import subprocess
 
 
-def capture(command, cwd=None):
+def capture(command, cwd=None, shell=False):
     proc = subprocess.Popen(
         command,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf8",
         cwd=cwd,
+        shell=shell,
     )
     out, err = proc.communicate()
     return out, err, proc.returncode

--- a/tests/utils/commands.py
+++ b/tests/utils/commands.py
@@ -1,14 +1,15 @@
 import subprocess
 
 
-def capture(command, cwd=None, shell=False):
+def capture(command, cwd=None, shell=False, command_input=None):
     proc = subprocess.Popen(
         command,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        stdin=subprocess.PIPE,
         encoding="utf8",
         cwd=cwd,
         shell=shell,
     )
-    out, err = proc.communicate()
+    out, err = proc.communicate(command_input)
     return out, err, proc.returncode

--- a/tests/utils/commands.py
+++ b/tests/utils/commands.py
@@ -1,7 +1,7 @@
 import subprocess
 
 
-def capture(command, cwd=None, shell=False, command_input=None):
+def capture(command, cwd=None, command_input=None):
     proc = subprocess.Popen(
         command,
         stdout=subprocess.PIPE,
@@ -9,7 +9,6 @@ def capture(command, cwd=None, shell=False, command_input=None):
         stdin=subprocess.PIPE,
         encoding="utf8",
         cwd=cwd,
-        shell=shell,
     )
     out, err = proc.communicate(command_input)
     return out, err, proc.returncode


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
The `-` as filename feature is currently broken. It allowed users to enter animation code directly into `STDIN` and as such was useful for rapid testing of animations.

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.


For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->

Single line change: the absolute path to the file is no longer taken if the passed filename is `-`.


## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Fixed bug : Fixed broken `-` as filename feature. (:pr:`1005`)
```

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
