### PR TITLE
Red pixels (different value) now appear over green pixels (same value) in GraphicalUnitTest

### DIFF
--- a/tests/utils/GraphicalUnitTester.py
+++ b/tests/utils/GraphicalUnitTester.py
@@ -102,16 +102,16 @@ class GraphicalUnitTester:
         diff_im = expected_frame_data.copy()
         diff_im = np.where(
             frame_data != np.array([0, 0, 0, 255]),
-            np.array([255, 0, 0, 255], dtype="uint8"),
+            np.array([0, 255, 0, 255], dtype="uint8"),
             np.array([0, 0, 0, 255], dtype="uint8"),
-        )  # Set the points of the frame generated to red.
+        )  # Set any non-black pixels to green
         np.putmask(
             diff_im,
-            expected_frame_data != np.array([0, 0, 0, 255], dtype="uint8"),
-            np.array([0, 255, 0, 255], dtype="uint8"),
-        )  # Set the points of the frame generated to green.
+            expected_frame_data != frame_data,
+            np.array([255, 0, 0, 255], dtype="uint8"),
+        )  # Set any different pixels to red
         ax.imshow(diff_im, interpolation="nearest")
-        ax.set_title("Differences summary : (red = got, green = expected)")
+        ax.set_title("Differences summary : (green = same, red = different)")
 
         plt.show()
         plt.savefig(f"{self.scene}.png")


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->

<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->
Based on discussion here: https://github.com/ManimCommunity/manim/issues/1180 the ordering of colors made it difficult to see what pixels were different, as they were overwritten by the green 'expected' pixels.

## Explanation for Changes
<!-- How do your changes improve the library?

For PRs introducing new features, please provide code snippets using the
newly introduced functionality and ideally even the expected rendered output.
-->

The red and green colors are now redefined such that red signals differences and green signals the same, with black being the background color.

## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->

## Further Comments
<!-- Optional: any further comments that might be useful for reviewers. -->

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [x] My new functions/classes either have a docstring or are private
- [x] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
