### PR TITLE
Automatically remove long tick marks not within the range of the :class:`~NumberLine`

### DIFF
--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -57,7 +57,6 @@ class NumberLine(Line):
         self.rotation = rotation
         self.tick_frequency = tick_frequency
         self.leftmost_tick = leftmost_tick
-        self.numbers_with_elongated_ticks = numbers_with_elongated_ticks
         self.include_numbers = include_numbers
         self.numbers_to_show = numbers_to_show
         self.longer_tick_multiple = longer_tick_multiple
@@ -88,6 +87,11 @@ class NumberLine(Line):
             self.width = width
             self.unit_size = self.get_unit_size()
         self.shift(-self.number_to_point(self.number_at_center))
+
+        self.numbers_with_elongated_ticks = []
+        for number in numbers_with_elongated_ticks:
+            if number >= self.x_min and number <= self.x_max:
+                self.numbers_with_elongated_ticks.append(number)
 
         self.init_leftmost_tick()
         if self.include_tip:

--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -88,10 +88,9 @@ class NumberLine(Line):
             self.unit_size = self.get_unit_size()
         self.shift(-self.number_to_point(self.number_at_center))
 
-        self.numbers_with_elongated_ticks = []
-        for number in numbers_with_elongated_ticks:
-            if number >= self.x_min and number <= self.x_max:
-                self.numbers_with_elongated_ticks.append(number)
+        self.numbers_with_elongated_ticks = [
+            nbr for nbr in numbers_with_elongated_ticks if self.x_min <= nbr <= self.x_max
+        ]
 
         self.init_leftmost_tick()
         if self.include_tip:

--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -89,7 +89,9 @@ class NumberLine(Line):
         self.shift(-self.number_to_point(self.number_at_center))
 
         self.numbers_with_elongated_ticks = [
-            nbr for nbr in numbers_with_elongated_ticks if self.x_min <= nbr <= self.x_max
+            nbr
+            for nbr in numbers_with_elongated_ticks
+            if self.x_min <= nbr <= self.x_max
         ]
 
         self.init_leftmost_tick()


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->

<!--changelog-end-->
Based on the discussion in [#1180](https://github.com/ManimCommunity/manim/issues/1180), changed the NumberLine class so that when initialized any tick marks defined in `numbers_with_elongated_ticks` would be checked to see if they are in fact on the number line.  Any tick marks not on the number line would be ignored.

## Motivation
<!-- In what way do your changes improve the library? -->
Removes unintended tick marks that are not on the number line.

## Explanation for Changes
<!-- How do your changes improve the library?

For PRs introducing new features, please provide code snippets using the
newly introduced functionality and ideally even the expected rendered output.
-->
Without the changes, tick marks defined in `numbers_with_elongated_ticks` that are not on the number line would still show, as seen here:

![PlotFunctions_ManimCE_v0 5 0](https://user-images.githubusercontent.com/79891353/114256866-2bcad780-9971-11eb-8e33-acdf487ed7a6.gif)

With the change, any tick marks which are not on the number line are ignored, as seen here:

https://user-images.githubusercontent.com/79891353/114256982-adbb0080-9971-11eb-8109-600b0e6e6218.mp4

This is necessary as `numbers_with_elongated_ticks` defaults to 0, but if 0 is not on the number line then the tick mark is still drawn and visible.

## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->
Ran pytest, which returned the same result with and without the change.  Also ran the above renderings to do a visual inspection of the changes.

## Further Comments
<!-- Optional: any further comments that might be useful for reviewers. -->

## Checklist
- [X] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [X] I have written a descriptive PR title (see top of PR template for examples)
- [X] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [x] The PR title is descriptive enough
- [x] The PR is labeled correctly
- [x] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
