### PR TITLE
 fix #1045 changes in line 118

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,7 +115,7 @@ def linkcode_resolve(domain, info):
         return None
     filename = info["module"].replace(".", "/")
     version = os.getenv("READTHEDOCS_VERSION", "master")
-    if version == "latest":
+    if version == "latest" or version == "stable":
         version = "master"
     return f"https://github.com/ManimCommunity/manim/blob/{version}/{filename}.py"
 


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
the link could work and I am learning to do PR.

## Proposed changes
<!-- What you changed in those files -->
fix-1045  [(https://github.com/ManimCommunity/manim/issues/1045)]
- The stable branch does not exist, that's why it showing the 404.
- posibly, an oversight after getting rid of the stable branch. Can be fixed similarly to what is done here:
`manim/docs/source/conf.py`

Line 118 in 6744c48
`if version == "latest": ` 

- possibly also just by linking to master, so adding ` or ... == "stable" to that line.`
- 

