### PR TITLE
Remove SmallDot from example

### DIFF
--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -8,7 +8,7 @@ Examples
 
     class UsefulAnnotations(Scene):
         def construct(self):
-            m0 = SmallDot()
+            m0 = Dot()
             m1 = AnnotationDot()
             m2 = LabeledDot("ii")
             m3 = LabeledDot(MathTex(r"\alpha").set_color(ORANGE))

--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -12,10 +12,11 @@ Examples
             m1 = AnnotationDot()
             m2 = LabeledDot("ii")
             m3 = LabeledDot(MathTex(r"\alpha").set_color(ORANGE))
-            m4 = CurvedArrow(ORIGIN, 2*LEFT)
-            m5 = CurvedDoubleArrow(ORIGIN, 2*RIGHT)
+            m4 = CurvedArrow(2*LEFT, 2*RIGHT, radius= -5)
+            m5 = CurvedArrow(2*LEFT, 2*RIGHT, radius= 8)
+            m6 = CurvedDoubleArrow(ORIGIN, 2*RIGHT)
 
-            self.add(m0, m1, m2, m3, m4, m5)
+            self.add(m0, m1, m2, m3, m4, m5, m6)
             for i, mobj in enumerate(self.mobjects):
                 mobj.shift(DOWN * (i-3))
 


### PR DESCRIPTION
As SmallDot will go soon, I removed it from the docs in the annotation section.