### PR TITLE
rtd: add manimpango wheels

### DIFF
--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -1,2 +1,3 @@
 imageio-ffmpeg
 jupyterlab
+https://github.com/ManimCommunity/ManimPango/releases/download/v0.2.4/ManimPango-0.2.4-cp38-cp38-manylinux2014_x86_64.whl


### PR DESCRIPTION
## Motivation
see https://github.com/ManimCommunity/ManimPango/issues/27 wheels are removed in the latest release from PyPI so the wheel is added manually so RTD doesn't fail. Without this change RTD builds would be failing.

## Oneline Summary of Changes
```
- Add ManimPango to ReadTheDocs requirements (:pr:`1067`)
```

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
