### PR TITLE
Output errors to stderr

### DIFF
--- a/manim/_config/__init__.py
+++ b/manim/_config/__init__.py
@@ -10,6 +10,7 @@ from .utils import ManimConfig, ManimFrame, make_config_parser
 __all__ = [
     "logger",
     "console",
+    "error_console",
     "config",
     "frame",
     "tempconfig",
@@ -20,7 +21,10 @@ parser = make_config_parser()
 # The logger can be accessed from anywhere as manim.logger, or as
 # logging.getLogger("manim").  The console must be accessed as manim.console.
 # Throughout the codebase, use manim.console.print() instead of print().
-logger, console = make_logger(parser["logger"], parser["CLI"]["verbosity"])
+# Use error_console to print errors so that it outputs to stderr.
+logger, console, error_console = make_logger(
+    parser["logger"], parser["CLI"]["verbosity"]
+)
 # TODO: temporary to have a clean terminal output when working with PIL or matplotlib
 logging.getLogger("PIL").setLevel(logging.INFO)
 logging.getLogger("matplotlib").setLevel(logging.INFO)

--- a/manim/_config/logger_utils.py
+++ b/manim/_config/logger_utils.py
@@ -14,6 +14,7 @@ import copy
 import json
 import logging
 import os
+import sys
 import typing
 from typing import TYPE_CHECKING
 
@@ -62,9 +63,10 @@ def make_logger(
 
     Returns
     -------
-    :class:`logging.Logger`, :class:`rich.Console`
-        The manim logger and console.  Both use the theme returned by
-        :func:`parse_theme`
+    :class:`logging.Logger`, :class:`rich.Console`, :class:`rich.Console`
+        The manim logger and consoles. The first console outputs
+        to stdout, the second to stderr. All use the theme returned by
+        :func:`parse_theme`.
 
     See Also
     --------
@@ -80,6 +82,9 @@ def make_logger(
     theme = parse_theme(parser)
     console = Console(theme=theme)
 
+    # With rich 9.5.0+ we could pass stderr=True instead
+    error_console = Console(theme=theme, file=sys.stderr)
+
     # set the rich handler
     RichHandler.KEYWORDS = HIGHLIGHTED_KEYWORDS
     rich_handler = RichHandler(
@@ -91,7 +96,7 @@ def make_logger(
     logger.addHandler(rich_handler)
     logger.setLevel(verbosity)
 
-    return logger, console
+    return logger, console, error_console
 
 
 def parse_theme(parser: configparser.ConfigParser) -> Theme:

--- a/manim/cli/render/commands.py
+++ b/manim/cli/render/commands.py
@@ -14,7 +14,7 @@ import click
 import cloup
 import requests
 
-from ... import __version__, config, console, logger
+from ... import __version__, config, console, error_console, logger
 from ...constants import CONTEXT_SETTINGS, EPILOG
 from ...utils.module_ops import scene_classes_from_file
 from .ease_of_access_options import ease_of_access_options
@@ -134,7 +134,8 @@ def render(
                     else:
                         break
             except Exception:
-                console.print_exception()
+                error_console.print_exception()
+                sys.exit(1)
     elif config.renderer == "webgl":
         try:
             from manim.grpc.impl import frame_server_impl
@@ -147,14 +148,16 @@ def render(
                 "Dependencies for the WebGL render are missing. Run "
                 "pip install manim[webgl_renderer] to install them."
             )
-            console.print_exception()
+            error_console.print_exception()
+            sys.exit(1)
     else:
         for SceneClass in scene_classes_from_file(file):
             try:
                 scene = SceneClass()
                 scene.render()
             except Exception:
-                console.print_exception()
+                error_console.print_exception()
+                sys.exit(1)
 
     if config.notify_outdated_version:
         manim_info_url = "https://pypi.org/pypi/manim/json"

--- a/tests/test_logging/basic_scenes_error.py
+++ b/tests/test_logging/basic_scenes_error.py
@@ -1,0 +1,8 @@
+from manim import *
+
+# This module is intended to raise an error.
+
+
+class Error(Scene):
+    def construct(self):
+        raise Exception("An error has occured")

--- a/tests/test_logging/basic_scenes_error.py
+++ b/tests/test_logging/basic_scenes_error.py
@@ -5,4 +5,4 @@ from manim import *
 
 class Error(Scene):
     def construct(self):
-        raise Exception("An error has occured")
+        raise Exception("An error has occurred")

--- a/tests/test_logging/test_logging.py
+++ b/tests/test_logging/test_logging.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 from pathlib import Path
 
 from ..utils.commands import capture
@@ -56,11 +55,11 @@ def test_logging_when_scene_is_not_specified(tmp_path, python_version):
     assert exitcode == 0, err
 
 
-def test_error_logging(tmp_path):
+def test_error_logging(tmp_path, python_version):
     path_error_scene = Path("tests/test_logging/basic_scenes_error.py")
 
     command = [
-        sys.executable,
+        python_version,
         "-m",
         "manim",
         "-ql",

--- a/tests/test_logging/test_logging.py
+++ b/tests/test_logging/test_logging.py
@@ -1,7 +1,6 @@
 import os
 import re
 import sys
-
 from pathlib import Path
 
 from ..utils.commands import capture

--- a/tests/test_logging/test_logging.py
+++ b/tests/test_logging/test_logging.py
@@ -1,5 +1,8 @@
 import os
 import re
+import sys
+
+from pathlib import Path
 
 from ..utils.commands import capture
 from ..utils.logging_tester import *
@@ -52,3 +55,20 @@ def test_logging_when_scene_is_not_specified(tmp_path, python_version):
     ]
     _, err, exitcode = capture(command)
     assert exitcode == 0, err
+
+
+def test_error_logging(tmp_path):
+    path_error_scene = Path("tests/test_logging/basic_scenes_error.py")
+
+    command = [
+        sys.executable,
+        "-m",
+        "manim",
+        "-ql",
+        "--media_dir",
+        str(tmp_path),
+        str(path_error_scene),
+    ]
+
+    _, err, exitcode = capture(command)
+    assert exitcode != 0 and len(err) > 0


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
<!--changelog-end-->
- Added `error_console` that is the same as `console` but outputs to stderr.
- Made it so an exit code of 1 is outputted when an error occurs instead of always outputting 0.

## Motivation
<!-- In what way do your changes improve the library? -->
Errors should be outputted to stderr, which is particularly important for the DiscordManimator bot.

Additionally, since we always outputted an exit code of 0, a good chunk of our tests just always passed no matter what. Thankfully after fixing that all the tests still passed.

## Explanation for Changes
<!-- How do your changes improve the library? -->
I make an `error_console` object that's the same as `console` but outputs to `sys.stderr`. With rich 9.5.0+ we could pass `stderr=True` instead, but passing `file=sys.stderr` is [functionally equivalent](https://github.com/willmcgugan/rich/blob/22e95c9b10219eed0e679508348fe880477c7415/rich/console.py#L708).

For the exit code, after `error_console.print_exception()` I do `sys.exit(1)`. I looked to see if click had anything special for this purpose but [it didn't seem so](https://github.com/pallets/click/issues/747).

## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->
Added a test that tests both that the exit code isn't 0 and that errors are outputted to stderr. All tests pass and docs build correctly locally.

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [x] My new functions/classes either have a docstring or are private
- [x] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
