### PR TITLE
Added documentation guidelines for type hints

### DIFF
--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -326,14 +326,14 @@ If you've never used type hints before, this is a good place to get started:
 https://realpython.com/python-type-checking/#hello-types.
 When adding type hints to manim, there are some guidelines that should be followed:
 
-* Coordinates have the typehint `Sequence[float]`, e.g.
+* Coordinates have the typehint ``Sequence[float]``, e.g.
 
 .. code:: py
 
     def set_points_as_corners(self, points: Sequence[float]) -> "VMobject":
         """Given an array of points, set them as corner of the Vmobject."""
 
-* `**kwargs` has no typehint
+* ``**kwargs`` has no typehint
 
 * Mobjects have the typehint "Mobject", e.g.
 
@@ -343,13 +343,13 @@ When adding type hints to manim, there are some guidelines that should be follow
         """Match the color with the color of another :class:`~.Mobject`."""
         return self.set_color(mobject.get_color())
 
-* Colors have the typehint "Color", e.g.
+* Colors have the typehint ``Color``, e.g.
 
 .. code:: py
 
     def set_color(self, color: Color = YELLOW_C, family: bool = True):
         """Condition is function which takes in one arguments, (x, y, z)."""
 
-* As `float` and `Union[int, float]` are the same, use only `float`
+* As ``float`` and ``Union[int, float]`` are the same, use only ``float``
 
-* For numpy arrays use the typehint `np.ndarray`
+* For numpy arrays use the typehint ``np.ndarray``

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -382,9 +382,11 @@ When adding type hints to manim, there are some guidelines that should be follow
 
     rate_func: Callable[float] = lambda t: smooth(1 - t)
     
-
+*  numpy arrays can get type hints with `np.ndarray`
+    
 Missing Sections
 ----------------
 * Tools for typehinting
 * Link to MyPy
+* Mypy and numpy import errors: https://realpython.com/python-type-checking/#running-mypy
 * Where to find the alias

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -330,27 +330,21 @@ When adding type hints to manim, there are some guidelines that should be follow
 * Coordinates have the typehint ``Sequence[float]``, e.g.
 
 .. code:: py
-
     def set_points_as_corners(self, points: Sequence[float]) -> "VMobject":
         """Given an array of points, set them as corner of the Vmobject."""
-
 * ``**kwargs`` has no typehint
 
 * Mobjects have the typehint "Mobject", e.g.
 
 .. code:: py
-
     def match_color(self, mobject: "Mobject"):
         """Match the color with the color of another :class:`~.Mobject`."""
         return self.set_color(mobject.get_color())
-
 * Colors have the typehint ``Color``, e.g.
 
 .. code:: py
-
     def set_color(self, color: Color = YELLOW_C, family: bool = True):
         """Condition is function which takes in one arguments, (x, y, z)."""
-
 * As ``float`` and ``Union[int, float]`` are the same, use only ``float``
 
 * For numpy arrays use the typehint ``np.ndarray``
@@ -358,32 +352,27 @@ When adding type hints to manim, there are some guidelines that should be follow
 * Functions that does not return a value should get the type hint ``None``. (This annotations help catch the kinds of subtle bugs where you are trying to use a meaningless return value. )
 
 .. code:: py
-
     def height(self, value) -> None:
         self.scale_to_fit_height(value)
-
 * When a paramter is None by default, it can get the type hint ``Optional`` 
 
 .. code:: py
-
-  def rotate(
+    def rotate(
         self,
         angle,
         axis=OUT,
         about_point: Optional[Sequence[float]] = None,
         **kwargs,
     ):
-
 * the .__init__() method always should have None as its return type.
 
 * functions and lambda functions should get the typehint `Callable`
 
 .. code:: py
-
     rate_func: Callable[float] = lambda t: smooth(1 - t)
     
 *  numpy arrays can get type hints with `np.ndarray`
-    
+
 Missing Sections
 ----------------
 * Tools for typehinting

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -184,8 +184,8 @@ Example:
 
 .. _types:
 
-Types
------
+Reference to types in documentaion
+----------------------------------
 
 Always specify types with the correct **role** (see
 https://www.sphinx-doc.org/en/1.7/domains.html#python-roles) for the
@@ -232,7 +232,7 @@ Example: ``:class:`~.Animation`​``, ``:meth:`~.VMobject.set_color`​``,
 
 Example: ``:class:`numpy.ndarray`​`` for a numpy ndarray.
 
-Type specifications
+Reference Type specifications
 ~~~~~~~~~~~~~~~~~~~
 
 **The following instructions refer to types of attributes, parameters
@@ -317,3 +317,38 @@ elements that are either a ``str`` or ``None``;
 ``Tuple[:class:`str`, :class:`int`]`` for a tuple of type
 ``(str, int)``; ``Tuple[:class:`int`, ...]`` for a tuple of variable
 length with only integers.
+
+
+Adding type hints to functions and parameters
+---------------------------------------------
+
+When you've never used type hints before, here is a good place to get startd:
+https://realpython.com/python-type-checking/#hello-types
+By adding type hints to manim, there are some guidlines that should be followed:
+* Coordinates have the typehint `Sequence[float]`, e.g.
+
+.. code:: py
+
+    def set_points_as_corners(self, points: Sequence[float]) -> "VMobject":
+        """Given an array of points, set them as corner of the Vmobject."""
+
+* `**kwargs` has no typehint
+
+* Mobjects have the typehint "Mobject", e.g.
+
+.. code:: py
+
+    def match_color(self, mobject: "Mobject"):
+        """Match the color with the color of another :class:`~.Mobject`."""
+        return self.set_color(mobject.get_color())
+
+* Colors have the typhint "Color", e.g.
+
+.. code:: py
+
+    def set_color(self, color: Color = YELLOW_C, family: bool = True):
+        """Condition is function which takes in one arguments, (x, y, z)."""
+
+* As `float` and `Union[int,float]` are the same, use only `float`
+
+* For numpy arrays use the typehint `np.ndarray`

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -232,7 +232,7 @@ Example: ``:class:`~.Animation`​``, ``:meth:`~.VMobject.set_color`​``,
 
 Example: ``:class:`numpy.ndarray`​`` for a numpy ndarray.
 
-Reference Type specifications
+Reference type specifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **The following instructions refer to types of attributes, parameters
@@ -358,7 +358,7 @@ When adding type hints to manim, there are some guidelines that should be follow
 
     def height(self, value) -> None:
         self.scale_to_fit_height(value)
-* When a parameter is None by default, it can get the type hint ``Optional``
+* Parameters that are None by default should get the type hint ``Optional``
 
 .. code:: py
 

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -354,3 +354,16 @@ When adding type hints to manim, there are some guidelines that should be follow
 * As ``float`` and ``Union[int, float]`` are the same, use only ``float``
 
 * For numpy arrays use the typehint ``np.ndarray``
+
+* Functions that does not return a value should get the type hint ``None``. (This annotations help catch the kinds of subtle bugs where you are trying to use a meaningless return value. )
+
+.. code:: py
+    def height(self, value) -> None:
+        self.scale_to_fit_height(value)
+
+Missing Sections
+################
+
+* Tools for typehinting
+* Link to MyPy
+* Where to find the alias

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -358,7 +358,7 @@ When adding type hints to manim, there are some guidelines that should be follow
 
     def height(self, value) -> None:
         self.scale_to_fit_height(value)
-* When a paramter is None by default, it can get the type hint ``Optional`` 
+* When a parameter is None by default, it can get the type hint ``Optional``
 
 .. code:: py
 
@@ -369,17 +369,18 @@ When adding type hints to manim, there are some guidelines that should be follow
         about_point: Optional[Sequence[float]] = None,
         **kwargs,
     ):
+        pass
 
 
 * the .__init__() method always should have None as its return type.
 
-* functions and lambda functions should get the typehint `Callable`
+* functions and lambda functions should get the typehint ``Callable``
 
 .. code:: py
 
     rate_func: Callable[[float], float] = lambda t: smooth(1 - t)
-    
-*  numpy arrays can get type hints with `np.ndarray`
+
+*  numpy arrays can get type hints with ``np.ndarray``
 
 Missing Sections
 ----------------

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -390,3 +390,4 @@ Missing Sections
 * Link to MyPy
 * Mypy and numpy import errors: https://realpython.com/python-type-checking/#running-mypy
 * Where to find the alias
+* How to use "VMobject" , "Mobject" typehints?

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -374,6 +374,15 @@ When adding type hints to manim, there are some guidelines that should be follow
         **kwargs,
     ):
 
+* the .__init__() method always should have None as its return type.
+
+* functions and lambda functions should get the typehint `Callable`
+
+.. code:: py
+
+    rate_func: Callable[float] = lambda t: smooth(1 - t)
+    
+
 Missing Sections
 ----------------
 * Tools for typehinting

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -233,7 +233,7 @@ Example: ``:class:`~.Animation`​``, ``:meth:`~.VMobject.set_color`​``,
 Example: ``:class:`numpy.ndarray`​`` for a numpy ndarray.
 
 Reference Type specifications
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **The following instructions refer to types of attributes, parameters
 and return values.** When specifying a type mid-text, it does not

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -330,6 +330,7 @@ When adding type hints to manim, there are some guidelines that should be follow
 * Coordinates have the typehint ``Sequence[float]``, e.g.
 
 .. code:: py
+
     def set_points_as_corners(self, points: Sequence[float]) -> "VMobject":
         """Given an array of points, set them as corner of the Vmobject."""
 * ``**kwargs`` has no typehint
@@ -337,12 +338,14 @@ When adding type hints to manim, there are some guidelines that should be follow
 * Mobjects have the typehint "Mobject", e.g.
 
 .. code:: py
+
     def match_color(self, mobject: "Mobject"):
         """Match the color with the color of another :class:`~.Mobject`."""
         return self.set_color(mobject.get_color())
 * Colors have the typehint ``Color``, e.g.
 
 .. code:: py
+
     def set_color(self, color: Color = YELLOW_C, family: bool = True):
         """Condition is function which takes in one arguments, (x, y, z)."""
 * As ``float`` and ``Union[int, float]`` are the same, use only ``float``
@@ -352,11 +355,13 @@ When adding type hints to manim, there are some guidelines that should be follow
 * Functions that does not return a value should get the type hint ``None``. (This annotations help catch the kinds of subtle bugs where you are trying to use a meaningless return value. )
 
 .. code:: py
+
     def height(self, value) -> None:
         self.scale_to_fit_height(value)
 * When a paramter is None by default, it can get the type hint ``Optional`` 
 
 .. code:: py
+
     def rotate(
         self,
         angle,
@@ -364,11 +369,14 @@ When adding type hints to manim, there are some guidelines that should be follow
         about_point: Optional[Sequence[float]] = None,
         **kwargs,
     ):
+    j = 42
+    
 * the .__init__() method always should have None as its return type.
 
 * functions and lambda functions should get the typehint `Callable`
 
 .. code:: py
+
     rate_func: Callable[float] = lambda t: smooth(1 - t)
     
 *  numpy arrays can get type hints with `np.ndarray`

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -369,15 +369,15 @@ When adding type hints to manim, there are some guidelines that should be follow
         about_point: Optional[Sequence[float]] = None,
         **kwargs,
     ):
-    j = 42
-    
+
+
 * the .__init__() method always should have None as its return type.
 
 * functions and lambda functions should get the typehint `Callable`
 
 .. code:: py
 
-    rate_func: Callable[float] = lambda t: smooth(1 - t)
+    rate_func: Callable[[float], float] = lambda t: smooth(1 - t)
     
 *  numpy arrays can get type hints with `np.ndarray`
 

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -358,12 +358,24 @@ When adding type hints to manim, there are some guidelines that should be follow
 * Functions that does not return a value should get the type hint ``None``. (This annotations help catch the kinds of subtle bugs where you are trying to use a meaningless return value. )
 
 .. code:: py
+
     def height(self, value) -> None:
         self.scale_to_fit_height(value)
 
-Missing Sections
-################
+* When a paramter is None by default, it can get the type hint ``Optional`` 
 
+.. code:: py
+
+  def rotate(
+        self,
+        angle,
+        axis=OUT,
+        about_point: Optional[Sequence[float]] = None,
+        **kwargs,
+    ):
+
+Missing Sections
+----------------
 * Tools for typehinting
 * Link to MyPy
 * Where to find the alias

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -323,8 +323,9 @@ Adding type hints to functions and parameters
 ---------------------------------------------
 
 If you've never used type hints before, this is a good place to get started:
-https://realpython.com/python-type-checking/#hello-types
+https://realpython.com/python-type-checking/#hello-types.
 When adding type hints to manim, there are some guidelines that should be followed:
+
 * Coordinates have the typehint `Sequence[float]`, e.g.
 
 .. code:: py

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -388,4 +388,6 @@ Missing Sections
 * Link to MyPy
 * Mypy and numpy import errors: https://realpython.com/python-type-checking/#running-mypy
 * Where to find the alias
-* How to use "VMobject" , "Mobject" typehints?
+* When to use Object and when to use "Object".
+* The use of a TypeVar on the type hints for copy().
+* The definition and use of Protocols (like Sized, or Sequence, or Iterable...)

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -324,6 +324,7 @@ Adding type hints to functions and parameters
 
 If you've never used type hints before, this is a good place to get started:
 https://realpython.com/python-type-checking/#hello-types.
+
 When adding type hints to manim, there are some guidelines that should be followed:
 
 * Coordinates have the typehint ``Sequence[float]``, e.g.

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -322,9 +322,9 @@ length with only integers.
 Adding type hints to functions and parameters
 ---------------------------------------------
 
-When you've never used type hints before, here is a good place to get startd:
+If you've never used type hints before, this is a good place to get started:
 https://realpython.com/python-type-checking/#hello-types
-By adding type hints to manim, there are some guidlines that should be followed:
+When adding type hints to manim, there are some guidelines that should be followed:
 * Coordinates have the typehint `Sequence[float]`, e.g.
 
 .. code:: py
@@ -342,13 +342,13 @@ By adding type hints to manim, there are some guidlines that should be followed:
         """Match the color with the color of another :class:`~.Mobject`."""
         return self.set_color(mobject.get_color())
 
-* Colors have the typhint "Color", e.g.
+* Colors have the typehint "Color", e.g.
 
 .. code:: py
 
     def set_color(self, color: Color = YELLOW_C, family: bool = True):
         """Condition is function which takes in one arguments, (x, y, z)."""
 
-* As `float` and `Union[int,float]` are the same, use only `float`
+* As `float` and `Union[int, float]` are the same, use only `float`
 
 * For numpy arrays use the typehint `np.ndarray`


### PR DESCRIPTION
# Motivation
As we are using type hints, I think we should also add some guidelines of how we want to add typehints in the docs.
I started with some thoughts of mine that could be useful, but it is only an early draft, feel free to push any changes/additions to these guidelines (that's also why I made this branch a ManimCommunity branch and not a fork branch).
 
Further discussions in this:
https://github.com/ManimCommunity/manim/issues/1212
https://github.com/ManimCommunity/manim/issues/1337

EDIT: Preview can be seen here: https://manimce--1338.org.readthedocs.build/en/1338/contributing/documentation.html#adding-type-hints-to-functions-and-parameters
## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [x] The PR title is descriptive enough
- [x] The PR is labeled correctly
- [x] The changelog entry is completed if necessary
