### PR TITLE
Don't use deprecated methods in deprecation.py

### DIFF
--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -363,7 +363,7 @@ def deprecated_params(
         params = []
 
     # Construct params list
-    params = re.split("[,\s]+", params) if isinstance(params, str) else list(params)
+    params = re.split(r"[,\s]+", params) if isinstance(params, str) else list(params)
 
     # Add params which are only implicitly given via redirections
     if redirections is None:
@@ -372,7 +372,7 @@ def deprecated_params(
         if isinstance(redirector, tuple):
             params.append(redirector[0])
         else:
-            params.extend(inspect.getargspec(redirector).args)
+            params.extend(list(inspect.signature(redirector).parameters))
     # Keep ordering of params so that warning message is consistently the same
     # This will also help pass unit testing
     params = list(dict.fromkeys(params))

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -423,7 +423,7 @@ def deprecated_params(
                 if old_param in used:
                     kwargs[new_param] = kwargs.pop(old_param)
             else:
-                redirector_params = inspect.getargspec(redirector).args
+                redirector_params = list(inspect.signature(redirector).parameters)
                 redirector_args = {}
                 for redirector_param in redirector_params:
                     if redirector_param in used:


### PR DESCRIPTION
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->

<!--changelog-end-->

- And fix a missing r-string there
- Use `inspect.signature` rather than `inspect.getargspec`.

## Motivation
There were warning there when running pytest, fixing that.

## Explanation for Changes
Fix some warning.

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [x] The PR title is descriptive enough
- [x] The PR is labeled correctly
- [x] The changelog entry is completed if necessary
- [x] Newly added functions/classes either have a docstring or are private
- [x] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
