### PR TITLE
Enhancement: parse .log file and try to print LaTeX errors if compilation fails

### DIFF
--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -171,19 +171,21 @@ def compile_tex(tex_file, tex_compiler, output_format):
                 )
             with open(log_file, "r") as f:
                 log = f.readlines()
-                log_error_pos = [ind for (ind, line) in enumerate(log) if line.startswith("!")]
+                log_error_pos = [
+                    ind for (ind, line) in enumerate(log) if line.startswith("!")
+                ]
                 if log_error_pos:
                     logger.error(f"LaTeX compilation error! {tex_compiler} reports:")
                     for lineno in log_error_pos:
-                        # search for a line starting with "l." in the next 
+                        # search for a line starting with "l." in the next
                         # few lines past the error; otherwise just print some lines.
                         printed_lines = 1
                         for _ in range(10):
-                            if log[lineno+printed_lines].startswith("l."):
+                            if log[lineno + printed_lines].startswith("l."):
                                 break
                             printed_lines += 1
 
-                        for line in log[lineno:lineno+printed_lines+1]:
+                        for line in log[lineno : lineno + printed_lines + 1]:
                             logger.error(line)
 
             raise ValueError(

--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -164,6 +164,28 @@ def compile_tex(tex_file, tex_compiler, output_format):
         exit_code = os.system(command)
         if exit_code != 0:
             log_file = tex_file.replace(".tex", ".log")
+            if not Path(log_file).exists():
+                raise RuntimeError(
+                    f"{tex_compiler} failed but did not produce a log file. "
+                    "Check your LaTeX installation."
+                )
+            with open(log_file, "r") as f:
+                log = f.readlines()
+                log_error_pos = [ind for (ind, line) in enumerate(log) if line.startswith("!")]
+                if log_error_pos:
+                    logger.error(f"LaTeX compilation error! {tex_compiler} reports:")
+                    for lineno in log_error_pos:
+                        # search for a line starting with "l." in the next 
+                        # few lines past the error; otherwise just print some lines.
+                        printed_lines = 1
+                        for _ in range(10):
+                            if log[lineno+printed_lines].startswith("l."):
+                                break
+                            printed_lines += 1
+
+                        for line in log[lineno:lineno+printed_lines+1]:
+                            logger.error(line)
+
             raise ValueError(
                 f"{tex_compiler} error converting to"
                 f" {output_format[1:]}. See log output above or"


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Recently, 3b1b/manim has introduced a change which makes the LaTeX errors a bit more visible. I've tried to build upon that so that manim tries to log the full error with this PR.

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.

For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->
The .log file is opened, lines starting with `!` are searched. After each such line, a line starting with `l.<some number>` is expected, containing the problematic code. This line is searched for and everything between the `!`-line and the "line number" line is logged. If no such line is found, then just some number of lines after the `!`-line are logged. 

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Enhancement: parse .log file and try to print LaTeX errors if compilation fails (:pr:`PR NUMBER HERE`)
```

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->

With this PR:
```
>>> Tex(r"\asdf")
...
[02/14/21 14:06:04] INFO     Writing "\asdf" to media/Tex/51e30f63afa8eeb3.tex                                                 tex_file_writing.py:81
                    ERROR    LaTeX compilation error! latex reports:                                                          tex_file_writing.py:178
                    ERROR    ! Undefined control sequence.                                                                    tex_file_writing.py:189
                                                                                                                                                     
                    ERROR    l.26 \asdf                                                                                       tex_file_writing.py:189
                                                                                                                                                     
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/behackl/Documents/code/manim/manim/mobject/svg/tex_mobject.py", line 502, in __init__
    MathTex.__init__(
  File "/Users/behackl/Documents/code/manim/manim/mobject/svg/tex_mobject.py", line 381, in __init__
    SingleStringMathTex.__init__(
  File "/Users/behackl/Documents/code/manim/manim/mobject/svg/tex_mobject.py", line 228, in __init__
    file_name = tex_to_svg_file(
  File "/Users/behackl/Documents/code/manim/manim/utils/tex_file_writing.py", line 44, in tex_to_svg_file
    dvi_file = compile_tex(
  File "/Users/behackl/Documents/code/manim/manim/utils/tex_file_writing.py", line 191, in compile_tex
    raise ValueError(
ValueError: latex error converting to dvi. See log output above or the log file: media/Tex/51e30f63afa8eeb3.log
```

```
>>> Tex(r"\alpha = 12")
...
[02/14/21 14:06:37] ERROR    LaTeX compilation error! latex reports:                                                          tex_file_writing.py:178
                    ERROR    ! Missing $ inserted.                                                                            tex_file_writing.py:189
                                                                                                                                                     
                    ERROR    <inserted text>                                                                                  tex_file_writing.py:189
                                                                                                                                                     
                    ERROR                    $                                                                                tex_file_writing.py:189
                                                                                                                                                     
                    ERROR    l.26 \alpha                                                                                      tex_file_writing.py:189
                                                                                                                                                     
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/behackl/Documents/code/manim/manim/mobject/svg/tex_mobject.py", line 502, in __init__
    MathTex.__init__(
  File "/Users/behackl/Documents/code/manim/manim/mobject/svg/tex_mobject.py", line 381, in __init__
    SingleStringMathTex.__init__(
  File "/Users/behackl/Documents/code/manim/manim/mobject/svg/tex_mobject.py", line 228, in __init__
    file_name = tex_to_svg_file(
  File "/Users/behackl/Documents/code/manim/manim/utils/tex_file_writing.py", line 44, in tex_to_svg_file
    dvi_file = compile_tex(
  File "/Users/behackl/Documents/code/manim/manim/utils/tex_file_writing.py", line 191, in compile_tex
    raise ValueError(
ValueError: latex error converting to dvi. See log output above or the log file: media/Tex/8e085068748f9b8d.log
```


## Further Comments
<!-- Optional, any further comments regarding your PR
that might be useful for reviewers.. -->

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
