### PR TITLE
More descriptive error when accessing an unhandled mobject attribute

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -352,7 +352,7 @@ class Mobject(Container):
             return types.MethodType(setter, self)
 
         # Unhandled attribute, therefore error
-        raise AttributeError(f"{self} object has no attribute '{attr}'")
+        raise AttributeError(f"{type(self).__name__} object has no attribute '{attr}'")
 
     @property
     def width(self):

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -352,7 +352,7 @@ class Mobject(Container):
             return types.MethodType(setter, self)
 
         # Unhandled attribute, therefore error
-        raise AttributeError
+        raise AttributeError(f"{self} object has no attribute '{attr}'")
 
     @property
     def width(self):

--- a/tests/test_get_set.py
+++ b/tests/test_get_set.py
@@ -36,5 +36,5 @@ def test_set_compat_layer():
 def test_nonexistent_attr():
     m = Mobject()
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError, match="object has no attribute"):
         m.test


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Because #995 added a `__getattr__` method to `Mobject`, all incorrect accesses to a mobject's attributes goes through that method, but the resulting error does not have an accompanying message (sorry). This fixes that.

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.

For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->
Adds an error message to the error raised at the end of `__getattr__`. It uses `f"{self} ..."` to take advantage of mobjects' custom representations, particularly with `Text` and `Tex` and such which include their content in their representation.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- More descriptive error when accessing an unhandled mobject attribute (:pr:`1059`)
```

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->
This change shouldn't affect any tests.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
