### PR TITLE
Fix using -p and -s together

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -291,12 +291,11 @@ class SceneFileWriter(object):
         image : np.array
             The pixel array of the image to save.
         """
-        file_path = self.image_file_path
         if not config["output_file"]:
-            file_path = add_version_before_extension(file_path)
+            self.image_file_path = add_version_before_extension(self.image_file_path)
 
-        image.save(file_path)
-        self.print_file_ready_message(file_path)
+        image.save(self.image_file_path)
+        self.print_file_ready_message(self.image_file_path)
 
     def idle_stream(self):
         """


### PR DESCRIPTION
## Motivation
Fix using `-p` flag with `-s` flag.

## Overview / Explanation for Changes
`self.image_file_path` was not updated which broke `-p`

## Oneline Summary of Changes
```
- Fixed using the `-p` flag with the `-s` flag (:pr:`PR NUMBER HERE`)
```

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
