### PR TITLE
CI: Use poetry's cache dir rather than pip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,19 +32,6 @@ jobs:
           pip install wheel
           curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
 
-      - name: Get Poetry Cache Dir
-        shell: bash
-        id: pip-cache-and-time
-        run: |
-          echo "::set-output name=dir::$(poetry config cache-dir)"
-          echo "::set-output name=date::$(/bin/date -u "+%m%Y")"
-
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache-and-time.outputs.dir }}
-          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}-${{ matrix.python }}
-
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -67,6 +54,19 @@ jobs:
           sudo tlmgr install standalone preview doublestroke relsize fundus-calligra wasysym physics dvisvgm.x86_64-darwin dvisvgm rsfs wasy cm-super
           echo "/Library/TeX/texbin" >> $GITHUB_PATH
           echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+
+      - name: Get Poetry Cache Dir
+        shell: bash
+        id: pip-cache-and-time
+        run: |
+          echo "::set-output name=dir::$(poetry config cache-dir)"
+          echo "::set-output name=date::$(/bin/date -u "+%m%Y")"
+
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache-and-time.outputs.dir }}
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}-${{ matrix.python }}
 
       - name: Cache Windows
         id: cache-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,18 +32,18 @@ jobs:
           pip install wheel
           curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
 
-      - name: Get pip cache dir
+      - name: Get Poetry Cache Dir
         shell: bash
         id: pip-cache-and-time
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "::set-output name=dir::$(poetry config cache-dir)"
           echo "::set-output name=date::$(/bin/date -u "+%m%Y")"
 
       - name: pip cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache-and-time.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ matrix.python }}-${{ steps.pip-cache-and-time.outputs.date }}
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}-${{ matrix.python }}
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         shell: bash
         id: pip-cache-and-time
         run: |
+          export PATH="$HOME/.poetry/bin:$PATH"
           echo "::set-output name=dir::$(poetry config cache-dir)"
           echo "::set-output name=date::$(/bin/date -u "+%m%Y")"
 


### PR DESCRIPTION
## Motivation
Caching pip's cache dir is useless instead poetry's one should be cached.

## Overview / Explanation for Changes
Changes pip cache to poetry's cache.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have chosen a descriptive PR title (see top of PR template for examples)
<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The PR title is descriptive enough
