### PR TITLE
Make TexTemplate() simle, but keep Tex()'s default template

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -25,6 +25,7 @@ import numpy as np
 
 from .. import constants
 from ..utils.tex import TexTemplate, TexTemplateFromFile
+from ..utils.tex_templates import TexTemplateLibrary
 from .logger_utils import set_file_logger
 
 
@@ -1341,7 +1342,7 @@ class ManimConfig(MutableMapping):
             if fn:
                 self._tex_template = TexTemplateFromFile(filename=fn)
             else:
-                self._tex_template = TexTemplate()
+                self._tex_template = TexTemplateLibrary.default.copy()
         return self._tex_template
 
     @tex_template.setter

--- a/manim/utils/tex.py
+++ b/manim/utils/tex.py
@@ -46,25 +46,8 @@ class TexTemplate:
     default_documentclass = r"\documentclass[preview]{standalone}"
     default_preamble = r"""
 \usepackage[english]{babel}
-\usepackage[utf8]{inputenc}
-\usepackage[T1]{fontenc}
-\usepackage{lmodern}
 \usepackage{amsmath}
 \usepackage{amssymb}
-\usepackage{dsfont}
-\usepackage{setspace}
-\usepackage{tipa}
-\usepackage{relsize}
-\usepackage{textcomp}
-\usepackage{mathrsfs}
-\usepackage{calligra}
-\usepackage{wasysym}
-\usepackage{ragged2e}
-\usepackage{physics}
-\usepackage{xcolor}
-\usepackage{microtype}
-\DisableLigatures{encoding = *, family = * }
-\linespread{1}
 """
     default_placeholder_text = "YourTextHere"
     default_tex_compiler = "latex"

--- a/manim/utils/tex_templates.py
+++ b/manim/utils/tex_templates.py
@@ -20,6 +20,31 @@ def _new_ams_template():
     return TexTemplate(preamble=preamble)
 
 
+""" Tex Template preamble used by original upstream 3b1b """
+_3b3b_preamble = r"""
+\usepackage[english]{babel}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{dsfont}
+\usepackage{setspace}
+\usepackage{tipa}
+\usepackage{relsize}
+\usepackage{textcomp}
+\usepackage{mathrsfs}
+\usepackage{calligra}
+\usepackage{wasysym}
+\usepackage{ragged2e}
+\usepackage{physics}
+\usepackage{xcolor}
+\usepackage{microtype}
+\DisableLigatures{encoding = *, family = * }
+\linespread{1}
+"""
+
+
 # TexTemplateLibrary
 #
 class TexTemplateLibrary(object):
@@ -34,16 +59,16 @@ class TexTemplateLibrary(object):
 
     """
 
-    default = TexTemplate()
+    default = TexTemplate(preamble=_3b3b_preamble)
     """An instance of the default TeX template in manim"""
 
-    threeb1b = TexTemplate()
+    threeb1b = TexTemplate(preamble=_3b3b_preamble)
     """ An instance of the default TeX template used by 3b1b """
 
     ctex = TexTemplate(
         tex_compiler="xelatex",
         output_format=".xdv",
-        preamble=TexTemplate.default_preamble.replace(
+        preamble=_3b3b_preamble.replace(
             r"\DisableLigatures{encoding = *, family = * }", r"\usepackage[UTF8]{ctex}"
         ),
     )


### PR DESCRIPTION
## Changelog / Overview
TexTemplate() now returns a simple tex template.
However, Tex() mobjects still keep the same default template:
TexTemplateLibrary.3b1b (or equivalently) TexTemplateLibrary.default

<!--changelog-start-->
TexTemplate() now returns a simple tex template.

<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->
When people create their own tex templates, they usually want to start simple. They get confused if too many packages are already loaded. This is the result of numerous discussions in Discord.


## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->

## Further Comments
<!-- Optional: any further comments that might be useful for reviewers. -->

## Checklist
- [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [x] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
