### PR TITLE
Updated Discord links in the docs to point towards a standardized redirect

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@
 
 
 
-   > TL;DR Be excellent to each other; we're a community after all. If you run into issues with others in our community, please [contact](https://discord.gg/mMRrZQW) a Manim Community Dev, or Moderator.
+   > TL;DR Be excellent to each other; we're a community after all. If you run into issues with others in our community, please [contact](https://www.manim.community/discord/) a Manim Community Dev, or Moderator.
 
 ## Purpose
 
@@ -68,7 +68,7 @@ This Code of Conduct applies to the following online spaces:
 
 - The [ManimCommunity GitHub Organization](https://github.com/ManimCommunity) and all of its repositories
 
-- The Manim [Discord](https://discord.gg/mMRrZQW)
+- The Manim [Discord](https://www.manim.community/discord/)
 
 - The Manim [Reddit](https://www.reddit.com/r/manim/)
 
@@ -104,7 +104,7 @@ Thank you for helping make this a welcoming, friendly community for everyone.
 
 ## Contact Information
 
-If you believe someone is violating the code of conduct, or have any other concerns, please contact a Manim Community Dev, or Moderator immediately. They can be reached on Manim's Community [Discord](https://discord.gg/mMRrZQW).
+If you believe someone is violating the code of conduct, or have any other concerns, please contact a Manim Community Dev, or Moderator immediately. They can be reached on Manim's Community [Discord](https://www.manim.community/discord/).
 
 
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ When executing `manim` within a Docker container, several command line flags (in
 ## Help with Manim
 
 If you need help installing or using Manim, feel free to reach out to our [Discord
-Server](https://discord.gg/mMRrZQW) or [Reddit Community](https://www.reddit.com/r/manim). If you would like to submit a bug report or feature request, please open an issue.
+Server](https://www.manim.community/discord/) or [Reddit Community](https://www.reddit.com/r/manim). If you would like to submit a bug report or feature request, please open an issue.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <a href="http://choosealicense.com/licenses/mit/"><img src="https://img.shields.io/badge/license-MIT-red.svg?style=flat" alt="MIT License"></a>
     <a href="https://www.reddit.com/r/manim/"><img src="https://img.shields.io/reddit/subreddit-subscribers/manim.svg?color=orange&label=reddit&logo=reddit" alt="Reddit" href=></a>
     <a href="https://twitter.com/manim_community/"><img src="https://img.shields.io/twitter/url/https/twitter.com/cloudposse.svg?style=social&label=Follow%20%40manim_community" alt="Twitter">
-    <a href="https://discord.gg/mMRrZQW"><img src="https://img.shields.io/discord/581738731934056449.svg?label=discord&color=yellow&logo=discord" alt="Discord"></a>
+    <a href="https://www.manim.community/discord/"><img src="https://img.shields.io/discord/581738731934056449.svg?label=discord&color=yellow&logo=discord" alt="Discord"></a>
     <a href="https://github.com/psf/black"><img src="https://img.shields.io/badge/code%20style-black-000000.svg" alt="Code style: black">
     <a href="https://docs.manim.community/"><img src="https://readthedocs.org/projects/manimce/badge/?version=latest" alt="Documentation Status"></a>
     <a href="https://pepy.tech/project/manim"><img src="https://pepy.tech/badge/manim/month?" alt="Downloads"> </a>

--- a/docs/source/contributing/testing.rst
+++ b/docs/source/contributing/testing.rst
@@ -304,4 +304,4 @@ look like this:
     }
 
 If you have any questions, please don't hesitate to ask on `Discord
-<https://discord.gg/mMRrZQW>`_, in your pull request, or in an issue.
+<https://www.manim.community/discord/>`_, in your pull request, or in an issue.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,7 +22,7 @@ information here will make it easier for newcomers to get started using
 
     We are curious to see the awesome projects you build using this library, feel
     free to share your projects with us `on Twitter <https://twitter.com/manim_community>`_,
-    `Reddit <https://www.reddit.com/r/manim/>`_, or via `Discord <https://discord.gg/mMRrZQW>`_.
+    `Reddit <https://www.reddit.com/r/manim/>`_, or via `Discord <https://www.manim.community/discord/>`_.
 
     In case you publish your work made with Manim, we would appreciate if you
     add a link to `our homepage <https://www.manim.community>`_ or

--- a/docs/source/installation/plugins.rst
+++ b/docs/source/installation/plugins.rst
@@ -95,7 +95,7 @@ Creating Plugins
 ****************
 Plugins are intended to extend Manim's core functionality. If you aren't sure
 whether a feature should be included in Manim's core, feel free to ask over
-on the `Discord server <https://discord.gg/mMRrZQW>`_. Visit
+on the `Discord server <https://www.manim.community/discord/>`_. Visit
 `manim-plugintemplate <https://pypi.org/project/manim-plugintemplate/>`_
 on PyPI.org which serves as an in-depth tutorial for creating plugins.
 

--- a/docs/source/installation/troubleshooting.rst
+++ b/docs/source/installation/troubleshooting.rst
@@ -6,7 +6,7 @@ List of known installation problems.
 ``pip install manim`` fails when installing manimpango?
 -------------------------------------------------------
 Most likely this means that pip was not able to use our pre-built wheels
-of ``manimpango``. Let us know (via our `Discord <https://discord.gg/mMRrZQW>`_
+of ``manimpango``. Let us know (via our `Discord <https://www.manim.community/discord/>`_
 or by opening a
 `new issue on GitHub <https://github.com/ManimCommunity/ManimPango/issues/new>`_)
 which architecture you would like to see supported, and we'll see what we

--- a/docs/source/reporting_bugs.rst
+++ b/docs/source/reporting_bugs.rst
@@ -10,7 +10,7 @@ steps:
 
 2. Search for other users who may have had similar issues in the
    past. Search the repository's `issues page <https://github.com/ManimCommunity/manim/issues>`_ (don't forget to search closed
-   issues), bring it up on our `Discord server <https://discord.gg/mMRrZQW>`_, use sites like StackOverflow, and exercise
+   issues), bring it up on our `Discord server <https://www.manim.community/discord/>`_, use sites like StackOverflow, and exercise
    your best Google practices.  If you can't find anything helpful, then go to
    the next step.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ isort = "^5.8.0"
 "Bug Tracker" = "https://github.com/ManimCommunity/manim/issues"
 "Changelog" = "https://docs.manim.community/en/stable/changelog.html"
 "Twitter" = "https://twitter.com/manim_community"
-"Discord" = "https://discord.gg/mMRrZQW"
+"Discord" = "https://www.manim.community/discord/"
 
 [tool.poetry.dev-dependencies.black]
 version = "^20.8b1"


### PR DESCRIPTION
## Changelog / Overview
Replaced the old https://discord.gg/mMRrZQW to https://www.manim.community/discord/ in the docs
<!--changelog-start-->

<!--changelog-end-->

## Motivation
The contributors can find and access the right discord link.

## Explanation for Changes
updated docs with the new discord links

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [x] My new functions/classes either have a docstring or are private
- [x] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] My new documentation builds, looks correctly formatted, and adds no additional build warnings

<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [x] The PR title is descriptive enough
- [x] The PR is labeled correctly
- [x] The changelog entry is completed if necessary
- [x] Newly added functions/classes either have a docstring or are private
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
