### PR TITLE
fix - make sure stroke color & width gets applied in Cross object

### DIFF
--- a/manim/mobject/shape_matchers.py
+++ b/manim/mobject/shape_matchers.py
@@ -75,7 +75,7 @@ class BackgroundRectangle(SurroundingRectangle):
 
 
 class Cross(VGroup):
-    def __init__(self, mobject, stroke_color=RED, stroke_width=6, **kwargs):        
+    def __init__(self, mobject, stroke_color=RED, stroke_width=6, **kwargs):
         VGroup.__init__(
             self,
             Line(UP + LEFT, DOWN + RIGHT),

--- a/manim/mobject/shape_matchers.py
+++ b/manim/mobject/shape_matchers.py
@@ -75,16 +75,14 @@ class BackgroundRectangle(SurroundingRectangle):
 
 
 class Cross(VGroup):
-    def __init__(self, mobject, stroke_color=RED, stroke_width=6, **kwargs):
-        self.stroke_color = stroke_color
-        self.stroke_width = stroke_width
+    def __init__(self, mobject, stroke_color=RED, stroke_width=6, **kwargs):        
         VGroup.__init__(
             self,
             Line(UP + LEFT, DOWN + RIGHT),
             Line(UP + RIGHT, DOWN + LEFT),
         )
         self.replace(mobject, stretch=True)
-        self.set_stroke(self.stroke_color, self.stroke_width)
+        self.set_stroke(color=stroke_color, width=stroke_width)
 
 
 class Underline(Line):


### PR DESCRIPTION
## Motivation
Make sure that the user-supplied stroke color & width gets applied to the Cross object 

## Overview / Explanation for Changes
Here is the current implementation
```
class Cross(VGroup):
    def __init__(self, mobject, stroke_color=RED, stroke_width=6, **kwargs):
        self.stroke_color = stroke_color
        self.stroke_width = stroke_width
        VGroup.__init__(
            self,
            Line(UP + LEFT, DOWN + RIGHT),
            Line(UP + RIGHT, DOWN + LEFT),
        )
        self.replace(mobject, stretch=True)
        self.set_stroke(self.stroke_color, self.stroke_width)
```

`VGroup.__init__` resets stroke_color and stroke_width attributes & therefore the first 2 lines in this function are nullified. As a consequence, the last line of this function ends up passing None for both the parameters 

Also, there is nothing to be gained by setting the attributes, we need to simply pass the stroke_color & stroke_width to the self.set_stroke. Please see the change.

## Oneline Summary of Changes
- Make sure that the user-supplied stroke color & width gets applied to the Cross object 
 (:pr:`1050`)

## Testing Status
Tested it using a sample script

## Further Comments
No

## Acknowledgements
- [ X] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
