### PR TITLE
docs: update installation docs for linux - pango

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update -qq \
         gcc \
         libcairo2-dev \
         libffi-dev \
-		libpango1.0-dev \
+        libpango1.0-dev \
         pkg-config \
         wget
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update -qq \
         gcc \
         libcairo2-dev \
         libffi-dev \
+		libpango1.0-dev \
         pkg-config \
         wget
 

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -30,7 +30,7 @@ To install Pango:
 
 .. code-block:: bash
 
-   sudo apt install libcairo2-dev
+   sudo apt install libpango1.0-dev
 
 To install ffmpeg:
 

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -26,6 +26,12 @@ To install cairo:
 
    sudo apt install libcairo2-dev
 
+To install Pango:
+
+.. code-block:: bash
+
+   sudo apt install libcairo2-dev
+
 To install ffmpeg:
 
 .. code-block:: bash
@@ -57,6 +63,12 @@ To install cairo:
 .. code-block:: bash
 
   sudo dnf install cairo-devel
+
+To install Pango:
+
+.. code-block:: bash
+
+   sudo dnf install pango-devel
 
 To install ffmpeg, you have to add RPMfusion repository (If it's not already added). Please follow the instructions for your specific distribution in the following URL:
 
@@ -96,6 +108,11 @@ To install cairo:
 
    sudo pacman -S cairo
 
+To install pango:
+
+.. code-block:: bash
+
+   sudo pacman -S pango
 
 To install ffmpeg:
 


### PR DESCRIPTION
## Motivation
see https://github.com/ManimCommunity/ManimPango/issues/27
manylinux wheels are to be removed in the next release on ManimPango
as they are problematic to maintain and use.

## Oneline Summary of Changes
```
- Update Linux installation docs to install Pango. (:pr:`PR NUMBER HERE`)
```

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
