### PR TITLE
Allow passing animation arguments with .animate syntax

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -131,6 +131,19 @@ class Mobject(Container):
 
                 self.play(my_mobject.animate.shift(RIGHT).rotate(PI))
 
+        Keyword arguments that can be passed to :meth:`.Scene.play` can be passed
+        directly after accessing ``.animate``, like so::
+
+            self.play(my_mobject.animate(rate_func=linear).shift(RIGHT))
+
+        This is especially useful when animating simultaneous ``.animate`` calls that
+        you want to behave differently::
+
+            self.play(
+                mobject1.animate(run_time=2).rotate(PI),
+                mobject2.animate(rate_func=there_and_back).shift(RIGHT),
+            )
+
         .. seealso::
 
             :func:`override_animate`
@@ -159,6 +172,21 @@ class Mobject(Container):
                     self.play(ShowCreation(s))
                     self.play(s.animate.shift(RIGHT).scale(2).rotate(PI / 2))
                     self.play(Uncreate(s))
+
+        .. manim:: AnimateWithArgsExample
+
+            class AnimateWithArgsExample(Scene):
+                def construct(self):
+                    s = Square()
+                    c = Circle()
+
+                    VGroup(s, c).arrange(RIGHT, buff=2)
+                    self.add(s, c)
+
+                    self.play(
+                        s.animate(run_time=2).rotate(PI / 2),
+                        c.animate(rate_func=there_and_back).shift(RIGHT),
+                    )
 
         """
         return _AnimationBuilder(self)
@@ -1778,10 +1806,25 @@ class Group(Mobject):
 class _AnimationBuilder:
     def __init__(self, mobject):
         self.mobject = mobject
-        self.overridden_animation = None
         self.mobject.generate_target()
+
+        self.overridden_animation = None
         self.is_chaining = False
         self.methods = []
+
+        self.cannot_call = False
+        self.anim_args = {}
+
+    def __call__(self, **kwargs):
+        if self.cannot_call:
+            raise ValueError(
+                "Animation arguments must be passed before accessing methods and can only be passed once"
+            )
+
+        self.anim_args = kwargs
+        self.cannot_call = True
+
+        return self
 
     def __getattr__(self, method_name):
         method = getattr(self.mobject.target, method_name)
@@ -1804,15 +1847,22 @@ class _AnimationBuilder:
             return self
 
         self.is_chaining = True
+        self.cannot_call = True
+
         return update_target
 
     def build(self):
         from ..animation.transform import _MethodAnimation
 
         if self.overridden_animation:
-            return self.overridden_animation
+            anim = self.overridden_animation
+        else:
+            anim = _MethodAnimation(self.mobject, self.methods)
 
-        return _MethodAnimation(self.mobject, self.methods)
+        for attr, value in self.anim_args.items():
+            setattr(anim, attr, value)
+
+        return anim
 
 
 def override_animate(method):

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1812,17 +1812,18 @@ class _AnimationBuilder:
         self.is_chaining = False
         self.methods = []
 
-        self.cannot_call = False
+        # Whether animation args can be passed
+        self.cannot_pass_args = False
         self.anim_args = {}
 
     def __call__(self, **kwargs):
-        if self.cannot_call:
+        if self.cannot_pass_args:
             raise ValueError(
                 "Animation arguments must be passed before accessing methods and can only be passed once"
             )
 
         self.anim_args = kwargs
-        self.cannot_call = True
+        self.cannot_pass_args = True
 
         return self
 
@@ -1847,7 +1848,7 @@ class _AnimationBuilder:
             return self
 
         self.is_chaining = True
-        self.cannot_call = True
+        self.cannot_pass_args = True
 
         return update_target
 

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -74,3 +74,39 @@ def test_chaining_overridden_animate():
         NotImplementedError, match="not supported for overridden animations"
     ):
         DotsWithLine().animate.remove_line().shift((1, 0, 0))
+
+
+def test_animate_with_args():
+    s = Square()
+    scale_factor = 2
+    run_time = 2
+
+    anim = s.animate(run_time=run_time).scale(scale_factor).build()
+    assert anim.mobject.target.width == scale_factor * s.width
+    assert anim.run_time == run_time
+
+
+def test_chained_animate_with_args():
+    s = Square()
+    scale_factor = 2
+    direction = np.array((1, 1, 0))
+    run_time = 2
+
+    anim = s.animate(run_time=run_time).scale(scale_factor).shift(direction).build()
+    assert (
+        anim.mobject.target.width == scale_factor * s.width
+        and (anim.mobject.target.get_center() == direction).all()
+    )
+    assert anim.run_time == run_time
+
+
+def test_animate_with_args_misplaced():
+    s = Square()
+    scale_factor = 2
+    run_time = 2
+
+    with pytest.raises(ValueError, match="must be passed before"):
+        s.animate.scale(scale_factor)(run_time=run_time)
+
+    with pytest.raises(ValueError, match="must be passed before"):
+        s.animate(run_time=run_time)(run_time=run_time).scale(scale_factor)


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
`.animate` syntax was severely lacking when a user would want to play simultaneous `.animate` calls but with different animation arguments (i.e. different `run_time`s or `rate_func`s). `ApplyMethod` could be used in certain cases, but can't chain methods like `.animate` can, and still uses the old-style syntax which imo users should be discouraged from.

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.

For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->
With these changes, users will now be able to do things like `obj.animate(run_time=2).method(arg)` if they want to specify animation arguments for an individual `.animate` call, and can still not specify any arguments like `obj.animate.method(arg)`.

Passing animation arguments is only allowed directly after `.animate` is accessed, if passed elsewhere then a `ValueError` is raised. I considered using a `SyntaxError` but that seems like it's only meant for the parser to raise.

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->
Tests pass and documentation builds correctly locally.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have chosen a descriptive PR title (see top of PR template for examples)
<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The PR title is descriptive enough
