### PR TITLE
Fix custom fonts in textemplate

### DIFF
--- a/manim/utils/tex.py
+++ b/manim/utils/tex.py
@@ -48,7 +48,6 @@ class TexTemplate:
 \usepackage[english]{babel}
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
-\usepackage{lmodern}
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{dsfont}


### PR DESCRIPTION
After #1296, it was not possible anymore to add a custom tex font.
e.g. with this script:
```py
class ComparingTex(Scene):
    def construct(self):
        temp_stix2= TexTemplate()
        temp_stix2.add_to_preamble(r"\usepackage{stix2}", prepend= True)
        tex_stix2  = Tex(r"$dk_x dk_y = |\mu| d\mu d\phi$", tex_template=temp_stix2).scale(3)

        self.add(tex_stix2)
        self.wait()
```
After this pr, it will be fixed.
## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->

## Further Comments
<!-- Optional: any further comments that might be useful for reviewers. -->

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [x] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
