### PR TITLE
Docs: added Bezier example

### DIFF
--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -934,6 +934,7 @@ class CubicBezier(VMobject):
                 self.add(l1, d1,l2, d2,bezier)
 
     """
+
     def __init__(self, points, **kwargs):
         VMobject.__init__(self, **kwargs)
         self.set_points(points)

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -930,7 +930,7 @@ class CubicBezier(VMobject):
                 d2 = Dot(point=p2).set_color(RED)
                 l2 = Line(p2, p2b)
                 bezier=CubicBezier([p1b, p1b + 3 * RIGHT, p2b - 3 * RIGHT, p2b])
-                self.add(l1, d1,l2, d2,bezier)
+                self.add(l1, d1, l2, d2, bezier)
 
     """
 

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -921,7 +921,6 @@ class CubicBezier(VMobject):
 
         class BezierSplineExample(Scene):
             def construct(self):
-                np.random.seed(42)
                 p1 = np.array([-3, 1, 0])
                 p1b = p1 + [1, 0, 0]
                 d1 = Dot(point=p1).set_color(BLUE)

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -912,6 +912,28 @@ class DoubleArrow(Arrow):
 
 
 class CubicBezier(VMobject):
+    """
+    Example
+    -------
+
+    .. manim:: BezierSplineExample
+        :save_last_frame:
+
+        class BezierSplineExample(Scene):
+            def construct(self):
+                np.random.seed(42)
+                p1 = np.array([-3, 1, 0])
+                p1b = p1 + [1, 0, 0]
+                d1 = Dot(point=p1).set_color(BLUE)
+                l1 = Line(p1, p1b)
+                p2 = np.array([3, -1, 0])
+                p2b = p2 - [1, 0, 0]
+                d2 = Dot(point=p2).set_color(RED)
+                l2 = Line(p2, p2b)
+                bezier=CubicBezier([p1b, p1b + 3 * RIGHT, p2b - 3 * RIGHT, p2b])
+                self.add(l1, d1,l2, d2,bezier)
+
+    """
     def __init__(self, points, **kwargs):
         VMobject.__init__(self, **kwargs)
         self.set_points(points)

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -929,7 +929,7 @@ class CubicBezier(VMobject):
                 p2b = p2 - [1, 0, 0]
                 d2 = Dot(point=p2).set_color(RED)
                 l2 = Line(p2, p2b)
-                bezier=CubicBezier([p1b, p1b + 3 * RIGHT, p2b - 3 * RIGHT, p2b])
+                bezier = CubicBezier([p1b, p1b + 3 * RIGHT, p2b - 3 * RIGHT, p2b])
                 self.add(l1, d1, l2, d2, bezier)
 
     """


### PR DESCRIPTION
Some more documentation for the CubicBezier example

EDIT: example can be found here: https://manimce--1021.org.readthedocs.build/en/1021/reference/manim.mobject.geometry.CubicBezier.html?highlight=bezier#manim.mobject.geometry.CubicBezier

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
