### PR TITLE
Update docs to use t_range instead of t_min and t_max in ParametricFunction

### DIFF
--- a/manim/mobject/functions.py
+++ b/manim/mobject/functions.py
@@ -25,7 +25,7 @@ class ParametricFunction(VMobject):
                 return np.array((np.sin(2 * t), np.sin(3 * t), 0))
 
             def construct(self):
-                func = ParametricFunction(self.func, t_max = TAU, fill_opacity=0).set_color(RED)
+                func = ParametricFunction(self.func, t_range = [0, TAU, 0.01], fill_opacity=0).set_color(RED)
                 self.add(func.scale(3))
 
     .. manim:: ThreeDParametricSpring
@@ -38,7 +38,7 @@ class ParametricFunction(VMobject):
                         1.2 * np.cos(u),
                         1.2 * np.sin(u),
                         u * 0.05
-                    ]), color=RED, t_min=-3 * TAU, t_max=5 * TAU,
+                    ]), color=RED, t_range = np.array([-3*TAU, 5*TAU, 0.01])
                 ).set_shade_in_3d(True)
                 axes = ThreeDAxes()
                 self.add(axes, curve1)

--- a/manim/mobject/functions.py
+++ b/manim/mobject/functions.py
@@ -25,7 +25,7 @@ class ParametricFunction(VMobject):
                 return np.array((np.sin(2 * t), np.sin(3 * t), 0))
 
             def construct(self):
-                func = ParametricFunction(self.func, t_range = [0, TAU, 0.01], fill_opacity=0).set_color(RED)
+                func = ParametricFunction(self.func, t_range = np.array([0, TAU]), fill_opacity=0).set_color(RED)
                 self.add(func.scale(3))
 
     .. manim:: ThreeDParametricSpring


### PR DESCRIPTION
`ParametricFunction` no longer uses `t_min` and `t_max` for defining the parameter's range. This PR fixes the remaining references to that old syntax in the documentation.

Fixes #1515 

## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->

<!--changelog-end-->


## Checklist
- [X] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [X] I have written a descriptive PR title (see top of PR template for examples)
- [X] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [X] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->

<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
