### PR TITLE
fix - use absolute path in make_and_open_docs.py

### DIFF
--- a/scripts/make_and_open_docs.py
+++ b/scripts/make_and_open_docs.py
@@ -6,7 +6,7 @@ import webbrowser
 path_makefile = Path(__file__).parents[1] / "docs"
 os.system(f"cd {path_makefile} && make html")
 
-website = "file://" + str((path_makefile / "build" / "html" / "index.html").absolute())
+website = (path_makefile / "build" / "html" / "index.html").absolute().as_uri()
 try:  # Allows you to pass a custom browser if you want.
     webbrowser.get(sys.argv[1]).open_new_tab(f"{website}")
 except IndexError:

--- a/scripts/make_and_open_docs.py
+++ b/scripts/make_and_open_docs.py
@@ -6,7 +6,7 @@ import webbrowser
 path_makefile = Path(__file__).parents[1] / "docs"
 os.system(f"cd {path_makefile} && make html")
 
-website = "file://" + str(path_makefile / "build" / "html" / "index.html")
+website = "file://" + str((path_makefile / "build" / "html" / "index.html").absolute())
 try:  # Allows you to pass a custom browser if you want.
     webbrowser.get(sys.argv[1]).open_new_tab(f"{website}")
 except IndexError:


### PR DESCRIPTION
## Motivation
Corrects the local (file:///) URL opening script 

## Overview / Explanation for Changes
The file:/// URL generated by script was only including the relative path i.e. docs/... but to be
displayed in the browser you need a full absolute path.

## One line Summary of Changes
```
- Fixed the opening of local documentation build URL
```

## Testing Status
Verified it manually 

## Further Comments
NA

## Acknowledgements
- [x ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
