### PR TITLE
Replaced `.play(Animate(` syntax with `.add(` in test cases

### DIFF
--- a/tests/template_generate_graphical_units_data.py
+++ b/tests/template_generate_graphical_units_data.py
@@ -10,7 +10,7 @@ from tests.helpers.graphical_units import set_test_scene
 class YourClassTest(Scene):  # e.g. RoundedRectangleTest
     def construct(self):
         circle = Circle()
-        self.play(Animation(circle))
+        self.add(circle)
 
 
 set_test_scene(

--- a/tests/test_graphical_units/test_geometry.py
+++ b/tests/test_graphical_units/test_geometry.py
@@ -8,25 +8,25 @@ from ..utils.GraphicalUnitTester import GraphicalUnitTester
 class CoordinatesTest(Scene):
     def construct(self):
         dots = [Dot(np.array([x, y, 0])) for x in range(-7, 8) for y in range(-4, 5)]
-        self.play(Animation(VGroup(*dots)))
+        self.add(VGroup(*dots))
 
 
 class ArcTest(Scene):
     def construct(self):
         a = Arc(PI)
-        self.play(Animation(a))
+        self.add(a)
 
 
 class ArcBetweenPointsTest(Scene):
     def construct(self):
         a = ArcBetweenPoints(np.array([1, 1, 0]), np.array([2, 2, 0]))
-        self.play(Animation(a))
+        self.add(a)
 
 
 class CurvedArrowTest(Scene):
     def construct(self):
         a = CurvedArrow(np.array([1, 1, 0]), np.array([2, 2, 0]))
-        self.play(Animation(a))
+        self.add(a)
 
 
 class CustomDoubleArrowTest(Scene):
@@ -39,91 +39,91 @@ class CustomDoubleArrowTest(Scene):
             tip_shape_start=ArrowCircleTip,
             tip_shape_end=ArrowSquareFilledTip,
         )
-        self.play(Animation(a))
+        self.add(a)
 
 
 class CircleTest(Scene):
     def construct(self):
         circle = Circle()
-        self.play(Animation(circle))
+        self.add(circle)
 
 
 class DotTest(Scene):
     def construct(self):
         dot = Dot()
-        self.play(Animation(dot))
+        self.add(dot)
 
 
 class AnnotationDotTest(Scene):
     def construct(self):
         adot = AnnotationDot()
-        self.play(Animation(adot))
+        self.add(adot)
 
 
 class EllipseTest(Scene):
     def construct(self):
         e = Ellipse()
-        self.play(Animation(e))
+        self.add(e)
 
 
 class SectorTest(Scene):
     def construct(self):
         e = Sector()
-        self.play(Animation(e))
+        self.add(e)
 
 
 class AnnulusTest(Scene):
     def construct(self):
         a = Annulus()
-        self.play(Animation(a))
+        self.add(a)
 
 
 class AnnularSectorTest(Scene):
     def construct(self):
         a = AnnularSector()
-        self.play(Animation(a))
+        self.add(a)
 
 
 class LineTest(Scene):
     def construct(self):
         a = Line(np.array([1, 1, 0]), np.array([2, 2, 0]))
-        self.play(Animation(a))
+        self.add(a)
 
 
 class ElbowTest(Scene):
     def construct(self):
         a = Elbow()
-        self.play(Animation(a))
+        self.add(a)
 
 
 class DoubleArrowTest(Scene):
     def construct(self):
         a = DoubleArrow()
-        self.play(Animation(a))
+        self.add(a)
 
 
 class VectorTest(Scene):
     def construct(self):
         a = Vector(UP)
-        self.play(Animation(a))
+        self.add(a)
 
 
 class PolygonTest(Scene):
     def construct(self):
         a = Polygon(*[np.array([1, 1, 0]), np.array([2, 2, 0]), np.array([2, 3, 0])])
-        self.play(Animation(a))
+        self.add(a)
 
 
 class RectangleTest(Scene):
     def construct(self):
         a = Rectangle()
-        self.play(Animation(a))
+        self.add(a)
 
 
 class RoundedRectangleTest(Scene):
     def construct(self):
         a = RoundedRectangle()
-        self.play(Animation(a))
+        self.add(a)
 
 
 class ArrangeTest(Scene):

--- a/tests/test_graphical_units/test_graphscene.py
+++ b/tests/test_graphical_units/test_graphscene.py
@@ -26,7 +26,7 @@ class PlotFunctions(GraphScene):
         self.setup_axes()
         f = self.get_graph(lambda x: x ** 2)
 
-        self.play(Animation(f))
+        self.add(f)
 
 
 MODULE_NAME = "plot"

--- a/tests/test_graphical_units/test_mobjects.py
+++ b/tests/test_graphical_units/test_mobjects.py
@@ -8,7 +8,7 @@ from ..utils.GraphicalUnitTester import GraphicalUnitTester
 class PointCloudDotTest(ThreeDScene):
     def construct(self):
         p = PointCloudDot()
-        self.play(Animation(p))
+        self.add(p)
 
 
 MODULE_NAME = "mobjects"

--- a/tests/test_graphical_units/test_modifier_methods.py
+++ b/tests/test_graphical_units/test_modifier_methods.py
@@ -8,7 +8,7 @@ from ..utils.GraphicalUnitTester import GraphicalUnitTester
 class GradientTest(Scene):
     def construct(self):
         c = Circle(fill_opacity=1).set_color(color=[YELLOW, GREEN])
-        self.play(Animation(c))
+        self.add(c)
 
 
 MODULE_NAME = "modifier_methods"

--- a/tests/test_graphical_units/test_threed.py
+++ b/tests/test_graphical_units/test_threed.py
@@ -7,48 +7,48 @@ from ..utils.GraphicalUnitTester import GraphicalUnitTester
 
 class CubeTest(ThreeDScene):
     def construct(self):
-        self.play(Animation(Cube()))
+        self.add(Cube())
 
 
 class SphereTest(ThreeDScene):
     def construct(self):
-        self.play(Animation(Sphere()))
+        self.add(Sphere())
 
 
 class ConeTest(ThreeDScene):
     def construct(self):
-        self.play(Animation(Cone()))
+        self.add(Cone())
 
 
 class CylinderTest(ThreeDScene):
     def construct(self):
-        self.play(Animation(Cylinder()))
+        self.add(Cylinder())
 
 
 class Line3DTest(ThreeDScene):
     def construct(self):
-        self.play(Animation(Line3D()))
+        self.add(Line3D())
 
 
 class Arrow3DTest(ThreeDScene):
     def construct(self):
-        self.play(Animation(Arrow3D()))
+        self.add(Arrow3D())
 
 
 class TorusTest(ThreeDScene):
     def construct(self):
-        self.play(Animation(Torus()))
+        self.add(Torus())
 
 
 class AxesTest(ThreeDScene):
     def construct(self):
-        self.play(Animation(ThreeDAxes()))
+        self.add(ThreeDAxes())
 
 
 class CameraMoveTest(ThreeDScene):
     def construct(self):
         cube = Cube()
-        self.play(Animation(cube))
+        self.add(cube)
         self.move_camera(phi=PI / 4, theta=PI / 4, frame_center=[0, 0, -1])
 
 
@@ -56,7 +56,7 @@ class AmbientCameraMoveTest(ThreeDScene):
     def construct(self):
         cube = Cube()
         self.begin_ambient_camera_rotation(rate=0.5)
-        self.play(Animation(cube))
+        self.add(cube)
 
 
 class FixedInFrameMObjectTest(ThreeDScene):
@@ -67,7 +67,6 @@ class FixedInFrameMObjectTest(ThreeDScene):
         self.add_fixed_in_frame_mobjects(circ)
         circ.to_corner(UL)
         self.add(axes)
-        self.wait()
 
 
 MODULE_NAME = "threed"

--- a/tests/test_scene_rendering/simple_scenes.py
+++ b/tests/test_scene_rendering/simple_scenes.py
@@ -14,7 +14,7 @@ class SceneWithMultipleCalls(Scene):
         self.add(number)
         for i in range(10):
             number.become(Integer(i))
-            self.play(Animation(number))
+            self.add(number)
 
 
 class SceneWithMultipleWaitCalls(Scene):


### PR DESCRIPTION

## Motivation
As .add feels more natural to add an Mobject, I changed the syntax into this.
Problem: Currently this breaks the tests, but maybe a small change in GraphicalUnitTester can do the trick, @huguesdevimeux ?
## Overview / Explanation for Changes

`.play(Animate(` was removed from the tests and was changed to `.add(`syntax.
Was created by:
```py
from pathlib import Path

example_dict = Path.cwd() / "tests"
all_py_files = example_dict.rglob("*.py")

text_to_search = ".play(Animation("
replacement_text = ".add("

for i, py_file in enumerate(all_py_files):
    text = py_file.read_text()
    text = text.replace(text_to_search, replacement_text)
    py_file.write_text(text)
    print(i)

print("Done!")
```

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->

## Further Comments
<!-- Optional, any further comments regarding your PR
that might be useful for reviewers.. -->

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have chosen a descriptive PR title (see top of PR template for examples)
<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The PR title is descriptive enough
