### PR TITLE
Fix some typing hints. (ints to floats)

### DIFF
--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -34,7 +34,7 @@ class Animation:
         # If 0 < lag_ratio < 1, its applied to each
         # with lagged start times
         lag_ratio: float = DEFAULT_ANIMATION_LAG_RATIO,
-        run_time: int = DEFAULT_ANIMATION_RUN_TIME,
+        run_time: float = DEFAULT_ANIMATION_RUN_TIME,
         rate_func: typing.Callable[[float, float], np.ndarray] = smooth,
         name: str = None,
         remover: bool = False,  # remove a mobject from the screen?
@@ -117,7 +117,7 @@ class Animation:
             *[mob.family_members_with_points() for mob in self.get_all_mobjects()]
         )
 
-    def update_mobjects(self, dt: int) -> None:
+    def update_mobjects(self, dt: float) -> None:
         """
         Updates things like starting_mobject, and (for
         Transforms) target_mobject.  Note, since typically
@@ -259,7 +259,7 @@ class Wait(Animation):
     def clean_up_from_scene(self, scene: "Scene") -> None:
         pass
 
-    def update_mobjects(self, dt: int) -> None:
+    def update_mobjects(self, dt: float) -> None:
         pass
 
     def interpolate(self, alpha: float) -> None:

--- a/manim/animation/composition.py
+++ b/manim/animation/composition.py
@@ -59,7 +59,7 @@ class AnimationGroup(Animation):
         for anim in self.animations:
             anim.clean_up_from_scene(scene)
 
-    def update_mobjects(self, dt: int) -> None:
+    def update_mobjects(self, dt: float) -> None:
         for anim in self.animations:
             anim.update_mobjects(dt)
 
@@ -115,7 +115,7 @@ class Succession(AnimationGroup):
         while self.active_animation is not None:
             self.next_animation()
 
-    def update_mobjects(self, dt: int) -> None:
+    def update_mobjects(self, dt: float) -> None:
         if self.active_animation:
             self.active_animation.update_mobjects(dt)
 

--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -105,7 +105,7 @@ class Flash(AnimationGroup):
         flash_radius: float = 0.3,
         line_stroke_width: int = 3,
         color: str = YELLOW,
-        run_time: int = 1,
+        run_time: float = 1.0,
         **kwargs
     ) -> None:
         self.point = point

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -693,7 +693,7 @@ class Text(SVGMobject):
     def __init__(
         self,
         text: str,
-        fill_opacity: int = 1,
+        fill_opacity: float = 1.0,
         stroke_width: int = 0,
         color: str = WHITE,
         size: int = 1,


### PR DESCRIPTION
## Motivation
I found some variables tagged as type `int` but I know they can take fractional values.

## Overview / Explanation for Changes
I changed the typing hints.

## Further Comments
Does python do anything with these typing hints, or are they decorative?

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have chosen a descriptive PR title (see top of PR template for examples)

<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [x] Newly added functions/classes are either private or have a docstring
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [x] The PR title is descriptive enough
