### PR TITLE
Correct shape of torus

### DIFF
--- a/manim/mobject/three_dimensions.py
+++ b/manim/mobject/three_dimensions.py
@@ -649,4 +649,4 @@ class Torus(ParametricSurface):
 
     def func(self, u, v):
         P = np.array([np.cos(u), np.sin(u), 0])
-        return (self.R - self.r * np.cos(v)) * P - np.sin(v) * OUT
+        return (self.R - self.r * np.cos(v)) * P - self.r * np.sin(v) * OUT


### PR DESCRIPTION
## Overview / Explanation for Changes
The Torus class draws a surface with an elliptical cross-section when `minor_radius` is different from 1. This PR ensures the cross-section is always a circle.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Fix shape of torus with non-default `minor_radius`
```

## Acknowledgements
- [X] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
