### PR TITLE
Remove "one line summary" from pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ that might be useful for reviewers.. -->
 
 ## Acknowledgements
 - [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
-- [ ] The PR title is descriptive enough
+- [ ] I have chosen a descriptive PR title (see top of PR template for examples)
 <!-- Once again, thanks for helping out by contributing to manim! -->
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,26 +3,12 @@ Thanks for your contribution to ManimCommunity!
 
 Before filling in the details, ensure:
 - Your local changes are up-to-date with ManimCommunity/manim
-
-- The title of your PR starts with at least one capitalized acronym:
-  API: an API breaking change
-  CI: change related to building manim
-  BUG: bug fix
-  DEP: deprecation, or removal of a deprecated object
-  DEV: development tool or utility
-  DOC: documentation
-  ENH: enhancement or new feature
-  MNT: maintenance (refactoring, typos, etc.)
-  REV: revert an earlier commit
-  STY: style fix (whitespace, PEP8)
-  TST: addition or modification of tests
-  REL: manim release
   
 - The title of your PR gives a descriptive summary to end-users. Some examples:
-  - `BUG: Fixed the issue with last animations not running to completion`)
-  - `ENH, DOC: Added support and documentation for gradients in SVG files`)
+  - `Fixed last animations not running to completion`)
+  - `Added gradient support and documentation for SVG files`)
   Examples of what *NOT* to do:
-  - `MNT: fixed that styling issue` - not descriptive enough
+  - `fixed that styling issue` - not descriptive enough
   - `fixed issue #XYZ` - end-user needs to do further research
 -->
 
@@ -48,7 +34,7 @@ that might be useful for reviewers.. -->
 
 ## Acknowledgements
 - [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
-- [ ] The PR title includes at least one acronym and is descriptive enough
+- [ ] The PR title is descriptive enough
 <!-- Once again, thanks for helping out by contributing to manim! -->
 
 
@@ -57,5 +43,5 @@ that might be useful for reviewers.. -->
 - [ ] Newly added functions/classes are either private or have a docstring
 - [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
 - [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
-- [ ] The PR title includes at least one acronym and is descriptive enough
+- [ ] The PR title is descriptive enough
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Thanks for your contributing to ManimCommunity!
+Thanks for your contribution to ManimCommunity!
 
 Before filling in the details, ensure:
 - Your local changes are up-to-date with ManimCommunity/manim

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,29 @@
 <!--
-Thank you for your interest in contributing to ManimCommunity!
+Thanks for your contributing to ManimCommunity!
 
-Before filling out the details below, please ensure:
-- Your local changes are up-to-date with ManimCommunity/manim's latest
-changes and any conflicts are resolved.
+Before filling in the details, ensure:
+- Your local changes are up-to-date with ManimCommunity/manim
 
-- The title of your PR starts with a keyword describing the changes made:
-  Feature:
-  Bugfix:
-  Enhancement:
-  Doc:
-  Removal:
-  Misc:
+- The title of your PR starts with at least one capitalized acronym:
+  API: an API breaking change
+  CI: change related to building manim
+  BUG: bug fix
+  DEP: deprecation, or removal of a deprecated object
+  DEV: development tool or utility
+  DOC: documentation
+  ENH: enhancement or new feature
+  MNT: maintenance (refactoring, typos, etc.)
+  REV: revert an earlier commit
+  STY: style fix (whitespace, PEP8)
+  TST: addition or modification of tests
+  REL: manim release
   
-  Or create your own keyword if none of the previous keywords are applicable.
-
-- The title of your PR gives a short summary to end-users on what changes
-have been made. Some examples:
-  - `Bugfix: Fixed the issue with last animations not running to completion`)
-  - `Feature: Added support for gradients in SVG files`)
+- The title of your PR gives a descriptive summary to end-users. Some examples:
+  - `BUG: Fixed the issue with last animations not running to completion`)
+  - `ENH, DOC: Added support and documentation for gradients in SVG files`)
+  Examples of what *NOT* to do:
+  - `MNT: fixed that styling issue` - not descriptive enough
+  - `fixed issue #XYZ` - end-user needs to do further research
 -->
 
 ## Motivation
@@ -43,7 +48,7 @@ that might be useful for reviewers.. -->
 
 ## Acknowledgements
 - [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
-
+- [ ] The PR title includes at least one acronym and is descriptive enough
 <!-- Once again, thanks for helping out by contributing to manim! -->
 
 
@@ -52,3 +57,5 @@ that might be useful for reviewers.. -->
 - [ ] Newly added functions/classes are either private or have a docstring
 - [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
 - [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
+- [ ] The PR title includes at least one acronym and is descriptive enough
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,14 +16,6 @@ For PRs introducing new features, please provide code snippets
 using the newly introduced functionality and ideally even the
 expected rendered output. -->
 
-## Oneline Summary of Changes
-<!-- Please update the lines below with a oneline summary
-for your changes. It will be included in the list of upcoming changes at
-https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
-```
-- Added new feature ... / Fixed bug ... / ... (:pr:`PR NUMBER HERE`)
-```
-
 ## Testing Status
 <!-- Optional (but recommended): your computer specs and
 what tests you ran with their results, if any. This section
@@ -44,4 +36,3 @@ that might be useful for reviewers.. -->
 - [ ] Newly added functions/classes are either private or have a docstring
 - [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
 - [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
-- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,24 @@
 <!--
-Thank you for contributing to manim!
+Thank you for your interest in contributing to ManimCommunity!
 
-Please ensure that your pull request works with the latest
-version of manim from this repository.
+Before filling out the details below, please ensure:
+- Your local changes are up-to-date with ManimCommunity/manim's latest
+changes and any conflicts are resolved.
+
+- The title of your PR starts with a keyword describing the changes made:
+  Feature:
+  Bugfix:
+  Enhancement:
+  Doc:
+  Removal:
+  Misc:
+  
+  Or create your own keyword if none of the previous keywords are applicable.
+
+- The title of your PR gives a short summary to end-users on what changes
+have been made. Some examples:
+  - `Bugfix: Fixed the issue with last animations not running to completion`)
+  - `Feature: Added support for gradients in SVG files`)
 -->
 
 ## Motivation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,11 +5,11 @@ Before filling in the details, ensure:
 - Your local changes are up-to-date with ManimCommunity/manim
   
 - The title of your PR gives a descriptive summary to end-users. Some examples:
-  - `Fixed last animations not running to completion`)
-  - `Added gradient support and documentation for SVG files`)
+  - Fixed last animations not running to completion
+  - Added gradient support and documentation for SVG files
   Examples of what *NOT* to do:
-  - `fixed that styling issue` - not descriptive enough
-  - `fixed issue #XYZ` - end-user needs to do further research
+  - "fixed that styling issue" - not descriptive enough
+  - "fixed issue #XYZ" - end-user needs to do further research
 -->
 
 ## Motivation
@@ -44,4 +44,3 @@ that might be useful for reviewers.. -->
 - [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
 - [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
 - [ ] The PR title is descriptive enough
-

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,8 +14,6 @@ Upcoming release
 
 :Date: TBD
 
-Changes for the upcoming release are tracked `in our GitHub wiki <https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release>`_.
-
 
 ******
 v0.4.0


### PR DESCRIPTION
We changed the method to create the changelog from using the `one line summary`  to the method described here https://github.com/ManimCommunity/manim/pull/986#issue-564730313 (automatically taking the title from the pr).
So there is no point in still having the `one line summary` in the pr template.
Also, I think we can delete this wiki page: https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release