### PR TITLE
Better typehint for `about_point`  in `rotate` and coordinates

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -13,7 +13,7 @@ import types
 import warnings
 from functools import reduce
 from pathlib import Path
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional, Sequence, Union
 
 import numpy as np
 from colour import Color
@@ -1066,7 +1066,7 @@ class Mobject(Container):
         self,
         angle,
         axis=OUT,
-        about_point: Union[np.ndarray, List, None] = None,
+        about_point: Optional[Sequence[float]] = None,
         **kwargs,
     ):
         """Rotates the :class:`~.Mobject` about a certain point."""


### PR DESCRIPTION
Instead of `about_point: Union[np.ndarray, List, None] = None` , I think that `Optional[Sequence[float]] = None` is the better type hint here. I only changed it at in place, so it can be discussed in this pr if it is the best strategy.
We can add the result of the discussion into the guidelines in #1338

Edit:
from https://realpython.com/python-type-checking/#the-optional-type:
>  The Optional type simply says that a variable either has the type specified or is None. An equivalent way of specifying the same would be using the Union type: Union[None, str]

