### PR TITLE
Added progress_bar to digest_args

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -616,6 +616,7 @@ class ManimConfig(MutableMapping):
             "show_in_file_browser",
             "sound",
             "leave_progress_bars",
+            "progress_bar",
             "write_to_movie",
             "save_last_frame",
             "save_pngs",


### PR DESCRIPTION
## Motivation
DiscordManimator issues involving tqdm/progress bars. TQDM is NOT able to be disabled via CLI args, has to be done with config.

## Overview / Explanation for Changes
ManimConfig.digest_args digests the args from the CLI, and this adds the progress_bar flag so that it can be specified in CLI.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Added progress_bar to digest_args (:pr:`1017`)
```

## Further Comments
Not sure if this will fix DiscordManimator /shrug

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
