### PR TITLE
Deprecated SmallDot + OpenGLSmallDot

### DIFF
--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -444,11 +444,11 @@ class Dot(Circle):
 
 
 class SmallDot(Dot):
-    """Depreciated - A dot with small radius"""
+    """Deprecated - A dot with small radius"""
 
     def __init__(self, radius=DEFAULT_SMALL_DOT_RADIUS, **kwargs):
         logger.warning(
-            "SmallDot has been depreciated and will be removed in a future release. "
+            "SmallDot has been deprecated and will be removed in a future release. "
             "Use Dot instead."
         )
         Dot.__init__(self, radius=radius, **kwargs)

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -444,13 +444,13 @@ class Dot(Circle):
 
 
 class SmallDot(Dot):
-    """ Depreciated - A dot with small radius
-    """
+    """Depreciated - A dot with small radius"""
 
     def __init__(self, radius=DEFAULT_SMALL_DOT_RADIUS, **kwargs):
         logger.warning(
             "SmallDot has been depreciated and will be removed in a future release. "
-            "Use Dot instead.")
+            "Use Dot instead."
+        )
         Dot.__init__(self, radius=radius, **kwargs)
 
 

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -76,6 +76,7 @@ from ..utils.space_ops import get_norm
 from ..utils.space_ops import normalize
 from ..utils.space_ops import rotate_vector
 from ..utils.color import *
+from .. import logger
 
 DEFAULT_DOT_RADIUS = 0.08
 DEFAULT_SMALL_DOT_RADIUS = 0.04
@@ -443,11 +444,13 @@ class Dot(Circle):
 
 
 class SmallDot(Dot):
-    """
-    A dot with small radius
+    """ Depreciated - A dot with small radius
     """
 
     def __init__(self, radius=DEFAULT_SMALL_DOT_RADIUS, **kwargs):
+        logger.warning(
+            "SmallDot has been depreciated and will be removed in a future release. "
+            "Use Dot instead.")
         Dot.__init__(self, radius=radius, **kwargs)
 
 

--- a/manim/mobject/opengl_geometry.py
+++ b/manim/mobject/opengl_geometry.py
@@ -342,11 +342,11 @@ class OpenGLDot(OpenGLCircle):
 
 
 class OpenGLSmallDot(OpenGLDot):
-    """ Depreciated"""
+    """ Deprecated"""
 
     def __init__(self, radius=DEFAULT_SMALL_DOT_RADIUS, **kwargs):
         logger.warning(
-            "OpenGLSmallDot has been depreciated and will be removed in a future release."
+            "OpenGLSmallDot has been deprecated and will be removed in a future release."
             "Use OpenGLDot instead."
         )
         super().__init__(radius=radius, **kwargs)

--- a/manim/mobject/opengl_geometry.py
+++ b/manim/mobject/opengl_geometry.py
@@ -346,8 +346,9 @@ class OpenGLSmallDot(OpenGLDot):
 
     def __init__(self, radius=DEFAULT_SMALL_DOT_RADIUS, **kwargs):
         logger.warning(
-        "OpenGLSmallDot has been depreciated and will be removed in a future release."
-        "Use OpenGLDot instead.")
+            "OpenGLSmallDot has been depreciated and will be removed in a future release."
+            "Use OpenGLDot instead."
+        )
         super().__init__(radius=radius, **kwargs)
 
 

--- a/manim/mobject/opengl_geometry.py
+++ b/manim/mobject/opengl_geometry.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from .. import logger
 from ..constants import *
 from ..mobject.mobject import Mobject
 from ..mobject.types.opengl_vectorized_mobject import (
@@ -341,7 +342,12 @@ class OpenGLDot(OpenGLCircle):
 
 
 class OpenGLSmallDot(OpenGLDot):
+    """ Depreciated"""
+
     def __init__(self, radius=DEFAULT_SMALL_DOT_RADIUS, **kwargs):
+        logger.warning(
+        "OpenGLSmallDot has been depreciated and will be removed in a future release."
+        "Use OpenGLDot instead.")
         super().__init__(radius=radius, **kwargs)
 
 


### PR DESCRIPTION
## Motivation
Issue #1105 called for the deprecation of SmallDot due to community consensus that it is unnecessary.
## Overview / Explanation for Changes
- Added deprecation warnings for SmallDot and OpenGLSmallDot in the logger.
- Updated doc-strings to show functions as deprecated.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have chosen a descriptive PR title (see top of PR template for examples)
<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [x] The PR title is descriptive enough
