### PR TITLE
add new svg files to documentation and imports

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -37,6 +37,8 @@ Mobjects
    ~mobject.vector_field
    ~mobject.svg.brace
    ~mobject.svg.code_mobject
+   ~mobject.svg.style_utils
+   ~mobject.svg.svg_path
    ~mobject.svg.svg_mobject
    ~mobject.svg.tex_mobject
    ~mobject.svg.text_mobject

--- a/manim/__init__.py
+++ b/manim/__init__.py
@@ -50,10 +50,12 @@ from .mobject.numbers import *
 from .mobject.probability import *
 from .mobject.shape_matchers import *
 from .mobject.svg.brace import *
+from .mobject.svg.code_mobject import *
+from .mobject.svg.style_utils import *
 from .mobject.svg.svg_mobject import *
+from .mobject.svg.svg_path import *
 from .mobject.svg.tex_mobject import *
 from .mobject.svg.text_mobject import *
-from .mobject.svg.code_mobject import *
 from .mobject.three_d_utils import *
 from .mobject.three_dimensions import *
 from .mobject.types.image_mobject import *


### PR DESCRIPTION
## Motivation
In updating the SVG library, some newly created files were not added to exports or to the documentation.

## Overview / Explanation for Changes
This commits adds SVGPathMobject, VMobjectFromPathstring, and the style_utils functions to manim's namespace.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Add new SVG classes to the manim documentation and namespace (:pr:1088)
```

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
