### PR TITLE
Raise FileNotFoundError when unable to locate the .cfg file specified by --config_file 

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -739,7 +739,11 @@ class ManimConfig(MutableMapping):
 
         """
         if not os.path.isfile(filename):
-            raise FileNotFoundError(errno.ENOENT, "Error: --config_file could not find a valid config file.", filename)
+            raise FileNotFoundError(
+                errno.ENOENT,
+                "Error: --config_file could not find a valid config file.",
+                filename,
+            )
 
         if filename:
             return self.digest_parser(make_config_parser(filename))

--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -14,6 +14,7 @@ import configparser
 import copy
 import logging
 import os
+import errno
 import sys
 import typing
 from collections.abc import Mapping, MutableMapping
@@ -737,6 +738,9 @@ class ManimConfig(MutableMapping):
         multiple times.
 
         """
+        if not os.path.isfile(filename):
+            raise FileNotFoundError(errno.ENOENT, "Error: --config_file could not find a valid config file.", filename)
+
         if filename:
             return self.digest_parser(make_config_parser(filename))
 


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Raising the error will stop script execution and let the user know that there are problems with the --config_file location instead of reverting back to the default configuration.
## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.
For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->
Fixes #1038, manim will now raise a FileNotFoundError when it can't find the specified config file via --config_file. Previously it reverted back to the default configuration without notifying the user.
## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Raise FileNotFoundError when unable to locate the .cfg file specified by --config_file (1070)
```

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->

## Further Comments
<!-- Optional, any further comments regarding your PR
that might be useful for reviewers.. -->

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
