### PR TITLE
fix - corrections for setting stroke related attributes on VMobject

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -186,14 +186,20 @@ class VMobject(Mobject):
         if background:
             array_name = "background_stroke_rgbas"
             width_name = "background_stroke_width"
+            opacity_name = "background_stroke_opacity"
+            color_name = "background_stroke_color"
         else:
             array_name = "stroke_rgbas"
             width_name = "stroke_width"
+            opacity_name = "stroke_opacity"
+            color_name = "stroke_color"
         self.update_rgbas_array(array_name, color, opacity)
         if width is not None:
             setattr(self, width_name, width)
         if opacity is not None:
-            self.stroke_opacity = opacity
+            setattr(self, opacity_name, opacity)
+        if color is not None:
+            setattr(self, color_name, color)
         return self
 
     def set_background_stroke(self, **kwargs):

--- a/tests/test_stroke.py
+++ b/tests/test_stroke.py
@@ -1,0 +1,24 @@
+from manim import VMobject
+import manim.utils.color as C
+
+
+def test_stroke_props_in_ctor():
+    m = VMobject(stroke_color=C.ORANGE, stroke_width=10)
+    assert m.stroke_color == C.ORANGE
+    assert m.stroke_width == 10
+
+
+def test_set_stroke():
+    m = VMobject()
+    m.set_stroke(color=C.ORANGE, width=2, opacity=0.8)
+    assert m.stroke_width == 2
+    assert m.stroke_opacity == 0.8
+    assert m.stroke_color == C.ORANGE
+
+
+def test_set_background_stroke():
+    m = VMobject()
+    m.set_stroke(color=C.ORANGE, width=2, opacity=0.8, background=True)
+    assert m.background_stroke_width == 2
+    assert m.background_stroke_opacity == 0.8
+    assert m.background_stroke_color == C.ORANGE


### PR DESCRIPTION
## Motivation
`set_stroke` api of `VMobject` is not properly setting the color & opacity attributes

## Overview / Explanation for Changes
The modification is following the convention used for setting the width property of stroke (and background_stroke). Please see the changes

## Oneline Summary of Changes
```
- Fix the update of color and opacity attributes of VMobject (:pr:`PR NUMBER HERE`)
```

## Testing Status
Have added the tests 

## Further Comments
NA

## Acknowledgements
- [ X] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
