### PR TITLE
add api docs & examples for number_line module

### DIFF
--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -9,48 +9,35 @@ Examples
 
     class NumberLineExamples(Scene):
         def construct(self):
-            # the default number line (does not display labels, tips etc)
             txt1 = Text("Default Number Line", size=0.6).shift(3.5 * UP)
             num_line1 = NumberLine().next_to(txt1, direction=DOWN)
             self.add(txt1, num_line1)
 
-            # a number line with a tip
             txt2 = Text("Number Line with a tip", size=0.6).next_to(
-                num_line1,
-                direction=DOWN,
-                buff=2 * DEFAULT_MOBJECT_TO_MOBJECT_BUFFER)
+                num_line1, direction=DOWN, buff=2 * DEFAULT_MOBJECT_TO_MOBJECT_BUFFER
+            )
             num_line2 = NumberLine(include_tip=True).next_to(txt2, direction=DOWN)
             self.add(txt2, num_line2)
 
-            # a number line with the numbers/labels
             txt3 = Text("Number Line with labels", size=0.6).next_to(
-                num_line2,
-                direction=DOWN,
-                buff=2 * DEFAULT_MOBJECT_TO_MOBJECT_BUFFER)
-            num_line3 = NumberLine(include_numbers=True).next_to(txt3,
-                                                                direction=DOWN)
+                num_line2, direction=DOWN, buff=2 * DEFAULT_MOBJECT_TO_MOBJECT_BUFFER
+            )
+            num_line3 = NumberLine(include_numbers=True).next_to(txt3, direction=DOWN)
             self.add(txt3, num_line3)
 
-            # a number line with specific numbers to show
             txt4 = Text("Number Line with specific labels", size=0.6).next_to(
-                num_line3,
-                direction=DOWN,
-                buff=2 * DEFAULT_MOBJECT_TO_MOBJECT_BUFFER)
-            num_line4 = NumberLine(include_numbers=False).next_to(txt4,
-                                                                direction=DOWN)
+                num_line3, direction=DOWN, buff=2 * DEFAULT_MOBJECT_TO_MOBJECT_BUFFER
+            )
+            num_line4 = NumberLine(include_numbers=False).next_to(txt4, direction=DOWN)
             self.add(txt4, num_line4)
 
-            # get the numbers to be displayed
             x_numbers = num_line4.get_number_mobjects(1, 2, -2)
-            # may be color them if you wish
             x_numbers.set_color(ORANGE)
-            # and must add them to the screen
             self.add(x_numbers)
 
             txt5 = Text("Number Line with unit interval", size=0.6).next_to(
-                num_line4,
-                direction=DOWN,
-                buff=2 * DEFAULT_MOBJECT_TO_MOBJECT_BUFFER)
+                num_line4, direction=DOWN, buff=2 * DEFAULT_MOBJECT_TO_MOBJECT_BUFFER
+            )
             num_line5 = UnitInterval().next_to(txt5, direction=DOWN)
             self.add(txt5, num_line5)
 """

--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -1,4 +1,59 @@
-"""Mobject representing a number line."""
+r"""Mobjects representing number lines.
+
+
+Examples
+--------
+
+.. manim:: NumberLineExamples
+    :save_last_frame:
+
+    class NumberLineExamples(Scene):
+        def construct(self):
+            # the default number line (does not display labels, tips etc)
+            txt1 = Text("Default Number Line", size=0.6).shift(3.5 * UP)
+            num_line1 = NumberLine().next_to(txt1, direction=DOWN)
+            self.add(txt1, num_line1)
+
+            # a number line with a tip
+            txt2 = Text("Number Line with a tip", size=0.6).next_to(
+                num_line1,
+                direction=DOWN,
+                buff=2 * DEFAULT_MOBJECT_TO_MOBJECT_BUFFER)
+            num_line2 = NumberLine(include_tip=True).next_to(txt2, direction=DOWN)
+            self.add(txt2, num_line2)
+
+            # a number line with the numbers/labels
+            txt3 = Text("Number Line with labels", size=0.6).next_to(
+                num_line2,
+                direction=DOWN,
+                buff=2 * DEFAULT_MOBJECT_TO_MOBJECT_BUFFER)
+            num_line3 = NumberLine(include_numbers=True).next_to(txt3,
+                                                                direction=DOWN)
+            self.add(txt3, num_line3)
+
+            # a number line with specific numbers to show
+            txt4 = Text("Number Line with specific labels", size=0.6).next_to(
+                num_line3,
+                direction=DOWN,
+                buff=2 * DEFAULT_MOBJECT_TO_MOBJECT_BUFFER)
+            num_line4 = NumberLine(include_numbers=False).next_to(txt4,
+                                                                direction=DOWN)
+            self.add(txt4, num_line4)
+
+            # get the numbers to be displayed
+            x_numbers = num_line4.get_number_mobjects(1, 2, -2)
+            # may be color them if you wish
+            x_numbers.set_color(ORANGE)
+            # and must add them to the screen
+            self.add(x_numbers)
+
+            txt5 = Text("Number Line with unit interval", size=0.6).next_to(
+                num_line4,
+                direction=DOWN,
+                buff=2 * DEFAULT_MOBJECT_TO_MOBJECT_BUFFER)
+            num_line5 = UnitInterval().next_to(txt5, direction=DOWN)
+            self.add(txt5, num_line5)
+"""
 
 
 __all__ = ["NumberLine", "UnitInterval"]
@@ -19,6 +74,8 @@ from ..utils.color import LIGHT_GREY
 
 
 class NumberLine(Line):
+    """Creates a number line"""
+
     def __init__(
         self,
         color=LIGHT_GREY,
@@ -50,6 +107,53 @@ class NumberLine(Line):
         x_max=config["frame_x_radius"],
         **kwargs
     ):
+        """
+
+        Parameters
+        ----------
+        color : :class:`Colors`, optional
+            the color for the number line, by default LIGHT_GREY
+        unit_size : :class:`int`, optional
+            the unit size, by default 1
+        width : :class:`float`, optional
+            the width of the number line, by default None
+        include_ticks : :class:`bool`, optional
+            True if should include the tick marks, by default True
+        tick_size : :class:`float`, optional
+            the size of the ticks, by default 0.1
+        tick_frequency : :class:`int`, optional
+            the frequency of the tick marks, by default 1
+        leftmost_tick : :class:`float`, optional
+            the leftmost tick, by default None
+        numbers_with_elongated_ticks : :class:`list`, optional
+            the numbers with elongated ticks, by default [0]
+        include_numbers : :class:`bool`, optional
+            True if should display numbers, by default False
+        numbers_to_show : :class:`list`, optional
+            the list of numbers to display, by default None
+        longer_tick_multiple : :class:`int`, optional
+            the scale factor for longer ticks, by default 2
+        number_at_center : :class:`int`, optional
+            the number at the center, by default 0
+        number_scale_val : :class:`float`, optional
+            the scale factor for the numbers, by default 0.75
+        label_direction : :class:`np.ndarray`, optional
+            the direction of the label, by default DOWN
+        line_to_number_buff : :class:`float`, optional
+            the buffer between the line and numbers, by default MED_SMALL_BUFF
+        include_tip : :class:`bool`, optional
+            True if should include tip, by default False
+        tip_width : :class:`float`, optional
+            the width of the tip, by default 0.25
+        tip_height : :class:`float`, optional
+            the height of the tip, by default 0.25
+        exclude_zero_from_default_numbers : :class:`bool`, optional
+            True if should exclude zero from numbers/labels , by default False
+        x_min : :class:`float`, optional
+            the min number, by default -config["frame_x_radius"]
+        x_max : :class:`float`, optional
+            the max number, by default config["frame_x_radius"]
+        """
         self.unit_size = unit_size
         self.include_ticks = include_ticks
         self.tick_size = tick_size
@@ -102,6 +206,7 @@ class NumberLine(Line):
             )
 
     def add_tick_marks(self):
+        """Adds the tick marks on the NumberLine"""
         tick_size = self.tick_size
         self.tick_marks = VGroup(
             *[self.get_tick(x, tick_size) for x in self.get_tick_numbers()]
@@ -119,6 +224,20 @@ class NumberLine(Line):
         )
 
     def get_tick(self, x, size=None):
+        """Returns the tick Mobject (:class:`~.Line`)
+
+        Parameters
+        ----------
+        x : :class:`float`
+            the number corresponding to the tick mark
+        size : :class:`float`, optional
+            the size of the tick mark, by default None
+
+        Returns
+        -------
+        :class:`~.Line`
+            the tick mark (:class:`~.Line`) Mobject
+        """
         if size is None:
             size = self.tick_size
         result = Line(size * DOWN, size * UP)
@@ -128,12 +247,26 @@ class NumberLine(Line):
         return result
 
     def get_tick_marks(self):
+        """Returns the tick marks on the NumberLine
+
+        Returns
+        -------
+        :class:`~.VGroup`
+            the VGroup containing the tick marks
+        """
         return VGroup(
             *self.tick_marks,
             *self.big_tick_marks,
         )
 
     def get_tick_numbers(self):
+        """Returns the numbers corresponding to the tick marks
+
+        Returns
+        -------
+        :class:`np.array`
+            the numpy array containing the numbers
+        """
         u = -1 if self.include_tip and self.add_end == 0 else 1
         return np.arange(
             self.leftmost_tick,
@@ -142,6 +275,18 @@ class NumberLine(Line):
         )
 
     def number_to_point(self, number):
+        """Converts the point on the screen to the number of NumberLine
+
+        Parameters
+        ----------
+        number : :class:`float`
+            the number to convert
+
+        Returns
+        -------
+        :class:`np.ndarray`
+            the point on the screen
+        """
         alpha = float(number - self.x_min) / (self.x_max - self.x_min)
         return interpolate(
             self.get_start() + self.add_start * RIGHT,
@@ -150,6 +295,18 @@ class NumberLine(Line):
         )
 
     def point_to_number(self, point):
+        """Converts the point on the screen to the number on NumberLine
+
+        Parameters
+        ----------
+        point : :class:`np.ndarray`
+            the point to convert
+
+        Returns
+        -------
+        :class:`float`
+            the number on the NumberLine
+        """
         start_point, end_point = self.get_start_and_end()
         full_vect = end_point - start_point
         unit_vect = normalize(full_vect)
@@ -161,20 +318,41 @@ class NumberLine(Line):
         return interpolate(self.x_min, self.x_max, proportion)
 
     def n2p(self, number):
-        """Abbreviation for number_to_point"""
+        """An alias for :meth:`~.NumberLine.number_to_point`"""
         return self.number_to_point(number)
 
     def p2n(self, point):
-        """Abbreviation for point_to_number"""
+        """An alias for :meth:`~.NumberLine.point_to_number`"""
         return self.point_to_number(point)
 
     def get_unit_size(self):
+        """Returns the unit size of the NumberLine
+
+        Returns
+        -------
+        :class:`float`
+            the unit size
+        """
         return self.get_length() / (self.x_max - self.x_min)
 
     def get_unit_vector(self):
+        """Returns a unit vector
+
+        Returns
+        -------
+        :class:`np.ndarray`
+            the unit vector scaled with the unit size of the NumberLine
+        """
         return super().get_unit_vector() * self.unit_size
 
     def default_numbers_to_display(self):
+        """Returns the default numbers to display
+
+        Returns
+        -------
+        :class:`np.array`
+            the default numbers as numpy array
+        """
         if self.numbers_to_show is not None:
             return self.numbers_to_show
         numbers = np.arange(
@@ -188,6 +366,26 @@ class NumberLine(Line):
     def get_number_mobject(
         self, number, number_config=None, scale_val=None, direction=None, buff=None
     ):
+        """Returns the :class:`~.DecimalNumber` mobject for the passed number
+
+        Parameters
+        ----------
+        number : :class:`float`
+            the number on the line
+        number_config : :class:`dict`, optional
+            the config to be passed to :class:`~.DecimalNumber`, by default None
+        scale_val : :class:`float`, optional
+            the scale factor for :class:`~.DecimalNumber` mobject, by default None
+        direction : :class:`np.ndarray, optional
+            the direction for the :class:`~.DecimalNumber` mobject, by default None
+        buff : :class:`float`, optional
+            the buffer between the number and the number line, by default None
+
+        Returns
+        -------
+        :class:`~.DecimalNumber`
+            The :class:`~.DecimalNumber` mobject for the passed number
+        """
         number_config = merge_dicts_recursively(
             self.decimal_number_config,
             number_config or {},
@@ -203,6 +401,18 @@ class NumberLine(Line):
         return num_mob
 
     def get_number_mobjects(self, *numbers, **kwargs):
+        """Returns the labels (type :class:`~.DecimalNumber`) of the number line as a VGroup.
+
+        Parameters
+        ----------
+        numbers : :class:`list[float]`
+            the numbers to put
+
+        Returns
+        --------
+        :class:`~.VGroup`
+            VGroup containing the :class:`~.DecimalNumber` mobjects.
+        """
         if len(numbers) == 0:
             numbers = self.default_numbers_to_display()
         return VGroup(
@@ -210,15 +420,36 @@ class NumberLine(Line):
         )
 
     def get_labels(self):
+        """Returns the default labels (type :class:`~.DecimalNumber`) of the number line as a VGroup.
+
+        Returns
+        --------
+        :class:`~.VGroup`
+            VGroup containing the :class:`~.DecimalNumber` mobjects.
+        """
         return self.get_number_mobjects()
 
     def add_numbers(self, *numbers, **kwargs):
+        """Add the numbers (labels) to the NumberLine
+
+        Parameters
+        ----------
+        numbers : :class:`list[float]`
+            the numbers to put
+
+        Returns
+        -------
+        :class:`NumberLine`
+            The current number line object (self).
+        """
         self.numbers = self.get_number_mobjects(*numbers, **kwargs)
         self.add(self.numbers)
         return self
 
 
 class UnitInterval(NumberLine):
+    """Creates a NumberLine with a unit interval """
+
     def __init__(
         self,
         unit_size=6,
@@ -230,6 +461,21 @@ class UnitInterval(NumberLine):
         },
         **kwargs
     ):
+        """
+
+        Parameters
+        ----------
+        unit_size : :class:`int`, optional
+            the unit size, by default 6
+        tick_frequency : :class:`float`, optional
+            the tick frequency, by default 0.1
+        numbers_with_elongated_ticks : :class:`list`, optional
+            the numbers on elongated ticks, by default [0, 1]
+        number_at_center : :class:`float`, optional
+            the number to be put at the center, by default 0.5
+        decimal_number_config : :class:`dict`, optional
+            the configuration for :class:`DecimalNnumber`, by default { "num_decimal_places": 1, }
+        """
         NumberLine.__init__(
             self,
             unit_size=unit_size,

--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -98,7 +98,7 @@ class NumberLine(Line):
 
         Parameters
         ----------
-        color : :class:`Colors`, optional
+        color : :class:`~.Colors`, optional
             the color for the number line, by default LIGHT_GREY
         unit_size : :class:`int`, optional
             the unit size, by default 1

--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -1,4 +1,4 @@
-r"""Mobjects representing number lines.
+"""Mobjects representing number lines.
 
 
 Examples
@@ -57,7 +57,7 @@ from ..utils.bezier import interpolate
 from ..utils.config_ops import merge_dicts_recursively
 from ..utils.simple_functions import fdiv
 from ..utils.space_ops import normalize
-from ..utils.color import LIGHT_GREY
+from ..utils.color import Colors, LIGHT_GREY
 
 
 class NumberLine(Line):
@@ -65,33 +65,33 @@ class NumberLine(Line):
 
     def __init__(
         self,
-        color=LIGHT_GREY,
-        unit_size=1,
-        width=None,
-        include_ticks=True,
-        tick_size=0.1,
-        tick_frequency=1,
+        color: Colors = LIGHT_GREY,
+        unit_size: int = 1,
+        width: float = None,
+        include_ticks: bool = True,
+        tick_size: float = 0.1,
+        tick_frequency: int = 1,
         # Defaults to value near x_min s.t. 0 is a tick
         # TODO, rename this
-        leftmost_tick=None,
+        leftmost_tick: float = None,
         # Change name
-        numbers_with_elongated_ticks=[0],
-        include_numbers=False,
-        numbers_to_show=None,
-        longer_tick_multiple=2,
-        number_at_center=0,
-        number_scale_val=0.75,
-        label_direction=DOWN,
-        line_to_number_buff=MED_SMALL_BUFF,
-        include_tip=False,
-        tip_width=0.25,
-        tip_height=0.25,
-        add_start=0,  # extend number line by this amount at its starting point
-        add_end=0,  # extend number line by this amount at its end point
-        decimal_number_config={"num_decimal_places": 0},
-        exclude_zero_from_default_numbers=False,
-        x_min=-config["frame_x_radius"],
-        x_max=config["frame_x_radius"],
+        numbers_with_elongated_ticks: typing.List[float] = [0],
+        include_numbers: bool = False,
+        numbers_to_show: typing.List[float] = None,
+        longer_tick_multiple: int = 2,
+        number_at_center: float = 0,
+        number_scale_val: float = 0.75,
+        label_direction: np.ndarray = DOWN,
+        line_to_number_buff: float = MED_SMALL_BUFF,
+        include_tip: bool = False,
+        tip_width: float = 0.25,
+        tip_height: float = 0.25,
+        add_start: float = 0,  # extend number line by this amount at its starting point
+        add_end: float = 0,  # extend number line by this amount at its end point
+        decimal_number_config: dict = {"num_decimal_places": 0},
+        exclude_zero_from_default_numbers: bool = False,
+        x_min: float = -config["frame_x_radius"],
+        x_max: float = config["frame_x_radius"],
         **kwargs
     ):
         """
@@ -210,7 +210,7 @@ class NumberLine(Line):
             self.big_tick_marks,
         )
 
-    def get_tick(self, x, size=None):
+    def get_tick(self, x: float, size: float = None) -> Line:
         """Returns the tick Mobject (:class:`~.Line`)
 
         Parameters
@@ -233,7 +233,7 @@ class NumberLine(Line):
         result.match_style(self)
         return result
 
-    def get_tick_marks(self):
+    def get_tick_marks(self) -> VGroup:
         """Returns the tick marks on the NumberLine
 
         Returns
@@ -246,7 +246,7 @@ class NumberLine(Line):
             *self.big_tick_marks,
         )
 
-    def get_tick_numbers(self):
+    def get_tick_numbers(self) -> np.ndarray:
         """Returns the numbers corresponding to the tick marks
 
         Returns
@@ -261,7 +261,7 @@ class NumberLine(Line):
             self.tick_frequency,
         )
 
-    def number_to_point(self, number):
+    def number_to_point(self, number: float) -> np.ndarray:
         """Converts the point on the screen to the number of NumberLine
 
         Parameters
@@ -281,7 +281,7 @@ class NumberLine(Line):
             alpha,
         )
 
-    def point_to_number(self, point):
+    def point_to_number(self, point: np.ndarray) -> float:
         """Converts the point on the screen to the number on NumberLine
 
         Parameters
@@ -304,15 +304,15 @@ class NumberLine(Line):
         proportion = fdiv(distance_from_start(point), distance_from_start(end_point))
         return interpolate(self.x_min, self.x_max, proportion)
 
-    def n2p(self, number):
+    def n2p(self, number: float) -> np.ndarray:
         """An alias for :meth:`~.NumberLine.number_to_point`"""
         return self.number_to_point(number)
 
-    def p2n(self, point):
+    def p2n(self, point: np.ndarray) -> float:
         """An alias for :meth:`~.NumberLine.point_to_number`"""
         return self.point_to_number(point)
 
-    def get_unit_size(self):
+    def get_unit_size(self) -> float:
         """Returns the unit size of the NumberLine
 
         Returns
@@ -322,7 +322,7 @@ class NumberLine(Line):
         """
         return self.get_length() / (self.x_max - self.x_min)
 
-    def get_unit_vector(self):
+    def get_unit_vector(self) -> np.ndarray:
         """Returns a unit vector
 
         Returns
@@ -332,7 +332,7 @@ class NumberLine(Line):
         """
         return super().get_unit_vector() * self.unit_size
 
-    def default_numbers_to_display(self):
+    def default_numbers_to_display(self) -> np.ndarray:
         """Returns the default numbers to display
 
         Returns
@@ -351,8 +351,13 @@ class NumberLine(Line):
         return numbers
 
     def get_number_mobject(
-        self, number, number_config=None, scale_val=None, direction=None, buff=None
-    ):
+        self,
+        number: float,
+        number_config: dict = None,
+        scale_val: float = None,
+        direction: np.ndarray = None,
+        buff: float = None,
+    ) -> DecimalNumber:
         """Returns the :class:`~.DecimalNumber` mobject for the passed number
 
         Parameters
@@ -387,7 +392,7 @@ class NumberLine(Line):
         num_mob.next_to(self.number_to_point(number), direction=direction, buff=buff)
         return num_mob
 
-    def get_number_mobjects(self, *numbers, **kwargs):
+    def get_number_mobjects(self, *numbers: float, **kwargs) -> VGroup:
         """Returns the labels (type :class:`~.DecimalNumber`) of the number line as a VGroup.
 
         Parameters
@@ -406,7 +411,7 @@ class NumberLine(Line):
             *[self.get_number_mobject(number, **kwargs) for number in numbers]
         )
 
-    def get_labels(self):
+    def get_labels(self) -> VGroup:
         """Returns the default labels (type :class:`~.DecimalNumber`) of the number line as a VGroup.
 
         Returns
@@ -416,7 +421,7 @@ class NumberLine(Line):
         """
         return self.get_number_mobjects()
 
-    def add_numbers(self, *numbers, **kwargs):
+    def add_numbers(self, *numbers: float, **kwargs) -> "NumberLine":
         """Add the numbers (labels) to the NumberLine
 
         Parameters
@@ -439,11 +444,11 @@ class UnitInterval(NumberLine):
 
     def __init__(
         self,
-        unit_size=6,
-        tick_frequency=0.1,
-        numbers_with_elongated_ticks=[0, 1],
-        number_at_center=0.5,
-        decimal_number_config={
+        unit_size: int = 6,
+        tick_frequency: float = 0.1,
+        numbers_with_elongated_ticks: typing.List[float] = [0, 1],
+        number_at_center: float = 0.5,
+        decimal_number_config: dict = {
             "num_decimal_places": 1,
         },
         **kwargs

--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -124,7 +124,7 @@ class NumberLine(Line):
             the number at the center, by default 0
         number_scale_val : :class:`float`, optional
             the scale factor for the numbers, by default 0.75
-        label_direction : :class:`np.ndarray`, optional
+        label_direction : :class:`numpy.ndarray`, optional
             the direction of the label, by default DOWN
         line_to_number_buff : :class:`float`, optional
             the buffer between the line and numbers, by default MED_SMALL_BUFF
@@ -251,7 +251,7 @@ class NumberLine(Line):
 
         Returns
         -------
-        :class:`np.array`
+        :class:`numpy.array`
             the numpy array containing the numbers
         """
         u = -1 if self.include_tip and self.add_end == 0 else 1
@@ -271,7 +271,7 @@ class NumberLine(Line):
 
         Returns
         -------
-        :class:`np.ndarray`
+        :class:`numpy.ndarray`
             the point on the screen
         """
         alpha = float(number - self.x_min) / (self.x_max - self.x_min)
@@ -286,7 +286,7 @@ class NumberLine(Line):
 
         Parameters
         ----------
-        point : :class:`np.ndarray`
+        point : :class:`numpy.ndarray`
             the point to convert
 
         Returns
@@ -327,7 +327,7 @@ class NumberLine(Line):
 
         Returns
         -------
-        :class:`np.ndarray`
+        :class:`numpy.ndarray`
             the unit vector scaled with the unit size of the NumberLine
         """
         return super().get_unit_vector() * self.unit_size
@@ -337,7 +337,7 @@ class NumberLine(Line):
 
         Returns
         -------
-        :class:`np.array`
+        :class:`numpy.array`
             the default numbers as numpy array
         """
         if self.numbers_to_show is not None:
@@ -368,7 +368,7 @@ class NumberLine(Line):
             the config to be passed to :class:`~.DecimalNumber`, by default None
         scale_val : :class:`float`, optional
             the scale factor for :class:`~.DecimalNumber` mobject, by default None
-        direction : :class:`np.ndarray, optional
+        direction : :class:`numpy.ndarray, optional
             the direction for the :class:`~.DecimalNumber` mobject, by default None
         buff : :class:`float`, optional
             the buffer between the number and the number line, by default None


### PR DESCRIPTION
## Motivation
Adding the documentation & examples for number_line module

## Overview / Explanation for Changes
- added the apis
- added the examples showing various ways NumberLine can be used

## Oneline Summary of Changes
```
- API docs & examples for number_line module (:pr:`1064`)
```

## Testing Status
Locally verified the generated document

## Further Comments
Have not documented `init_leftmost_tick` as it should be considered a private method

## Acknowledgements
- [X ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
