### PR TITLE
Add `path_arc` support to `.animate` syntax

### DIFF
--- a/manim/animation/transform.py
+++ b/manim/animation/transform.py
@@ -75,20 +75,29 @@ class Transform(Animation):
         super().__init__(mobject, **kwargs)
 
     @property
-    def path_arc(self):
+    def path_arc(self) -> float:
         return self._path_arc
 
     @path_arc.setter
-    def path_arc(self, path_arc):
+    def path_arc(self, path_arc: float) -> None:
         self._path_arc = path_arc
         self._path_func = path_along_arc(self._path_arc, self.path_arc_axis)
 
     @property
-    def path_func(self):
+    def path_func(
+        self,
+    ) -> Callable[
+        [Iterable[np.ndarray], Iterable[np.ndarray], float], Iterable[np.ndarray]
+    ]:
         return self._path_func
 
     @path_func.setter
-    def path_func(self, path_func):
+    def path_func(
+        self,
+        path_func: Callable[
+            [Iterable[np.ndarray], Iterable[np.ndarray], float], Iterable[np.ndarray]
+        ],
+    ) -> None:
         if path_func is not None:
             self._path_func = path_func
 

--- a/manim/animation/transform.py
+++ b/manim/animation/transform.py
@@ -63,9 +63,9 @@ class Transform(Animation):
         replace_mobject_with_target_in_scene: bool = False,
         **kwargs,
     ) -> None:
+        self.path_arc_axis: np.ndarray = path_arc_axis
         self.path_arc: float = path_arc
         self.path_func: Optional[Callable] = path_func
-        self.path_arc_axis: np.ndarray = path_arc_axis
         self.replace_mobject_with_target_in_scene: bool = (
             replace_mobject_with_target_in_scene
         )
@@ -73,18 +73,24 @@ class Transform(Animation):
             target_mobject if target_mobject is not None else Mobject()
         )
         super().__init__(mobject, **kwargs)
-        self._init_path_func()
 
-    def _init_path_func(self) -> None:
-        if self.path_func is not None:
-            return
-        elif self.path_arc == 0:
-            self.path_func = straight_path
-        else:
-            self.path_func = path_along_arc(
-                self.path_arc,
-                self.path_arc_axis,
-            )
+    @property
+    def path_arc(self):
+        return self._path_arc
+
+    @path_arc.setter
+    def path_arc(self, path_arc):
+        self._path_arc = path_arc
+        self._path_func = path_along_arc(self._path_arc, self.path_arc_axis)
+
+    @property
+    def path_func(self):
+        return self._path_func
+
+    @path_func.setter
+    def path_func(self, path_func):
+        if path_func is not None:
+            self._path_func = path_func
 
     def begin(self) -> None:
         # Use a copy of target_mobject for the align_data

--- a/manim/utils/paths.py
+++ b/manim/utils/paths.py
@@ -32,7 +32,7 @@ def path_along_arc(arc_angle, axis=OUT):
     If vect is vector from start to end, [vect[:,1], -vect[:,0]] is
     perpendicular to vect in the left direction.
     """
-    if abs(arc_angle) < STRAIGHT_PATH_THRESHOLD:
+    if abs(arc_angle) < STRAIGHT_PATH_THRESHOLD or arc_angle == 0:
         return straight_path
     if np.linalg.norm(axis) == 0:
         axis = OUT

--- a/manim/utils/paths.py
+++ b/manim/utils/paths.py
@@ -32,7 +32,7 @@ def path_along_arc(arc_angle, axis=OUT):
     If vect is vector from start to end, [vect[:,1], -vect[:,0]] is
     perpendicular to vect in the left direction.
     """
-    if abs(arc_angle) < STRAIGHT_PATH_THRESHOLD or arc_angle == 0:
+    if abs(arc_angle) < STRAIGHT_PATH_THRESHOLD:
         return straight_path
     if np.linalg.norm(axis) == 0:
         axis = OUT


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
The parameter `path_arc` of :class:`~.Transform` now works with the `.animate` syntax
<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->
Method animations currently do not take into account the `path_arc` argument. 

I was actually looking for a way to make `self.play(mob.animate.rotate(<radians>)` to actually rotate and not transform during the animation. One possible solution (has its limitations) is `self.play(mob.animate(path_arc=<radians>).rotate(<radians>)`. While trying this I noticed that `.animate` doesn't support `path_arc`s, hence this PR

## Explanation for Changes
<!-- How do your changes improve the library?
For PRs introducing new features, please provide code snippets using the
newly introduced functionality and ideally even the expected rendered output.
-->
Here's the issue
https://github.com/ManimCommunity/manim/blob/80a1bfcd2f4e44991fb58a3d7f2d3ebce87177b0/manim/mobject/mobject.py#L2413-L2422
The passed `anim_args` (in this case, `path_arc` and `path_func`) are set as `anim`'s attributes overriding their previous values,  but that's not enough to set an interpolation function via `path_arc`. Setting `path_arc=<path_arc>` should reset the `path_func` attribute as well using `anim.path_func = path_along_arc(<path_arc>, <path_arc_axis>)`. This shouted properties at me, so I implemented properties for `path_arc` and `path_func`. 
## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->
- `pytest` - local pass (Windows 10)
- `pytest --doctest-modules manim` - some opengl tests fail but that's not relevant ig, since I noticed in a previous PR that the [opengl tests are ignored](https://github.com/ManimCommunity/manim/runs/2406295586#step:19:2).
- It would be nice to have a graphical/video unit test for this, but I'm not sure how to go about it
- code to reproduce the issue
```py
class PathAnimate(Scene):
    def construct(self):
        s1 = Square(color=BLUE, fill_opacity=0.5).to_edge(RIGHT).save_state()
        s2 = Circle(color=YELLOW, fill_opacity=0.5).to_edge(LEFT).save_state()
        
        self.add(s1, s2)
        self.wait()

        self.play(
            s1.animate(path_arc=PI, run_time=2).center(),
            s2.animate(path_func=path_along_arc(PI/2), run_time=3).center()
        )
        self.wait(0.5)

        self.play(
            AnimationGroup(
                s1.animate(path_arc=np.pi/2, run_time=2).restore(),
                lag_ratio=0.5
            ),
            s2.animate(path_func=clockwise_path()).restore()
        )
        self.wait()
```
### master (`path_arc` doesn't work but `path_func` does)

https://user-images.githubusercontent.com/73361366/115747781-32b30a80-a3b3-11eb-8149-095ea030186f.mp4
### pr branch (both work)

https://user-images.githubusercontent.com/73361366/115747921-54ac8d00-a3b3-11eb-9e99-ea487e6bb38e.mp4

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
