### PR TITLE
Replace links to the latest version of the documentation to the stable version

### DIFF
--- a/.github/ISSUE_TEMPLATE/installation_issue.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue.md
@@ -10,8 +10,8 @@ assignees: ''
 #### Preliminaries
 
 - [ ] I have followed the latest version of the
-      [installation instructions](https://docs.manim.community/en/latest/installation.html).
-- [ ] I have checked the [troubleshooting page](https://docs.manim.community/en/latest/installation/troubleshooting.html) and my problem is either not mentioned there,
+      [installation instructions](https://docs.manim.community/en/stable/installation.html).
+- [ ] I have checked the [troubleshooting page](https://docs.manim.community/en/stable/installation/troubleshooting.html) and my problem is either not mentioned there,
       or the solution given there does not help.
 
 ## Description of error

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,7 @@ is also intended for other testing-related comments. -->
 that might be useful for reviewers.. -->
 
 ## Acknowledgements
-- [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
+- [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/stable/contributing.html)
 - [ ] I have chosen a descriptive PR title (see top of PR template for examples)
 <!-- Once again, thanks for helping out by contributing to manim! -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,7 @@ is also intended for other testing-related comments. -->
 that might be useful for reviewers.. -->
 
 ## Acknowledgements
-- [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/stable/contributing.html)
+- [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
 - [ ] I have chosen a descriptive PR title (see top of PR template for examples)
 <!-- Once again, thanks for helping out by contributing to manim! -->
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Manim requires a few dependencies that must be installed prior to using it. If y
 want to try it out first before installing it locally, you can do so
 [in our online Jupyter environment](https://mybinder.org/v2/gist/behackl/725d956ec80969226b7bf9b4aef40b78/HEAD?filepath=basic%20example%20scenes.ipynb).
 
-For the local installation, please visit the [Documentation](https://docs.manim.community/en/latest/installation.html)
+For the local installation, please visit the [Documentation](https://docs.manim.community/en/stable/installation.html)
 and follow the appropriate instructions for your operating system.
 
 Once the dependencies have been installed, run the following in a terminal window:
@@ -76,10 +76,10 @@ manim example.py SquareToCircle -p -ql
 ```
 
 You should see your native video player program pop up and play a simple scene in which a square is transformed into a circle. You may find some more simple examples within this
-[GitHub repository](master/example_scenes). You can also visit the [official gallery](https://docs.manim.community/en/latest/examples.html) for more advanced examples.
+[GitHub repository](master/example_scenes). You can also visit the [official gallery](https://docs.manim.community/en/stable/examples.html) for more advanced examples.
 
 Manim also ships with a `%%manim` IPython magic which allows to use it conveniently in JupyterLab (as well as classic Jupyter) notebooks. See the
-[corresponding documentation](https://docs.manim.community/en/latest/reference/manim.utils.ipython_magic.ManimMagic.html) for some guidance and 
+[corresponding documentation](https://docs.manim.community/en/stable/reference/manim.utils.ipython_magic.ManimMagic.html) for some guidance and 
 [try it out online](https://mybinder.org/v2/gist/behackl/725d956ec80969226b7bf9b4aef40b78/HEAD?filepath=basic%20example%20scenes.ipynb).
 
 ## Command line arguments
@@ -96,7 +96,7 @@ Some other useful flags include:
 -  `-n <number>` to skip ahead to the `n`'th animation of a scene.
 -  `-f` show the file in the file browser.
 
-For a thorough list of command line arguments, visit the [documentation](https://docs.manim.community/en/latest/tutorials/configuration.html).
+For a thorough list of command line arguments, visit the [documentation](https://docs.manim.community/en/stable/tutorials/configuration.html).
 
 ## Documentation
 
@@ -109,13 +109,13 @@ Server](https://discord.gg/mMRrZQW) or [Reddit Community](https://www.reddit.com
 
 ## Contributing
 
-Contributions to Manim are always welcome. In particular, there is a dire need for tests and documentation. For contribution guidelines, please see the [documentation](https://docs.manim.community/en/latest/contributing.html).
+Contributions to Manim are always welcome. In particular, there is a dire need for tests and documentation. For contribution guidelines, please see the [documentation](https://docs.manim.community/en/stable/contributing.html).
 
-Most developers on the project use [Poetry](https://python-poetry.org/docs/) for management. You'll want to have poetry installed and available in your environment. You can learn more `poetry` and how to use it at its [documentation](https://docs.manim.community/en/latest/installation/for_dev.html).
+Most developers on the project use [Poetry](https://python-poetry.org/docs/) for management. You'll want to have poetry installed and available in your environment. You can learn more `poetry` and how to use it at its [documentation](https://docs.manim.community/en/stable/installation/for_dev.html).
 
 ## Code of Conduct
 
-Our full code of conduct, and how we enforce it, can be read on [our website](https://docs.manim.community/en/latest/conduct.html).
+Our full code of conduct, and how we enforce it, can be read on [our website](https://docs.manim.community/en/stable/conduct.html).
 
 ## License
 

--- a/example_scenes/basic.py
+++ b/example_scenes/basic.py
@@ -129,4 +129,4 @@ class UpdatersExample(Scene):
         self.wait()
 
 
-# See many more examples at https://docs.manim.community/en/latest/examples.html
+# See many more examples at https://docs.manim.community/en/stable/examples.html

--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -236,7 +236,7 @@ def convert_to_svg(dvi_file, extension, page=1):
             f"Your installation does not support converting {extension} files to SVG."
             f" Consider updating dvisvgm to at least version 2.4."
             f" If this does not solve the problem, please refer to our troubleshooting guide at:"
-            f" https://docs.manim.community/en/latest/installation/troubleshooting.html"
+            f" https://docs.manim.community/en/stable/installation/troubleshooting.html"
         )
 
     return result


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->

## Motivation
Many Github templates link to the latest version of the documentation; this is not ideal as it is refers to the latest, unpublished library rather than the latest release. This can cause problems for users (who are mostly using pip releases) as they may try to follow documentation while there are differences between the released and latest version. 

## Overview / Explanation for Changes
This PR replaces links to /en/latest to /en/stable.

## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have chosen a descriptive PR title (see top of PR template for examples)
<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The PR title is descriptive enough
