### PR TITLE
Added BuiltinAnimation Animation

### DIFF
--- a/manim/animation/composition.py
+++ b/manim/animation/composition.py
@@ -117,7 +117,7 @@ class BuiltinAnimation(Animation):
         animation_name: str = "default",
         **kwargs,
     ) -> None:
-        """Grabs an plays an animation from an :class: Mobject
+        """Grabs an plays an animation from an :class: `Mobject`
 
         Parameters
         ----------

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -32,9 +32,6 @@ from ..utils.space_ops import get_norm
 from ..utils.space_ops import rotation_matrix
 from ..utils.space_ops import rotation_matrix_transpose
 
-from ..animation.composition import AnimationGroup
-from ..animation.creation import Create
-
 # TODO: Explain array_attrs
 
 Updater = Union[Callable[["Mobject"], None], Callable[["Mobject", float], None]]
@@ -1938,7 +1935,7 @@ class Mobject(Container):
     # Default Animations
     def get_animation(
         self, animation_name: str = "default"
-    ) -> Optional[AnimationGroup]:
+    ) -> Optional["AnimationGroup"]:
         """Grabs a builtin animation.
         Implemented by children
         """

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1942,8 +1942,7 @@ class Mobject(Container):
         """Grabs a builtin animation.
         Implemented by children
         """
-
-        return AnimationGroup(Create(self))
+        return None
 
     # Just here to keep from breaking old scenes.
     def arrange_submobjects(self, *args, **kwargs):

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -11,7 +11,7 @@ import operator as op
 import random
 import sys
 import types
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional, Union, TYPE_CHECKING
 import warnings
 
 from pathlib import Path
@@ -31,6 +31,9 @@ from ..utils.space_ops import angle_of_vector
 from ..utils.space_ops import get_norm
 from ..utils.space_ops import rotation_matrix
 from ..utils.space_ops import rotation_matrix_transpose
+
+from ..animation.composition import AnimationGroup
+from ..animation.creation import Create
 
 # TODO: Explain array_attrs
 
@@ -1931,6 +1934,16 @@ class Mobject(Container):
             for submob in self.submobjects:
                 submob.invert(recursive=True)
         list.reverse(self.submobjects)
+
+    # Default Animations
+    def get_animation(
+        self, animation_name: str = "default"
+    ) -> Optional[AnimationGroup]:
+        """Grabs a builtin animation.
+        Implemented by children
+        """
+
+        return AnimationGroup(Create(self))
 
     # Just here to keep from breaking old scenes.
     def arrange_submobjects(self, *args, **kwargs):

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -32,9 +32,6 @@ from ..utils.space_ops import get_norm
 from ..utils.space_ops import rotation_matrix
 from ..utils.space_ops import rotation_matrix_transpose
 
-if TYPE_CHECKING:
-    from ..animation.composition import AnimationGroup
-
 # TODO: Explain array_attrs
 
 Updater = Union[Callable[["Mobject"], None], Callable[["Mobject", float], None]]
@@ -1938,7 +1935,7 @@ class Mobject(Container):
     # Default Animations
     def get_animation(
         self, animation_name: str = "default"
-    ) -> Optional[AnimationGroup]:
+    ) -> Optional["AnimationGroup"]:
         """Grabs a builtin animation.
         Implemented by children
         """

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -32,6 +32,9 @@ from ..utils.space_ops import get_norm
 from ..utils.space_ops import rotation_matrix
 from ..utils.space_ops import rotation_matrix_transpose
 
+if TYPE_CHECKING:
+    from ..animation.composition import AnimationGroup
+
 # TODO: Explain array_attrs
 
 Updater = Union[Callable[["Mobject"], None], Callable[["Mobject", float], None]]
@@ -1935,7 +1938,7 @@ class Mobject(Container):
     # Default Animations
     def get_animation(
         self, animation_name: str = "default"
-    ) -> Optional["AnimationGroup"]:
+    ) -> Optional[AnimationGroup]:
         """Grabs a builtin animation.
         Implemented by children
         """


### PR DESCRIPTION
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
Added BuiltinAnimation Animation: An animation that grabs built-in animations from Mobjects.
<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->
I needed this for my plugin and it seems useful so I'm suggesting adding it to manim

## Explanation for Changes
<!-- How do your changes improve the library?

For PRs introducing new features, please provide code snippets using the
newly introduced functionality and ideally even the expected rendered output.
-->
This is an animation that calls the function get_animation to get an animation built-in to this function.

```python
class BuiltinAnimation(Animation):
    def __init__(
        self,
        graph: Graph,
        animation_name: str = "default",
        **kwargs,
    ) -> None:

        self.animation = graph.get_animation(animation_name)
        print(self.animation.group.submobjects)
        self.graph = graph
        self.check()

        prepare_animation(self.animation)

        super().__init__(self.animation.mobject, **kwargs)

    def check(self):
        if self.animation is None:
            raise TypeError(
                f"{self.graph.__class__.__name__} does not support this animation"
            )
```

Why would I ever need this? you ask.

- Allows for default animations to be set
- Allows for complex animations to be built into Mobjects, with timings and all other stuff you can normally do
- Allow for as many of the above as you want, without creating new classes
- Allows for new animations that would be infeasible to add as a class.

Here is an example form my plugin:

```python
class LinePlot(Plot):
    def __init__(
        self, *values: typing.List[typing.Union[float, int]], dot_points: bool = False
    ) -> None:
        """Plots s line

        Parameters
        ----------
        dot_points : bool, optional
            Put dots at points, by default False
        """
        super().__init__()

        self.dot_points = dot_points

        self.colors = ["RED", "BLUE", "GREEN"]

        self.animations = list()
        self.line_animations = list()

        self.axes = Axes(
            x_range=[0, max([len(x) for x in values]) - 1, 1],
            y_range=[0, max([max(a) for a in values]) + 1, 1],
            x_length=9,
            y_length=6,
            axis_config={"include_tip": False, "include_numbers": True},
        )

        self.add(self.axes)
        self.animations.append(Create(self.axes))

        for i, value in enumerate(values):
            self.value = value
            self.plot(self.colors[i])

    def plot(self, color: str) -> None:
        last_point = None
        for i, value in enumerate(self.value):
            point = self.axes.coords_to_point(i, value)

            if last_point is not None:
                line = Line(last_point, point, stroke_width=3, color=color)
                self.add(line)
                self.line_animations.append(Create(line, run_time=0.1))

            last_point = point

            if self.dot_points:
                d = Dot(point, color=color)
                self.add(d)
                self.line_animations.append(Create(d, run_time=0.5))

    def get_animation(self, animation_name: str = "default") -> typing.Optional[AnimationGroup]:
        animations = None

        if animation_name == "default":
            lines = AnimationGroup(*self.line_animations, lag_ratio=0.5)
            animations = AnimationGroup(*self.animations, lines, lag_ratio=1)

        return animations
```

## Checklist
- [X] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [X] I have written a descriptive PR title (see top of PR template for examples)
- [X] I have written a changelog entry for the PR or deem it unnecessary
- [X] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [X] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
