### PR TITLE
ci: fix release asset upload

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,17 +29,33 @@ jobs:
         poetry publish --build
         poetry build
 
+    - name: Store artifacts
+      uses: actions/upload-artifact@v2
+      with:
+          path: dist/*.tar.gz
+          name: manim.tar.gz
+    - name: Install Dependency
+      run: pip install requests
     - name: Get Upload URL
       id: create_release
-      shell: bash
+      shell: python
       env:
-        access_token: ${{ secrets.GITHUB_TOKEN }}
-        tag_act: ${{ github.ref }}
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_act: ${{ github.ref }}
       run: |
-          ref_tag=$(python -c "print('${tag_act}'.split('/')[-1])")
-          res=$(curl -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${access_token}" https://api.github.com/repos/ManimCommunity/manim/releases/tags/${ref_tag})
-          upload_url=$(python -c "import json;print(json.loads('''${res}''')['upload_url'])")
-          echo "::set-output name=upload_url::${upload_url}"
+          import requests
+          import os
+          ref_tag = os.getenv('tag_act').split('/')[-1]
+          access_token = os.getenv('access_token')
+          headers = {
+              "Accept":"application/vnd.github.v3+json",
+              "Authorization": f"token {access_token}"
+          }
+          url = f"https://api.github.com/repos/ManimCommunity/manim/releases/tags/{ref_tag}"
+          c = requests.get(url,headers=headers)
+          upload_url=c.json()['upload_url']
+          print(f"::set-output name=upload_url::{upload_url}")
+          print(f"::set-output name=tag_name::{ref_tag[1:]}")
 
     - name: Upload Release Asset
       id: upload-release
@@ -47,7 +63,7 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: dist/*.tar.gz
-          asset_name: manim-${{ steps.tag.outputs.tag }}.tar.gz
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/manim-${{ steps.create_release.outputs.tag_name }}.tar.gz
+          asset_name: manim-${{ steps.create_release.outputs.tag_name }}.tar.gz
           asset_content_type: application/gzip


### PR DESCRIPTION
## Motivation
Previously release failed upload of archive. This would fix it.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- ci: fix release asset upload (:pr:`PR NUMBER HERE`)
```

## Testing Status
this works for [manimpango](https://github.com/ManimCommunity/ManimPango/blob/main/.github/workflows/build.yml)

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
