### PR TITLE
Improved handling of substring isolation within sqrt, and fixed a bug with transform_mismatch for the matching shape transforms

### DIFF
--- a/manim/animation/transform_matching_parts.py
+++ b/manim/animation/transform_matching_parts.py
@@ -121,8 +121,10 @@ class TransformMatchingAbstractBase(AnimationGroup):
             fade_target.add(target_map[key])
 
         if transform_mismatches:
-            anims.append(Transform(fade_source.copy(), fade_target, **kwargs))
-        if fade_transform_mismatches:
+            if "replace_mobject_with_target_in_scene" not in kwargs:
+                kwargs["replace_mobject_with_target_in_scene"] = True
+            anims.append(Transform(fade_source, fade_target, **kwargs))
+        elif fade_transform_mismatches:
             anims.append(FadeTransformPieces(fade_source, fade_target, **kwargs))
         else:
             anims.append(FadeOut(fade_source, target_position=fade_target, **kwargs))

--- a/manim/mobject/svg/tex_mobject.py
+++ b/manim/mobject/svg/tex_mobject.py
@@ -287,7 +287,7 @@ class SingleStringMathTex(SVGMobject):
         return result
 
     def modify_special_strings(self, tex):
-        tex = self.remove_stray_braces(tex)
+        tex = tex.strip()
         should_add_filler = reduce(
             op.or_,
             [
@@ -296,12 +296,14 @@ class SingleStringMathTex(SVGMobject):
                 tex == "\\overline",
                 # Make sure sqrt has overbar
                 tex == "\\sqrt",
+                tex == "\\sqrt{",
                 # Need to add blank subscript or superscript
                 tex.endswith("_"),
                 tex.endswith("^"),
                 tex.endswith("dot"),
             ],
         )
+
         if should_add_filler:
             filler = "{\\quad}"
             tex += filler
@@ -324,6 +326,8 @@ class SingleStringMathTex(SVGMobject):
         if num_lefts != num_rights:
             tex = tex.replace("\\left", "\\big")
             tex = tex.replace("\\right", "\\big")
+
+        tex = self.remove_stray_braces(tex)
 
         for context in ["array"]:
             begin_in = ("\\begin{%s}" % context) in tex


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->

This PR ensures that if `\sqrt` is rendered (e.g. by using substring isolation), a dummy argument is added such that the root including its overline is rendered. Fixes #1525.

<!--changelog-start-->

<!--changelog-end-->

## Explanation for Changes

If substring isolation lead to `\sqrt` or `\sqrt{}` being rendered, the resulting curve is missing the overline (and thus contributes one curve element less than it should). Practically, this leads to the last curve in the full expression not being rendered.

With this change, the situation of `\sqrt{` is explicitly handled as a special case, transforming it to `\sqrt{{\quad}}`.

<!-- How do your changes improve the library? -->


## Testing Status
Tested locally that the snippet from #1525 renders correctly here.

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
