### PR TITLE
Breaking: Make CubicBezier explicitly accept four points

### DIFF
--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -924,14 +924,14 @@ class CubicBezier(VMobject):
                 p2b = p2 - [1, 0, 0]
                 d2 = Dot(point=p2).set_color(RED)
                 l2 = Line(p2, p2b)
-                bezier = CubicBezier([p1b, p1b + 3 * RIGHT, p2b - 3 * RIGHT, p2b])
+                bezier = CubicBezier(p1b, p1b + 3 * RIGHT, p2b - 3 * RIGHT, p2b)
                 self.add(l1, d1, l2, d2, bezier)
 
     """
 
-    def __init__(self, points, **kwargs):
+    def __init__(self, start_anchor, start_handle, end_handle, end_anchor, **kwargs):
         VMobject.__init__(self, **kwargs)
-        self.set_points(points)
+        self.set_points([start_anchor, start_handle, end_handle, end_anchor])
 
 
 class Polygon(VMobject):


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
Right now, `CubicBezier` remains largely undocumented and it's not entirely clear how it works. It actually exposes the internals of `set_points` in a very weird way and, IMHO, should remain just as a simple, single Bézier curve.

## Overview / Explanation for Changes
This changes the calling convention of `CubicBezier` from an arbitrary number of points (which, although it should be a length that's a multiple of four, doesn't have to be) to accept four specific points representing the anchors and handles.

## Oneline Summary of Changes
```
- BREAKING: `CubicBezier([a1, h1, h2, a2])` is now `CubicBezier(a1, h1, h2, a2)` and only one curve is supported (:pr:`PR NUMBER HERE`)
```

## Further Comments
This is a breaking change so it's understandable to not include it. For people who want a multi-curve shape without creating multiple `CubicBezier`s, I think that we should offer a better interface to do so other than just SVGs, but in the meantime this technically wouldn't be possible in its current form. 

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
