### PR TITLE
Add extra notes for TeX compilation errors

### DIFF
--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -8,6 +8,8 @@
 
 import hashlib
 import os
+import re
+import unicodedata
 from pathlib import Path
 
 from .. import config, logger
@@ -136,6 +138,22 @@ def tex_compilation_command(tex_compiler, output_format, tex_file, tex_dir):
     return " ".join(commands)
 
 
+def insight_inputenc_error(match):
+    code_point = chr(int(match[1], 16))
+    name = unicodedata.name(code_point)
+    yield "TexTemplate does not support character '{}' (U+{})".format(name, match[1])
+    yield "See the documentation for manim.mobject.svg.tex_mobject for details on using a custom TexTemplate"
+
+
+# used by compile_tex; maps regexp to function offering additional insights
+LATEX_ERROR_INSIGHTS = [
+    (
+        r"inputenc Error: Unicode character (?:.*) \(U\+([0-9a-fA-F]+)\)",
+        insight_inputenc_error,
+    ),
+]
+
+
 def compile_tex(tex_file, tex_compiler, output_format):
     """Compiles a tex_file into a .dvi or a .xdv or a .pdf
 
@@ -177,11 +195,11 @@ def compile_tex(tex_file, tex_compiler, output_format):
                 if error_pos:
                     with open(tex_file, "r") as g:
                         tex = g.readlines()
-                        logger.error("LaTeX compilation error! LaTeX reports:")
+                        logger.error("LaTeX compilation error: {log[error_pos][2:])}")
                         for log_index in error_pos:
                             index_line = log_index
-                            CONTENT = (
-                                f"{log[log_index][2:]}Here is the tex content:\n\n"
+                            context = (
+                                f"Context for error:\n\n"
                             )
 
                             # Find where the line of the error is indicated in the log file
@@ -199,12 +217,19 @@ def compile_tex(tex_file, tex_compiler, output_format):
                                 environment -= 1
 
                             # Print the entire environment including its end
-                            while not tex_lines[environment - 1].startswith("\\end"):
-                                CONTENT += tex_lines[environment]
+                            while not tex[environment - 1].startswith("\\end"):
+                                context += tex[environment]
                                 if environment == tex_index:
-                                    CONTENT += "^\n"
+                                    context += "^ this line\n"
                                 environment += 1
-                            logger.error(CONTENT)
+                            logger.error(context)
+
+                        # add insight for errors
+                        for prog, get_insight in LATEX_ERROR_INSIGHTS:
+                            match = re.search(prog, ''.join(log[log_index:index_line]))
+                            if match is not None:
+                                for insight in get_insight(match):
+                                    logger.info(insight)
 
             raise ValueError(
                 f"{tex_compiler} error converting to"

--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -198,9 +198,7 @@ def compile_tex(tex_file, tex_compiler, output_format):
                         logger.error("LaTeX compilation error: {log[error_pos][2:])}")
                         for log_index in error_pos:
                             index_line = log_index
-                            context = (
-                                "Context for error:\n\n"
-                            )
+                            context = "Context for error:\n\n"
 
                             # Find where the line of the error is indicated in the log file
                             while not log[index_line].startswith("l."):
@@ -226,7 +224,7 @@ def compile_tex(tex_file, tex_compiler, output_format):
 
                         # add insight for errors
                         for prog, get_insight in LATEX_ERROR_INSIGHTS:
-                            match = re.search(prog, ''.join(log[log_index:index_line]))
+                            match = re.search(prog, "".join(log[log_index:index_line]))
                             if match is not None:
                                 for insight in get_insight(match):
                                     logger.info(insight)

--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -199,7 +199,7 @@ def compile_tex(tex_file, tex_compiler, output_format):
                         for log_index in error_pos:
                             index_line = log_index
                             context = (
-                                f"Context for error:\n\n"
+                                "Context for error:\n\n"
                             )
 
                             # Find where the line of the error is indicated in the log file


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->

## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
Add hint to use custom `TexTemplate` on TeX compilation errors
<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->
Mostly a response to #1543. LaTeX errors can be extremely hard to understand, and this adds a simple way for us to provide additional hints for common problems so users aren't completely lost when things break. The code also makes it relatively simple to add new notes for errors based upon regular expressions.

## Explanation for Changes
<!-- How do your changes improve the library? -->
This adds some code to `tex_file_writing.py` to allow adding additional info to contextualise LaTeX errors in a way that can help users solve them. Ultimately, it helps us point users to the solutions for common TeX problems when they experience them.

<!-- In the link above replace #### with you PR number.
You can also adjust the path to the module / class you worked on. This could look like adding
"/en/####/reference/manim.mobject.geometry.Arc.html" to the link for the Arc class.
Notice that the link will only work once the documentation is build which may take a few minutes.-->


## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->
Given the sample program from #1543:

```python
from manim import *

class TestKorean(Scene):
    def construct(self):
        Korean = Tex(r"테스트입니다") # it means "this is test"
        self.play(Write(Korean))

TestKorean().render()
```

This adds additional `INFO` messages to the output:

```
[05/23/21 21:59:27] ERROR    LaTeX compilation error! latex reports:                                                                      tex_file_writing.py:196
                    ERROR    ! Package inputenc Error: Unicode character 테 (U+D14C)                                                      tex_file_writing.py:208

                    ERROR    (inputenc)                not set up for use with LaTeX.                                                     tex_file_writing.py:208

                    ERROR                                                                                                                 tex_file_writing.py:208

                    ERROR    See the inputenc package documentation for explanation.                                                      tex_file_writing.py:208

                    ERROR    Type  H <return>  for immediate help.                                                                        tex_file_writing.py:208

                    ERROR     ...                                                                                                         tex_file_writing.py:208

                    ERROR                                                                                                                 tex_file_writing.py:208

                    ERROR    l.27 테                                                                                                      tex_file_writing.py:208

                    INFO     TexTemplate does not support character 'HANGUL SYLLABLE TE' (U+D14C)                                         tex_file_writing.py:216
                    INFO     See the documentation for manim.mobject.svg.tex_mobject for details on using a custom TexTemplate            tex_file_writing.py:216
```

(before it just showed the `ERROR` messages)

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [x] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
