### PR TITLE
Disable STDIN interaction for ffmpeg concat.

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -445,6 +445,7 @@ class SceneFileWriter(object):
             file_list,
             "-loglevel",
             config["ffmpeg_loglevel"].lower(),
+            "-nostdin",
         ]
 
         if config["write_to_movie"] and not config["save_as_gif"]:


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->

Currently, when Manim concatenates the individual partial movie files via ffpmeg, it does so without disabling STDIN interaction for the concat command used. 
This caused a problem when running manim itself through `subprocess` from another python script, like a discord bot might do.

The underlying issue was that because ffmpeg was run without disabling STDIN interaction, it would (on MacOS and Linux OSes) "cause an FFMPEG job running in the background to suspend". Because of this, the concat command would never complete, preventing a final video file from being generated.




## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.

For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->

The change needed is simply the addition of a `-nostdin` flag to the FFMPEG concat command that's run.
This would prevent FFMPEG from ever looking at STDIN (when running that concat command) and therefore would prevent the command from freezing.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Disabled STDIN interaction for ffmpeg concat. (:pr:`1010`)
```

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->

The change was tested via a the working of a Discord bot that's currently being built on repl.it. 
All tests passed on MacOS Big Sur when the changes were made locally, and the Discord bot also functioned like it was supposed to, meaning the change did work.

## Further Comments
<!-- Optional, any further comments regarding your PR
that might be useful for reviewers.. -->
It should be noted that while this disables ffmpeg communicating with STDIN for that specific command, it still lets it show errors and debug information.

FFMPEG concat doesn't even need to communicate with STDIN in our use-case anyway, so yeah.

This SO answer might have a clearer answer as to why this change is necessary: https://stackoverflow.com/a/47114881


## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [x] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
