### PR TITLE
Cleanup __main__.py - remove stray print statements

### DIFF
--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -95,5 +95,6 @@ def main():
                 except Exception:
                     console.print_exception()
 
+
 if __name__ == "__main__":
     main()

--- a/manim/__main__.py
+++ b/manim/__main__.py
@@ -81,13 +81,11 @@ def main():
                 server.start()
                 server.wait_for_termination()
             except ModuleNotFoundError as e:
-                print("\n\n")
-                print(
+                console.print(
                     "Dependencies for the WebGL render are missing. Run "
                     "pip install manim[webgl_renderer] to install them."
                 )
-                print(e)
-                print("\n\n")
+                console.print_exception()
         else:
             for SceneClass in scene_classes_from_file(input_file):
                 try:
@@ -95,10 +93,7 @@ def main():
                     scene.render()
                     open_file_if_needed(scene.renderer.file_writer)
                 except Exception:
-                    print("\n\n")
-                    traceback.print_exc()
-                    print("\n\n")
-
+                    console.print_exception()
 
 if __name__ == "__main__":
     main()

--- a/manim/_config/main_utils.py
+++ b/manim/_config/main_utils.py
@@ -111,7 +111,6 @@ def parse_args(args: list) -> argparse.Namespace:
     elif subcmd == "plugins":
         return _parse_args_plugins(args)
     elif args[1] == "--version":
-        print(f"Manim Community v{ __version__ }")
         sys.exit()
     # elif subcmd == some_other_future_subcmd:
     #     return _parse_args_some_other_subcmd(args)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,77 @@
+import subprocess
+import sys
+
+from .test_plugins.test_plugins import function_like_plugin
+
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    import importlib_metadata
+
+import manim
+
+
+def call_command(command, cwd=None, env=None):
+    a = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+        text=True,
+        cwd=cwd,
+        env=env,
+    )
+    return a
+
+
+def test_manim_version_from_command_line():
+    a = call_command(
+        [
+            sys.executable,
+            "-m",
+            "manim",
+            "--version",
+        ]
+    )
+    version = importlib_metadata.version("manim")
+    assert version in a.stdout
+    assert a.stdout.strip() == f"Manim Community v{version}"
+    assert manim.__version__ == version
+
+
+def test_manim_cfg_subcommand_no_subcommand():
+    a = call_command(
+        [
+            sys.executable,
+            "-m",
+            "manim",
+            "cfg",
+        ]
+    )
+    assert "No subcommand provided; Exiting..." in a.stdout
+
+
+def test_manim_plugis_subcommand_no_subcommand():
+    a = call_command(
+        [
+            sys.executable,
+            "-m",
+            "manim",
+            "plugins",
+        ]
+    )
+    assert "No flag provided; Exiting..." in a.stdout
+
+def test_manim_plugis_subcommand_listing(function_like_plugin):
+    # Check whether `test_plugin` is in plugins list
+    a = call_command(
+        [
+            sys.executable,
+            "-m",
+            "manim",
+            "plugins",
+            "--list"
+        ]
+    )
+    assert "test_plugin" in a.stdout
+

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -62,16 +62,8 @@ def test_manim_plugis_subcommand_no_subcommand():
     )
     assert "No flag provided; Exiting..." in a.stdout
 
+
 def test_manim_plugis_subcommand_listing(function_like_plugin):
     # Check whether `test_plugin` is in plugins list
-    a = call_command(
-        [
-            sys.executable,
-            "-m",
-            "manim",
-            "plugins",
-            "--list"
-        ]
-    )
+    a = call_command([sys.executable, "-m", "manim", "plugins", "--list"])
     assert "test_plugin" in a.stdout
-

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,11 +3,6 @@ import sys
 
 from .test_plugins.test_plugins import function_like_plugin
 
-try:
-    import importlib.metadata as importlib_metadata
-except ModuleNotFoundError:
-    import importlib_metadata
-
 import manim
 
 
@@ -33,10 +28,9 @@ def test_manim_version_from_command_line():
             "--version",
         ]
     )
-    version = importlib_metadata.version("manim")
+    version = manim.__version__
     assert version in a.stdout
     assert a.stdout.strip() == f"Manim Community v{version}"
-    assert manim.__version__ == version
 
 
 def test_manim_cfg_subcommand_no_subcommand():


### PR DESCRIPTION
## Motivation
Cleanup `__main__.py` - remove stray print statements use rich's print traceback instead.
fix printing twice of version when --version is called
Add some tests for the subcommands

## Overview / Explanation for Changes
- Cleaned stray print statement in `__main__.py`
- When `manim --version` was called it printed `Manim Community v0.4.0` twice. Fixed that.
- Added some tests for testing subcommands.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Added tests for the subcommands. Miscellaneous cleanup of `__main__.py`. Fix `--version` flag (:pr:`1078`)
```

## Testing Status
Works on my PC, Windows.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
