### PR TITLE
Declare *.npz *.wav *.png as binary in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,10 @@
 * text eol=lf
 *.bat  text eol=crlf
 
+# Denote all files that are truly binary and should not be modified
+*.npz binary
+*.png binary
+*.wav binary
+
 manim/grpc/gen/** linguist-generated=true
 


### PR DESCRIPTION
## Changelog / Overview
<!--changelog-start-->

<!--changelog-end-->
On, https://github.com/ManimCommunity/manim/pull/1535 I marked all files as LF line ending, which caused some problems as git try to convert binary files also to LF which is problematic and confusing pre-commit ci. Now, in this PR all the binary files are declared as binary files to avoid this problem.

## Motivation
Fixes pre-commit CI bot and issues reported on discord about weird files added to commit history. 

## Explanation for Changes

## Testing Status

## Further Comments

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
