### PR TITLE
Update VGroup to support item assignment (#1530)

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1541,6 +1541,32 @@ class VGroup(VMobject):
     def __isub__(self, vmobject):
         return self.remove(vmobject)
 
+    def __setitem__(self, key: int, value: Union[VMobject, typing.Sequence[VMobject]]):
+        """Override the [] operator for item assignment.
+
+        Parameters
+        ----------
+        key
+            The index of the submobject to be assigned
+        value
+            The vmobject value to assign to the key
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        Normal usage::
+
+            >>> vgroup = VGroup(VMobject())
+            >>> new_obj = VMobject()
+            >>> vgroup[0] = new_obj
+        """
+        if not all(isinstance(m, VMobject) for m in value):
+            raise TypeError("All submobjects must be of type VMobject")
+        self.submobjects[key] = value
+
 
 class VDict(VMobject):
     """A VGroup-like class, also offering submobject access by

--- a/tests/test_vectorized_mobject.py
+++ b/tests/test_vectorized_mobject.py
@@ -174,3 +174,33 @@ def test_vdict_remove():
     assert len(obj.submob_dict) == 0
     with pytest.raises(KeyError):
         obj.remove("a")
+
+
+def test_vgroup_supports_item_assigment():
+    """Test VGroup supports array-like assignment for VMObjects"""
+    a = VMobject()
+    b = VMobject()
+    vgroup = VGroup(a)
+    assert vgroup[0] == a
+    vgroup[0] = b
+    assert vgroup[0] == b
+    assert len(vgroup) == 1
+
+
+def test_vgroup_item_assignment_at_correct_position():
+    """Test VGroup item-assignment adds to correct position for VMObjects"""
+    n_items = 10
+    vgroup = VGroup()
+    for i in range(n_items):
+        vgroup.add(VMobject())
+    new_obj = VMobject()
+    vgroup[6] = new_obj
+    assert vgroup[6] == new_obj
+    assert len(vgroup) == n_items
+
+
+def test_vgroup_item_assignment_only_allows_vmobjects():
+    """Test VGroup item-assignment raises TypeError when invalid type is passed"""
+    vgroup = VGroup(VMobject())
+    with pytest.raises(TypeError, match="All submobjects must be of type VMobject"):
+        vgroup[0] = "invalid object"


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
Support indexed item-assignment for VGroup
<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->
Easier item assignment for VGroups
## Explanation for Changes
<!-- How do your changes improve the library? -->
Currently VGroups act like immutable collections such as tuples. This change will allow them to act more like a list allowing item assignment at an index such as:

`vgroup[2] = vmobj`

## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->

## Further Comments
<!-- Optional: any further comments that might be useful for reviewers. -->

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [x] My new functions/classes either have a docstring or are private
- [x] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
