### PR TITLE
Remove duplicate word 'vector'

### DIFF
--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -35,7 +35,7 @@ skeleton of a thing that *could* be displayed.  Therefore, you will rarely need
 to use plain instances of :class:`.Mobject`; instead you will most likely
 create instances of its derived classes.  One of these derived classes is
 :class:`.VMobject`.  The ``V`` stands for Vectorized Mobject.  In essence, a
-vmobject is a mobject that uses vector `vector graphics
+vmobject is a mobject that uses `vector graphics
 <https://en.wikipedia.org/wiki/Vector_graphics>`_ to be displayed.  Most of
 the time, you will be dealing with vmobjects, though we will continue to use
 the term "mobject" to refer to the class of shapes that can be displayed on


### PR DESCRIPTION

## Oneline Summary of Changes
Removed a duplicate word from the docs.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
