### PR TITLE
Remove Square.side_length property

### DIFF
--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -1255,16 +1255,6 @@ class Square(Rectangle):
     def __init__(self, side_length=2.0, **kwargs):
         Rectangle.__init__(self, height=side_length, width=side_length, **kwargs)
 
-    @property
-    def side_length(self):
-        """The square's side length."""
-
-        return self.width
-
-    @side_length.setter
-    def side_length(self, value):
-        self.width = value
-
 
 class RoundedRectangle(Rectangle):
     def __init__(self, corner_radius=0.5, **kwargs):

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -1253,6 +1253,7 @@ class Rectangle(Polygon):
 
 class Square(Rectangle):
     def __init__(self, side_length=2.0, **kwargs):
+        self.side_length = side_length
         Rectangle.__init__(self, height=side_length, width=side_length, **kwargs)
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
We can't enforce accuracy of class-specific mobject attributes, so we shouldn't give users the impression that we can.

## Overview / Explanation for Changes
Removes the side_length property.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Remove Square.side_length property
```
