### PR TITLE
Fixed the `-a` flag.

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -102,7 +102,7 @@ class SceneFileWriter(object):
             self.partial_movie_directory = guarantee_existence(
                 config.get_dir(
                     "partial_movie_dir",
-                    scene_name=default_name,
+                    scene_name=scene_name,
                     module_name=module_name,
                 )
             )

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -68,7 +68,7 @@ class SceneFileWriter(object):
         else:
             module_name = ""
 
-        if config["output_file"]:
+        if config["output_file"] and not config["write_all"]:
             default_name = config.get_dir("output_file")
         else:
             default_name = Path(scene_name)

--- a/tests/test_scene_rendering/conftest.py
+++ b/tests/test_scene_rendering/conftest.py
@@ -11,3 +11,8 @@ def manim_cfg_file():
 @pytest.fixture
 def simple_scenes_path():
     return str(Path(__file__).parent / "simple_scenes.py")
+
+
+@pytest.fixture
+def infallible_scenes_path():
+    return str(Path(__file__).parent / "infallible_scenes.py")

--- a/tests/test_scene_rendering/infallible_scenes.py
+++ b/tests/test_scene_rendering/infallible_scenes.py
@@ -1,0 +1,11 @@
+from manim import *
+
+
+class Wait1(Scene):
+    def construct(self):
+        self.wait()
+
+
+class Wait2(Scene):
+    def construct(self):
+        self.wait(2)

--- a/tests/test_scene_rendering/test_cli_flags.py
+++ b/tests/test_scene_rendering/test_cli_flags.py
@@ -146,6 +146,34 @@ def test_r_flag(tmp_path, manim_cfg_file, simple_scenes_path):
 
 
 @pytest.mark.slow
+def test_a_flag(tmp_path, manim_cfg_file, infallible_scenes_path):
+    command = [
+        sys.executable,
+        "-m",
+        "manim",
+        infallible_scenes_path,
+        "-ql",
+        "--media_dir",
+        str(tmp_path),
+        "-a",
+    ]
+    out, err, exit_code = capture(command)
+    assert exit_code == 0, err
+
+    one_is_not_empty = (
+        tmp_path / "videos" / "infallible_scenes" / "480p15" / "Wait1.mp4"
+    ).is_file()
+    assert one_is_not_empty, "running manim with -a flag did not render the first scene"
+
+    two_is_not_empty = (
+        tmp_path / "videos" / "infallible_scenes" / "480p15" / "Wait2.mp4"
+    ).is_file()
+    assert (
+        two_is_not_empty
+    ), "running manim with -a flag did not render the second scene"
+
+
+@pytest.mark.slow
 def test_custom_folders(tmp_path, manim_cfg_file, simple_scenes_path):
     scene_name = "SquareToCircle"
     command = [


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Fixes #1108. The `-a`/`--write-all` flag was broken. When used, it would cause Manim to crash just after beginning to render the second scene. Thanks to @kilacoda, I'm able to fix the crashing, but there remained another issue with every combined file output writing to the same file.

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.

For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->
I changed a line in `scene_file_writer.py` as discussed in Issue #1108. This fixed the issue where `-a` crashed Manim.

The fix for the file output bug is a little bit more hacky. It seemed that `config["output_file"]` was being set somewhere after the `SceneFileWriter` for the first scene was initialized, but before it was initialized for the second scene. I couldn't find where this was, so I just added a check on line 71 of `scene_file_writer.py` for `config["write_all"]`. This is hacky, because it won't fix this issue when the user omits both a scene name and the `-a` flag, then enters more than one scene number into the prompt which appears.

I also added a test for the `-a` flag which ensures that two different files are generated. I created a new scenes file so that I could safely use the flag while relying on as few extra features as possible, so as to ensure that the scenes will at least render properly on their own.

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->
All tests pass on my local machine.

## Further Comments
<!-- Optional, any further comments regarding your PR
that might be useful for reviewers.. -->
I noticed some other irregularities with the file outputs while testing, but those are not directly to do with the functionality of the `-a` flag, and so I believe it is outside of the scope of this PR. In particular, scenes rendered with the `-i` or `-s` flag (and without the `-a` flag) will have the version number appended to the filename, before the extension. With my hacky fix for the `-a` flag, only the first scene will have this feature; successive scenes will be named properly.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have chosen a descriptive PR title (see top of PR template for examples)
<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [x] The PR title is descriptive enough
