### PR TITLE
Added Unwrite animation class to complement Write

### DIFF
--- a/manim/animation/creation.py
+++ b/manim/animation/creation.py
@@ -307,21 +307,17 @@ class Unwrite(Write):
 
         class UnwriteReverseFalse(Scene):
             def construct(self):
-                text = Tex("Alice and Bob")
+                text = Tex("Alice and Bob").scale(3)
                 self.add(text)
-                self.wait()
                 self.play(Unwrite(text))
-                self.wait()
 
     .. manim :: UnwriteReverseTrue
 
         class UnwriteReverseTrue(Scene):
             def construct(self):
-                text = Tex("Alice and Bob")
+                text = Tex("Alice and Bob").scale(3)
                 self.add(text)
-                self.wait()
                 self.play(Unwrite(text,reverse=True))
-                self.wait()
 
     """
 

--- a/manim/animation/creation.py
+++ b/manim/animation/creation.py
@@ -331,24 +331,33 @@ class Unwrite(Write):
         **kwargs,
     ) -> None:
 
-        if not reverse:
-            vmobject.submobjects[0].submobjects = list(
-                reversed(vmobject.submobjects[0].submobjects)
-            )
-
         backwards_rate_func = lambda t: -rate_func(t) + 1
 
+        self.vmobject = vmobject
         self.run_time = run_time
         self.lag_ratio = lag_ratio
         self.reverse = reverse
         self._set_default_config_from_length(vmobject)
         super().__init__(
             vmobject,
-            run_time=self.run_time,
-            lag_ratio=self.lag_ratio,
+            run_time=run_time,
+            lag_ratio=lag_ratio,
             rate_func=backwards_rate_func,
             **kwargs,
         )
+
+    def begin(self) -> None:
+        if not self.reverse:
+            self.reverse_submobjects()
+        super().begin()
+
+    def finish(self) -> None:
+        if not self.reverse:
+            self.reverse_submobjects()
+        super().finish()
+
+    def reverse_submobjects(self) -> None:
+        self.vmobject.invert(recursive=True)
 
 
 class ShowIncreasingSubsets(Animation):

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1569,6 +1569,12 @@ class Mobject(Container):
                 submob.shuffle(recursive=True)
         random.shuffle(self.submobjects)
 
+    def invert(self, recursive=False):
+        if recursive:
+            for submob in self.submobjects:
+                submob.invert(recursive=True)
+        list.reverse(self.submobjects)
+
     # Just here to keep from breaking old scenes.
     def arrange_submobjects(self, *args, **kwargs):
         return self.arrange(*args, **kwargs)


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
I found that it was a hassle, especially when working within an `AnimationGroup`, to animate the undoing of `Write`. Of course one could pass `rate_func = lambda t: -linear(t)+1`, but this would animate the unwriting in the opposite direction of how Write would act. It also was unbalanced how there existed an `Uncreate` animation to complement `ShowCreation`, but no corresponding function to complement `Write`.

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.

For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->
I added an `Unwrite` class which inherits from `Write`. It automatically reverses the animation of write by passing the reversed rate function, but it also takes an additional boolean parameter `reverse` which, if `False`, renders the animation from left to right (assuming text oriented in the usual way), but if `True`, it renders right to left.

Examples
---------
```python
class UnwriteReverseFalse(Scene):
    def construct(self):
        text = Tex("Alice and Bob").scale(3)
        self.add(text)
        self.play(Unwrite(text)) # reverse=False is the default
```

https://user-images.githubusercontent.com/10787002/111080936-44adad80-84d7-11eb-889c-5ac10c92229e.mp4



```python
class UnwriteReverseTrue(Scene):
    def construct(self):
        text = Tex("Alice and Bob").scale(3)
        self.add(text)
        self.play(Unwrite(text,reverse=True))
```

https://user-images.githubusercontent.com/10787002/111080941-47100780-84d7-11eb-8b4a-34fd994f4896.mp4



## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->
All tests pass on my machine (Windows 10 v1909, Python3.9.2). I did not write any new tests because it seems as per Issue #157 that `Write` is untestable, and so `Unwrite` is as well.

## Further Comments
<!-- Optional, any further comments regarding your PR
that might be useful for reviewers.. -->
Possibly this should be added to the reference/demo animation in the docs under `manim.animation.creation`. It looks like it would be tricky to fit it in with the other animations in the scene without removing one of them or making them smaller.

It is worth noting the artifact displayed when rendering a scene whose last animation is `Unwrite`, with no wait afterwards. I believe that this is a consequence of `Write` drawing to the screen on the first frame of its animation, so reversing that would have it end on that frame. I haven't looked into it too much, but with what time I did spend, I was unable to figure out how to fix this.

There's also room for debate about whether the rate function used for the reversed should be `lambda t: -rate_function(t) + 1` or `lambda: t: rate_function(1-t)`, where `rate_function` is the function passed as a parameter to `Unwrite`. I went with the first option, because it ensures that asymmetric rate functions keep their properties sensibly. For example, the rate function which could be described by the name `slow_then_fast` will render with the first given rate function in that manner, whereas if the second function would be used, the animation would play in a way which is better described by `fast_then_slow`.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have chosen a descriptive PR title (see top of PR template for examples)
<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [x] The PR title is descriptive enough
