### PR TITLE
Documentation + examples for Square, Dot, Circle and Rectangle

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.abspath("."))
 
+
 if os.environ.get("READTHEDOCS") == "True":
     site_path = get_python_lib()
     # we need to add ffmpeg to the path
@@ -30,11 +31,13 @@ if os.environ.get("READTHEDOCS") == "True":
     )
     os.environ["PATH"] += os.pathsep + ffmpeg_path
 
+
 # -- Project information -----------------------------------------------------
 
 project = "Manim"
 copyright = "2020, The Manim Community Dev Team"
 author = "The Manim Community Dev Team"
+
 
 # -- General configuration ---------------------------------------------------
 
@@ -74,9 +77,8 @@ napoleon_custom_sections = ["Tests", ("Test", "Tests")]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['examples.rst', 'reference\manim.mobject.geometry.ArrowTip.rst',
-                    'reference\manim.mobject.geometry.rst'
-    , 'reference\manim.mobject.functions.ParametricFunction.rst', 'tutorials']
+exclude_patterns = []
+
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -104,7 +106,6 @@ html_static_path = ["_static"]
 
 # This specifies any additional css files that will override the theme's
 html_css_files = ["custom.css"]
-
 
 # source links to github
 def linkcode_resolve(domain, info):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.abspath("."))
 
-
 if os.environ.get("READTHEDOCS") == "True":
     site_path = get_python_lib()
     # we need to add ffmpeg to the path
@@ -31,13 +30,11 @@ if os.environ.get("READTHEDOCS") == "True":
     )
     os.environ["PATH"] += os.pathsep + ffmpeg_path
 
-
 # -- Project information -----------------------------------------------------
 
 project = "Manim"
 copyright = "2020, The Manim Community Dev Team"
 author = "The Manim Community Dev Team"
-
 
 # -- General configuration ---------------------------------------------------
 
@@ -77,8 +74,9 @@ napoleon_custom_sections = ["Tests", ("Test", "Tests")]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
-
+exclude_patterns = ['examples.rst', 'reference\manim.mobject.geometry.ArrowTip.rst',
+                    'reference\manim.mobject.geometry.rst'
+    , 'reference\manim.mobject.functions.ParametricFunction.rst', 'tutorials']
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -106,6 +104,7 @@ html_static_path = ["_static"]
 
 # This specifies any additional css files that will override the theme's
 html_css_files = ["custom.css"]
+
 
 # source links to github
 def linkcode_resolve(domain, info):

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -392,6 +392,14 @@ class CurvedDoubleArrow(CurvedArrow):
 
 
 class Circle(Arc):
+    """
+
+    Parameters
+    ----------
+    close_new_points
+    anchors_span_full_range
+    kwargs
+    """
     def __init__(
         self, color=RED, close_new_points=True, anchors_span_full_range=False, **kwargs
     ):
@@ -1288,9 +1296,13 @@ class Rectangle(Polygon):
         color=WHITE,
         height=2.0,
         width=4.0,
+        mark_paths_closed=True,
+        close_new_points=True,
         **kwargs
     ):
         Polygon.__init__(self, UL, UR, DR, DL, color=color, **kwargs)
+        self.mark_paths_closed = mark_paths_closed
+        self.close_new_points = close_new_points
         self.stretch_to_fit_width(width)
         self.stretch_to_fit_height(height)
 

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -422,6 +422,30 @@ class Circle(Arc):
 
 
 class Dot(Circle):
+    """A circle with a very small radius.
+
+    Parameters
+    ----------
+    point : Optional[:class:`float`]
+        The location of the dot.
+    radius : Optional[:class:`float`]
+        The radius of the dot.
+
+    Examples
+    --------
+
+    .. manim:: DotExample
+        :save_last_frame:
+
+    class DotExample(Scene):
+        def construct(self):
+            d1 = Dot(point=ORIGIN, radius=0.08)
+            d2 = Dot(point=LEFT)
+            d3 = Dot(point=RIGHT)
+            self.add(d1,d2,d3)
+            self.wait()
+    """
+
     def __init__(
         self,
         point=ORIGIN,

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -1430,7 +1430,7 @@ class Square(Rectangle):
                 square_1 = Square(side_length=2.0).shift(DOWN)
                 square_2 = Square(side_length=1.0).next_to(square_1, direction=UP)
                 square_3 = Square(side_length=0.5).next_to(square_2, direction=UP)
-                self.add(square_1,square_2,square_3)
+                self.add(square_1, square_2, square_3)
     """
 
     def __init__(self, side_length=2.0, **kwargs):

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -396,12 +396,12 @@ class Circle(Arc):
 
     Parameters
     ----------
-    color : :class: `str`, optional
+    color : :class:`str`, optional
         The color of the shape.
-    close_new_points : :class: `bool`, optional
-    anchors_span_full_range : :class: `bool`, optional
+    close_new_points : :class:`bool`, optional
+    anchors_span_full_range : :class:`bool`, optional
     kwargs : Any
-        Additional arguments to be passed to Arc
+        Additional arguments to be passed to :class:`Arc`
 
     Examples
     --------
@@ -439,11 +439,11 @@ class Circle(Arc):
         ----------
         mobject : :class:`~.Mobject`
             The mobject that the circle will be surrounding.
-        dim_to_match : :class: `int`, optional
+        dim_to_match : :class:`int`, optional
         buffer_factor :  :class:`float`, optional
             Scales the circle with respect to the mobject. A `buffer_factor` < 1 makes the circle smaller than the mobject.
-        stretch : :class: `bool`, optional
-            Stretches the circle to fit more tightly around the mobject. Note: Does not work with :class: `Line`
+        stretch : :class:`bool`, optional
+            Stretches the circle to fit more tightly around the mobject. Note: Does not work with :class:`Line`
 
         Examples
         --------
@@ -506,7 +506,7 @@ class Circle(Arc):
 
         Returns
         -------
-        :class: `numpy.ndarray`
+        :class:`numpy.ndarray`
             The location of the point along the circle's circumference.
         """
 
@@ -523,12 +523,12 @@ class Dot(Circle):
         The location of the dot.
     radius : Optional[:class:`float`]
         The radius of the dot.
-    stroke_width : :class: `float`, optional
-    fill_opacity : :class: `float`, optional
-    color : :class: `str`, optional
+    stroke_width : :class:`float`, optional
+    fill_opacity : :class:`float`, optional
+    color : :class:`str`, optional
         The color of the dot.
     kwargs : Any
-        Additional arguments to be passed to :class: `Circle`
+        Additional arguments to be passed to :class:`Circle`
 
     Examples
     --------
@@ -1361,16 +1361,16 @@ class Rectangle(Polygon):
 
     Parameters
     ----------
-    color : :class: `str`, optional
+    color : :class:`str`, optional
         The color of the rectangle
     height : :class:`float`, optional
         The vertical height of the rectangle.
     width : :class:`float`, optional
         The horizontal width of the rectangle.
-    mark_paths_closed : :class: `bool`, optional
-    close_new_points : :class: `bool`, optional
+    mark_paths_closed : :class:`bool`, optional
+    close_new_points : :class:`bool`, optional
     kwargs : Any
-        Additional arguments to be passed to :class: `Polygon`
+        Additional arguments to be passed to :class:`Polygon`
 
     Examples
     ----------
@@ -1411,7 +1411,7 @@ class Square(Rectangle):
     side_length : :class:`float`, optional
         The length of the sides.
     kwargs : Any
-        Additional arguments to be passed to :class: `Square`
+        Additional arguments to be passed to :class:`Square`
 
     Examples
     --------

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -396,7 +396,7 @@ class Circle(Arc):
 
     Parameters
     ----------
-    kwargs :
+    kwargs : Any
         additional arguments to be passed to Arc
 
     Examples
@@ -405,11 +405,12 @@ class Circle(Arc):
     .. manim:: CircleExample
         :save_last_frame:
 
-    class CircleExample(Scene):
+    class ShowCircle(Scene):
         def construct(self):
             circle = Circle(radius=1.0)
             self.add(circle)
             self.wait()
+
 
     """
 
@@ -445,18 +446,18 @@ class Circle(Arc):
 
         class CircleSurround(Scene):
             def construct(self):
-                triangle1 = Triangle()
-                circle1 = Circle().surround(triangle1)
-                group1 = Group(triangle1,circle1) # treat the two mobjects as one
+                t1 = Triangle()
+                c1 = Circle().surround(t1)
+                group1 = Group(t1,c1) # treat the two mobjects as one
 
-                line2 = Line()
-                circle2 = Circle().surround(line2)
-                group2 = Group(line2,circle2)
+                l2 = Line()
+                c2 = Circle().surround(l2)
+                group2 = Group(l2,c2)
 
                 # buffer_factor < 1, so the circle is smaller than the square
-                square3 = Square()
-                circle3 = Circle().surround(square3, buffer_factor=0.5)
-                group3 = Group(square3, circle3)
+                s3 = Square()
+                c3 = Circle().surround(s3, buffer_factor=0.5)
+                group3 = Group(s3, c3)
 
                 group = Group(group1, group2, group3).arrange()
                 self.add(group)
@@ -496,10 +497,10 @@ class Dot(Circle):
 
     class DotExample(Scene):
         def construct(self):
-            dot1 = Dot(point=ORIGIN, radius=0.08)
-            dot2 = Dot(point=LEFT)
-            dot3 = Dot(point=RIGHT)
-            self.add(dot1,dot2,dot3)
+            d1 = Dot(point=ORIGIN, radius=0.08)
+            d2 = Dot(point=LEFT)
+            d3 = Dot(point=RIGHT)
+            self.add(d1,d2,d3)
             self.wait()
     """
 
@@ -1333,10 +1334,9 @@ class Rectangle(Polygon):
 
     class RectangleExample(Scene):
         def construct(self):
-            rect1 = Rectangle(width=4.0, height=2.0)
-            rect2 = Rectangle(width=1.0, height=4.0)
-            rects = Group(rect1,rect2).arrange(buff=1)
-
+            r1 = Rectangle(width=4.0, height=2.0)
+            r2 = Rectangle(width=1.0, height=4.0)
+            rects = Group(r1,r2).arrange(buff=1)
             self.add(rects)
             self.wait()
     """

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -409,8 +409,6 @@ class Circle(Arc):
             def construct(self):
                 circle = Circle(radius=1.0)
                 self.add(circle)
-                self.wait()
-
 
     """
 
@@ -500,7 +498,7 @@ class Dot(Circle):
                 dot2 = Dot(point=LEFT)
                 dot3 = Dot(point=RIGHT)
                 self.add(dot1,dot2,dot3)
-                self.wait()
+
     """
 
     def __init__(
@@ -1337,7 +1335,7 @@ class Rectangle(Polygon):
                 rect2 = Rectangle(width=1.0, height=4.0)
                 rects = Group(rect1,rect2).arrange(buff=1)
                 self.add(rects)
-                self.wait()
+
     """
 
     def __init__(
@@ -1374,7 +1372,6 @@ class Square(Rectangle):
             def construct(self):
                 square = Square(side_length=2.0)
                 self.add(square)
-                self.wait()
 
     """
 

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -1267,30 +1267,6 @@ class Triangle(RegularPolygon):
 
 
 class Rectangle(Polygon):
-    """A quadrilateral with two sets of parallel sides.
-
-    Parameters
-    ----------
-    height : Optional[:class:`float`]
-        The vertical height of the rectangle.
-    width : Optional[:class:`float`]
-        The horizontal width of the rectangle.
-
-    Examples
-    ----------
-
-    .. manim:: RectangleExample
-        :save_last_frame:
-
-    class RectangleExample(Scene):
-        def construct(self):
-            r1 = Rectangle(width=4.0, height=2.0)
-            r2 = Rectangle(width=1.0, height=4.0)
-            rects = Group(r1,r2).arrange(buff=1)
-            self.add(rects)
-            self.wait()
-    """
-
     def __init__(
         self,
         color=WHITE,
@@ -1300,6 +1276,8 @@ class Rectangle(Polygon):
         close_new_points=True,
         **kwargs
     ):
+        self.mark_paths_closed = mark_paths_closed
+        self.close_new_points = close_new_points
         Polygon.__init__(self, UL, UR, DR, DL, color=color, **kwargs)
         self.mark_paths_closed = mark_paths_closed
         self.close_new_points = close_new_points

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -392,14 +392,6 @@ class CurvedDoubleArrow(CurvedArrow):
 
 
 class Circle(Arc):
-    """
-
-    Parameters
-    ----------
-    close_new_points
-    anchors_span_full_range
-    kwargs
-    """
     def __init__(
         self, color=RED, close_new_points=True, anchors_span_full_range=False, **kwargs
     ):
@@ -1272,15 +1264,11 @@ class Rectangle(Polygon):
         color=WHITE,
         height=2.0,
         width=4.0,
-        mark_paths_closed=True,
-        close_new_points=True,
         **kwargs
     ):
         self.mark_paths_closed = mark_paths_closed
         self.close_new_points = close_new_points
         Polygon.__init__(self, UL, UR, DR, DL, color=color, **kwargs)
-        self.mark_paths_closed = mark_paths_closed
-        self.close_new_points = close_new_points
         self.stretch_to_fit_width(width)
         self.stretch_to_fit_height(height)
 

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -446,22 +446,21 @@ class Circle(Arc):
 
         class CircleSurround(Scene):
             def construct(self):
-                t1 = Triangle()
-                c1 = Circle().surround(t1)
-                group1 = Group(t1,c1) # treat the two mobjects as one
+                triangle1 = Triangle()
+                circle1 = Circle().surround(triangle1)
+                group1 = Group(triangle1,circle1) # treat the two mobjects as one
 
-                l2 = Line()
-                c2 = Circle().surround(l2)
-                group2 = Group(l2,c2)
+                line2 = Line()
+                circle2 = Circle().surround(line2)
+                group2 = Group(line2,circle2)
 
                 # buffer_factor < 1, so the circle is smaller than the square
-                s3 = Square()
-                c3 = Circle().surround(s3, buffer_factor=0.5)
-                group3 = Group(s3, c3)
+                square3 = Square()
+                circle3 = Circle().surround(square3, buffer_factor=0.5)
+                group3 = Group(square3, circle3)
 
                 group = Group(group1, group2, group3).arrange()
                 self.add(group)
-                self.wait()
 
         """
         # Ignores dim_to_match and stretch; result will always be a circle
@@ -497,10 +496,10 @@ class Dot(Circle):
 
     class DotExample(Scene):
         def construct(self):
-            d1 = Dot(point=ORIGIN, radius=0.08)
-            d2 = Dot(point=LEFT)
-            d3 = Dot(point=RIGHT)
-            self.add(d1,d2,d3)
+            dot1 = Dot(point=ORIGIN, radius=0.08)
+            dot2 = Dot(point=LEFT)
+            dot3 = Dot(point=RIGHT)
+            self.add(dot1,dot2,dot3)
             self.wait()
     """
 
@@ -1334,9 +1333,9 @@ class Rectangle(Polygon):
 
     class RectangleExample(Scene):
         def construct(self):
-            r1 = Rectangle(width=4.0, height=2.0)
-            r2 = Rectangle(width=1.0, height=4.0)
-            rects = Group(r1,r2).arrange(buff=1)
+            rect1 = Rectangle(width=4.0, height=2.0)
+            rect2 = Rectangle(width=1.0, height=4.0)
+            rects = Group(rect1,rect2).arrange(buff=1)
             self.add(rects)
             self.wait()
     """

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -396,8 +396,12 @@ class Circle(Arc):
 
     Parameters
     ----------
+    color : :class: `str`, optional
+        The color of the shape.
+    close_new_points : :class: `bool`, optional
+    anchors_span_full_range : :class: `bool`, optional
     kwargs : Any
-        additional arguments to be passed to Arc
+        Additional arguments to be passed to Arc
 
     Examples
     --------
@@ -407,9 +411,12 @@ class Circle(Arc):
 
         class CircleExample(Scene):
             def construct(self):
-                circle = Circle(radius=1.0)
-                self.add(circle)
+                circle_1 = Circle(radius=1.0)
+                circle_2 = Circle(radius=1.5, color=GREEN)
+                circle_3 = Circle(radius=1.0, color=BLUE_B, fill_opacity=1)
 
+                circ_group = Group(circle_1, circle_2,circle_3).arrange(buff=1)
+                self.add(circ_group)
     """
 
     def __init__(
@@ -431,10 +438,11 @@ class Circle(Arc):
         Parameters
         ----------
         mobject : :class:`~.Mobject`
-            The mobject that the circle will be surrounding
-        buffer_factor :  Optional[:class:`float`]
+            The mobject that the circle will be surrounding.
+        dim_to_match : :class: `int`, optional
+        buffer_factor :  :class:`float`, optional
             Scales the circle with respect to the mobject. A `buffer_factor` < 1 makes the circle smaller than the mobject.
-        stretch : :class: `bool`
+        stretch : :class: `bool`, optional
             Stretches the circle to fit more tightly around the mobject. Note: Does not work with :class: `Line`
 
         Examples
@@ -460,8 +468,8 @@ class Circle(Arc):
 
                     group = Group(group1, group2, group3).arrange(buff=1)
                     self.add(group)
-
         """
+
         # Ignores dim_to_match and stretch; result will always be a circle
         # TODO: Perhaps create an ellipse class to handle single-dimension stretching
 
@@ -494,15 +502,14 @@ class Circle(Arc):
 
                     s1 = Square(side_length=0.25).move_to(p1)
                     s2 = Square(side_length=0.25).move_to(p2)
-
                     self.add(circle, s1, s2)
 
         Returns
         -------
         :class: `numpy.ndarray`
             The location of the point along the circle's circumference.
-
         """
+
         start_angle = angle_of_vector(self.points[0] - self.get_center())
         return self.point_from_proportion((angle - start_angle) / TAU)
 
@@ -512,10 +519,16 @@ class Dot(Circle):
 
     Parameters
     ----------
-    point : Optional[:class:`float`]
+    point : :class:`float`, optional
         The location of the dot.
     radius : Optional[:class:`float`]
         The radius of the dot.
+    stroke_width : :class: `float`, optional
+    fill_opacity : :class: `float`, optional
+    color : :class: `str`, optional
+        The color of the dot.
+    kwargs : Any
+        Additional arguments to be passed to :class: `Circle`
 
     Examples
     --------
@@ -525,11 +538,10 @@ class Dot(Circle):
 
         class DotExample(Scene):
             def construct(self):
-                dot1 = Dot(point=ORIGIN, radius=0.08)
-                dot2 = Dot(point=LEFT)
+                dot1 = Dot(point=LEFT, radius=0.08)
+                dot2 = Dot(point=ORIGIN)
                 dot3 = Dot(point=RIGHT)
                 self.add(dot1,dot2,dot3)
-
     """
 
     def __init__(
@@ -1349,10 +1361,16 @@ class Rectangle(Polygon):
 
     Parameters
     ----------
-    height : Optional[:class:`float`]
+    color : :class: `str`, optional
+        The color of the rectangle
+    height : :class:`float`, optional
         The vertical height of the rectangle.
-    width : Optional[:class:`float`]
+    width : :class:`float`, optional
         The horizontal width of the rectangle.
+    mark_paths_closed : :class: `bool`, optional
+    close_new_points : :class: `bool`, optional
+    kwargs : Any
+        Additional arguments to be passed to :class: `Polygon`
 
     Examples
     ----------
@@ -1364,9 +1382,9 @@ class Rectangle(Polygon):
             def construct(self):
                 rect1 = Rectangle(width=4.0, height=2.0)
                 rect2 = Rectangle(width=1.0, height=4.0)
+
                 rects = Group(rect1,rect2).arrange(buff=1)
                 self.add(rects)
-
     """
 
     def __init__(
@@ -1390,8 +1408,10 @@ class Square(Rectangle):
 
     Parameters
     ----------
-    side_length : Optional[:class:`float`]
+    side_length : :class:`float`, optional
         The length of the sides.
+    kwargs : Any
+        Additional arguments to be passed to :class: `Square`
 
     Examples
     --------
@@ -1401,9 +1421,11 @@ class Square(Rectangle):
 
         class SquareExample(Scene):
             def construct(self):
-                square = Square(side_length=2.0)
-                self.add(square)
+                square_1 = Square(side_length=2.0).shift(DOWN)
+                square_2 = Square(side_length=1.0).next_to(square_1, direction=UP)
+                square_3 = Square(side_length=0.5).next_to(square_2, direction=UP)
 
+                self.add(square_1,square_2,square_3)
     """
 
     def __init__(self, side_length=2.0, **kwargs):

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -396,7 +396,7 @@ class Circle(Arc):
 
     Parameters
     ----------
-    kwargs : Any
+    kwargs :
         additional arguments to be passed to Arc
 
     Examples
@@ -405,12 +405,11 @@ class Circle(Arc):
     .. manim:: CircleExample
         :save_last_frame:
 
-    class ShowCircle(Scene):
+    class CircleExample(Scene):
         def construct(self):
             circle = Circle(radius=1.0)
             self.add(circle)
             self.wait()
-
 
     """
 
@@ -446,18 +445,18 @@ class Circle(Arc):
 
         class CircleSurround(Scene):
             def construct(self):
-                t1 = Triangle()
-                c1 = Circle().surround(t1)
-                group1 = Group(t1,c1) # treat the two mobjects as one
+                triangle1 = Triangle()
+                circle1 = Circle().surround(triangle1)
+                group1 = Group(triangle1,circle1) # treat the two mobjects as one
 
-                l2 = Line()
-                c2 = Circle().surround(l2)
-                group2 = Group(l2,c2)
+                line2 = Line()
+                circle2 = Circle().surround(line2)
+                group2 = Group(line2,circle2)
 
                 # buffer_factor < 1, so the circle is smaller than the square
-                s3 = Square()
-                c3 = Circle().surround(s3, buffer_factor=0.5)
-                group3 = Group(s3, c3)
+                square3 = Square()
+                circle3 = Circle().surround(square3, buffer_factor=0.5)
+                group3 = Group(square3, circle3)
 
                 group = Group(group1, group2, group3).arrange()
                 self.add(group)
@@ -497,10 +496,10 @@ class Dot(Circle):
 
     class DotExample(Scene):
         def construct(self):
-            d1 = Dot(point=ORIGIN, radius=0.08)
-            d2 = Dot(point=LEFT)
-            d3 = Dot(point=RIGHT)
-            self.add(d1,d2,d3)
+            dot1 = Dot(point=ORIGIN, radius=0.08)
+            dot2 = Dot(point=LEFT)
+            dot3 = Dot(point=RIGHT)
+            self.add(dot1,dot2,dot3)
             self.wait()
     """
 
@@ -1334,9 +1333,10 @@ class Rectangle(Polygon):
 
     class RectangleExample(Scene):
         def construct(self):
-            r1 = Rectangle(width=4.0, height=2.0)
-            r2 = Rectangle(width=1.0, height=4.0)
-            rects = Group(r1,r2).arrange(buff=1)
+            rect1 = Rectangle(width=4.0, height=2.0)
+            rect2 = Rectangle(width=1.0, height=4.0)
+            rects = Group(rect1,rect2).arrange(buff=1)
+
             self.add(rects)
             self.wait()
     """

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -396,10 +396,12 @@ class Circle(Arc):
 
     Parameters
     ----------
-    color : :class:`str`, optional
+    color : :class:`~.Colors`, optional
         The color of the shape.
     close_new_points : :class:`bool`, optional
+        No purpose.
     anchors_span_full_range : :class:`bool`, optional
+        No purpose.
     kwargs : Any
         Additional arguments to be passed to :class:`Arc`
 
@@ -415,8 +417,8 @@ class Circle(Arc):
                 circle_2 = Circle(radius=1.5, color=GREEN)
                 circle_3 = Circle(radius=1.0, color=BLUE_B, fill_opacity=1)
 
-                circ_group = Group(circle_1, circle_2,circle_3).arrange(buff=1)
-                self.add(circ_group)
+                circle_group = Group(circle_1, circle_2, circle_3).arrange(buff=1)
+                self.add(circle_group)
     """
 
     def __init__(
@@ -519,13 +521,15 @@ class Dot(Circle):
 
     Parameters
     ----------
-    point : :class:`float`, optional
+    point : Union[:class:`list`, :class:`numpy.ndarray`], optional
         The location of the dot.
     radius : Optional[:class:`float`]
         The radius of the dot.
     stroke_width : :class:`float`, optional
+        The thickness of the outline of the dot.
     fill_opacity : :class:`float`, optional
-    color : :class:`str`, optional
+        The opacity of the dot's fill_colour
+    color : :class:`~.Colors`, optional
         The color of the dot.
     kwargs : Any
         Additional arguments to be passed to :class:`Circle`
@@ -1361,14 +1365,16 @@ class Rectangle(Polygon):
 
     Parameters
     ----------
-    color : :class:`str`, optional
-        The color of the rectangle
+    color : :class:`~.Colors`, optional
+        The color of the rectangle.
     height : :class:`float`, optional
         The vertical height of the rectangle.
     width : :class:`float`, optional
         The horizontal width of the rectangle.
     mark_paths_closed : :class:`bool`, optional
+        No purpose.
     close_new_points : :class:`bool`, optional
+        No purpose.
     kwargs : Any
         Additional arguments to be passed to :class:`Polygon`
 
@@ -1409,7 +1415,7 @@ class Square(Rectangle):
     Parameters
     ----------
     side_length : :class:`float`, optional
-        The length of the sides.
+        The length of the sides of the square.
     kwargs : Any
         Additional arguments to be passed to :class:`Square`
 
@@ -1424,7 +1430,6 @@ class Square(Rectangle):
                 square_1 = Square(side_length=2.0).shift(DOWN)
                 square_2 = Square(side_length=1.0).next_to(square_1, direction=UP)
                 square_3 = Square(side_length=0.5).next_to(square_2, direction=UP)
-
                 self.add(square_1,square_2,square_3)
     """
 

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -1276,6 +1276,27 @@ class Rectangle(Polygon):
 
 
 class Square(Rectangle):
+    """A rectangle with equal side lengths.
+
+    Parameters
+    ----------
+    side_length : Optional[:class:`float`]
+        The length of a side.
+
+    Examples
+    --------
+
+    .. manim:: SquareExample
+        :save_last_frame:
+
+    class ShowSquare(Scene):
+        def construct(self):
+            square = Square(side_length=2.0)
+            self.add(square)
+            self.wait()
+
+    """
+
     def __init__(self, side_length=2.0, **kwargs):
         self.side_length = side_length
         Rectangle.__init__(self, height=side_length, width=side_length, **kwargs)

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -1259,17 +1259,37 @@ class Triangle(RegularPolygon):
 
 
 class Rectangle(Polygon):
+    """A quadrilateral with two sets of parallel sides.
+
+    Parameters
+    ----------
+    height : Optional[:class:`float`]
+        The vertical height of the rectangle.
+    width : Optional[:class:`float`]
+        The horizontal width of the rectangle.
+
+    Examples
+    ----------
+
+    .. manim:: RectangleExample
+        :save_last_frame:
+
+    class RectangleExample(Scene):
+        def construct(self):
+            r1 = Rectangle(width=4.0, height=2.0)
+            r2 = Rectangle(width=1.0, height=4.0)
+            rects = Group(r1,r2).arrange(buff=1)
+            self.add(rects)
+            self.wait()
+    """
+
     def __init__(
         self,
         color=WHITE,
         height=2.0,
         width=4.0,
-        mark_paths_closed=True,
-        close_new_points=True,
         **kwargs
     ):
-        self.mark_paths_closed = mark_paths_closed
-        self.close_new_points = close_new_points
         Polygon.__init__(self, UL, UR, DR, DL, color=color, **kwargs)
         self.stretch_to_fit_width(width)
         self.stretch_to_fit_height(height)

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -434,13 +434,13 @@ class Circle(Arc):
         ----------
         mobject : :class:`~.Mobject`
             The mobject that the circle will be surrounding
-        buffer_factor : :class: `float`
+        buffer_factor :  Optional[:class:`float`]
             The distance between the mobjects. A buffer_factor < 1 makes the circle smaller than the mobject.
 
 
         Examples
         ----------
-
+g
         .. manim:: CircleSurround
             :save_last_frame:
 

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -433,8 +433,9 @@ class Circle(Arc):
         mobject : :class:`~.Mobject`
             The mobject that the circle will be surrounding
         buffer_factor :  Optional[:class:`float`]
-            The distance between the mobjects. A buffer_factor < 1 makes the circle smaller than the mobject.
-
+            Scales the circle with respect to the mobject. A `buffer_factor` < 1 makes the circle smaller than the mobject.
+        stretch : :class: `bool`
+            Stretches the circle to fit more tightly around the mobject. Note: Does not work with :class: `Line`
 
         Examples
         --------
@@ -449,7 +450,7 @@ class Circle(Arc):
                     group1 = Group(triangle1,circle1) # treat the two mobjects as one
 
                     line2 = Line()
-                    circle2 = Circle().surround(line2)
+                    circle2 = Circle().surround(line2, buffer_factor=2.0)
                     group2 = Group(line2,circle2)
 
                     # buffer_factor < 1, so the circle is smaller than the square
@@ -457,7 +458,7 @@ class Circle(Arc):
                     circle3 = Circle().surround(square3, buffer_factor=0.5)
                     group3 = Group(square3, circle3)
 
-                    group = Group(group1, group2, group3).arrange()
+                    group = Group(group1, group2, group3).arrange(buff=1)
                     self.add(group)
 
         """
@@ -472,6 +473,36 @@ class Circle(Arc):
         return self.scale(buffer_factor)
 
     def point_at_angle(self, angle):
+        """Returns the position of a point on the circle.
+
+        Parameters
+        ----------
+        angle : class: `float`
+            The angle of the point along the circle in radians.
+
+        Examples
+        --------
+
+        .. manim:: PointAtAngleExample
+            :save_last_frame:
+
+            class PointAtAngleExample(Scene):
+                def construct(self):
+                    circle = Circle(radius=2.0)
+                    p1 = circle.point_at_angle(PI/2)
+                    p2 = circle.point_at_angle(270*DEGREES)
+
+                    s1 = Square(side_length=0.25).move_to(p1)
+                    s2 = Square(side_length=0.25).move_to(p2)
+
+                    self.add(circle, s1, s2)
+
+        Returns
+        -------
+        :class: `numpy.ndarray`
+            The location of the point along the circle's circumference.
+
+        """
         start_angle = angle_of_vector(self.points[0] - self.get_center())
         return self.point_from_proportion((angle - start_angle) / TAU)
 
@@ -1360,7 +1391,7 @@ class Square(Rectangle):
     Parameters
     ----------
     side_length : Optional[:class:`float`]
-        The length of a side.
+        The length of the sides.
 
     Examples
     --------

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -392,6 +392,26 @@ class CurvedDoubleArrow(CurvedArrow):
 
 
 class Circle(Arc):
+    """A circle.
+
+    Parameters
+    ----------
+    kwargs : Any
+        additional arguments to be passed to Arc
+
+    Examples
+    --------
+
+    .. manim:: CircleExample
+        :save_last_frame:
+
+    class ShowCircle(Scene):
+        def construct(self):
+            circle = Circle(radius=1.0)
+            self.add(circle)
+            self.wait()
+    """
+
     def __init__(
         self, color=RED, close_new_points=True, anchors_span_full_range=False, **kwargs
     ):
@@ -1259,11 +1279,37 @@ class Triangle(RegularPolygon):
 
 
 class Rectangle(Polygon):
+    """A quadrilateral with two sets of parallel sides.
+
+    Parameters
+    ----------
+    height : Optional[:class:`float`]
+        The vertical height of the rectangle.
+    width : Optional[:class:`float`]
+        The horizontal width of the rectangle.
+
+    Examples
+    ----------
+
+    .. manim:: RectangleExample
+        :save_last_frame:
+
+    class RectangleExample(Scene):
+        def construct(self):
+            r1 = Rectangle(width=4.0, height=2.0)
+            r2 = Rectangle(width=1.0, height=4.0)
+            rects = Group(r1,r2).arrange(buff=1)
+            self.add(rects)
+            self.wait()
+    """
+
     def __init__(
         self,
         color=WHITE,
         height=2.0,
         width=4.0,
+        mark_paths_closed=True,
+        close_new_points=True,
         **kwargs
     ):
         self.mark_paths_closed = mark_paths_closed

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -405,11 +405,11 @@ class Circle(Arc):
     .. manim:: CircleExample
         :save_last_frame:
 
-    class CircleExample(Scene):
-        def construct(self):
-            circle = Circle(radius=1.0)
-            self.add(circle)
-            self.wait()
+        class CircleExample(Scene):
+            def construct(self):
+                circle = Circle(radius=1.0)
+                self.add(circle)
+                self.wait()
 
 
     """
@@ -439,28 +439,28 @@ class Circle(Arc):
 
 
         Examples
-        ----------
+        --------
 
         .. manim:: CircleSurround
             :save_last_frame:
 
-        class CircleSurround(Scene):
-            def construct(self):
-                triangle1 = Triangle()
-                circle1 = Circle().surround(triangle1)
-                group1 = Group(triangle1,circle1) # treat the two mobjects as one
+            class CircleSurround(Scene):
+                def construct(self):
+                    triangle1 = Triangle()
+                    circle1 = Circle().surround(triangle1)
+                    group1 = Group(triangle1,circle1) # treat the two mobjects as one
 
-                line2 = Line()
-                circle2 = Circle().surround(line2)
-                group2 = Group(line2,circle2)
+                    line2 = Line()
+                    circle2 = Circle().surround(line2)
+                    group2 = Group(line2,circle2)
 
-                # buffer_factor < 1, so the circle is smaller than the square
-                square3 = Square()
-                circle3 = Circle().surround(square3, buffer_factor=0.5)
-                group3 = Group(square3, circle3)
+                    # buffer_factor < 1, so the circle is smaller than the square
+                    square3 = Square()
+                    circle3 = Circle().surround(square3, buffer_factor=0.5)
+                    group3 = Group(square3, circle3)
 
-                group = Group(group1, group2, group3).arrange()
-                self.add(group)
+                    group = Group(group1, group2, group3).arrange()
+                    self.add(group)
 
         """
         # Ignores dim_to_match and stretch; result will always be a circle
@@ -494,13 +494,13 @@ class Dot(Circle):
     .. manim:: DotExample
         :save_last_frame:
 
-    class DotExample(Scene):
-        def construct(self):
-            dot1 = Dot(point=ORIGIN, radius=0.08)
-            dot2 = Dot(point=LEFT)
-            dot3 = Dot(point=RIGHT)
-            self.add(dot1,dot2,dot3)
-            self.wait()
+        class DotExample(Scene):
+            def construct(self):
+                dot1 = Dot(point=ORIGIN, radius=0.08)
+                dot2 = Dot(point=LEFT)
+                dot3 = Dot(point=RIGHT)
+                self.add(dot1,dot2,dot3)
+                self.wait()
     """
 
     def __init__(
@@ -1331,13 +1331,13 @@ class Rectangle(Polygon):
     .. manim:: RectangleExample
         :save_last_frame:
 
-    class RectangleExample(Scene):
-        def construct(self):
-            rect1 = Rectangle(width=4.0, height=2.0)
-            rect2 = Rectangle(width=1.0, height=4.0)
-            rects = Group(rect1,rect2).arrange(buff=1)
-            self.add(rects)
-            self.wait()
+        class RectangleExample(Scene):
+            def construct(self):
+                rect1 = Rectangle(width=4.0, height=2.0)
+                rect2 = Rectangle(width=1.0, height=4.0)
+                rects = Group(rect1,rect2).arrange(buff=1)
+                self.add(rects)
+                self.wait()
     """
 
     def __init__(
@@ -1370,11 +1370,11 @@ class Square(Rectangle):
     .. manim:: SquareExample
         :save_last_frame:
 
-    class ShowSquare(Scene):
-        def construct(self):
-            square = Square(side_length=2.0)
-            self.add(square)
-            self.wait()
+        class SquareExample(Scene):
+            def construct(self):
+                square = Square(side_length=2.0)
+                self.add(square)
+                self.wait()
 
     """
 

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -410,6 +410,8 @@ class Circle(Arc):
             circle = Circle(radius=1.0)
             self.add(circle)
             self.wait()
+
+
     """
 
     def __init__(
@@ -426,6 +428,42 @@ class Circle(Arc):
         )
 
     def surround(self, mobject, dim_to_match=0, stretch=False, buffer_factor=1.2):
+        """Adjusts a circle so that it surrounds a given mobject
+
+        Parameters
+        ----------
+        mobject : :class:`~.Mobject`
+            The mobject that the circle will be surrounding
+        buffer_factor : :class: `float`
+            The distance between the mobjects. A buffer_factor < 1 makes the circle smaller than the mobject.
+
+
+        Examples
+        ----------
+
+        .. manim:: CircleSurround
+            :save_last_frame:
+
+        class CircleSurround(Scene):
+            def construct(self):
+                t1 = Triangle()
+                c1 = Circle().surround(t1)
+                group1 = Group(t1,c1) # treat the two mobjects as one
+
+                l2 = Line()
+                c2 = Circle().surround(l2)
+                group2 = Group(l2,c2)
+
+                # buffer_factor < 1, so the circle is smaller than the square
+                s3 = Square()
+                c3 = Circle().surround(s3, buffer_factor=0.5)
+                group3 = Group(s3, c3)
+
+                group = Group(group1, group2, group3).arrange()
+                self.add(group)
+                self.wait()
+
+        """
         # Ignores dim_to_match and stretch; result will always be a circle
         # TODO: Perhaps create an ellipse class to handle single-dimension stretching
 

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -405,7 +405,7 @@ class Circle(Arc):
     .. manim:: CircleExample
         :save_last_frame:
 
-    class ShowCircle(Scene):
+    class CircleExample(Scene):
         def construct(self):
             circle = Circle(radius=1.0)
             self.add(circle)

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -428,7 +428,7 @@ class Circle(Arc):
         )
 
     def surround(self, mobject, dim_to_match=0, stretch=False, buffer_factor=1.2):
-        """Adjusts a circle so that it surrounds a given mobject
+        """Modifies a circle so that it surrounds a given mobject.
 
         Parameters
         ----------

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -440,7 +440,7 @@ class Circle(Arc):
 
         Examples
         ----------
-g
+
         .. manim:: CircleSurround
             :save_last_frame:
 


### PR DESCRIPTION
## Motivation
I was browsing the source code and noticed that many of the basic/introductory mobjects did not have documentation or examples, so I thought it would be worthwhile to add some.

## Overview / Explanation for Changes
Adds documentation and examples for
- Circle + surround + point_at_angle
- Dot
- Square
- Rectangle

## Further Comments
None

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have chosen a descriptive PR title (see top of PR template for examples)

## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The PR title is descriptive enough
