### PR TITLE
OpenGL implement xfail tests for comparing opengl (metaclass) against cairo

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,11 +11,11 @@
 import pytest
 from _pytest.doctest import DoctestItem
 
-from manim import config, tempconfig
-
 
 @pytest.fixture(autouse=True)
 def temp_media_dir(tmpdir, monkeypatch, request):
+    from manim import config, tempconfig
+
     if isinstance(request.node, DoctestItem):
         monkeypatch.chdir(tmpdir)
         yield tmpdir

--- a/manim/__init__.py
+++ b/manim/__init__.py
@@ -32,6 +32,10 @@ for i, arg in enumerate(sys.argv):
     elif arg == "--use_webgl_renderer":
         config.renderer = "webgl"
 
+from tests.conftest import OPENGL
+
+if OPENGL:
+    config.renderer = "opengl"
 
 from .animation.animation import *
 from .animation.composition import *

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,10 +17,22 @@ def pytest_addoption(parser):
         default=False,
         help="Will show a visual comparison if a graphical unit test fails.",
     )
+    parser.addoption(
+        "--opengl",
+        action="store_true",
+        default=False,
+        help="Enable testing in opengl mode",
+    )
+
+
+OPENGL = False
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "skip_end_to_end: mark test as end_to_end test")
+
+    global OPENGL
+    OPENGL = config.getoption("--opengl")
 
 
 def pytest_collection_modifyitems(config, items):
@@ -51,3 +63,8 @@ def reset_cfg_file():
     yield
     with open(cfgfilepath, "w") as cfgfile:
         cfgfile.write(original)
+
+
+@pytest.fixture
+def opengl(request):
+    return request.config.getoption("opengl")

--- a/tests/test_graphical_units/test_opengl.py
+++ b/tests/test_graphical_units/test_opengl.py
@@ -2,6 +2,7 @@ import pytest
 
 from manim import *
 from manim.opengl import *
+from tests.test_graphical_units import test_geometry
 
 from ..utils.GraphicalUnitTester import GraphicalUnitTester
 from ..utils.testing_utils import get_scenes_to_test
@@ -24,3 +25,34 @@ def test_scene(scene_to_test, tmpdir, show_diff):
         GraphicalUnitTester(scene_to_test[1], MODULE_NAME, tmpdir, rgb_atol=1.01).test(
             show_diff=show_diff
         )
+
+
+modules_to_test = [test_geometry]
+
+for module in modules_to_test:
+    name = module.MODULE_NAME
+    scenes = get_scenes_to_test(module.__name__)
+
+    @pytest.mark.xfail
+    @pytest.mark.parametrize(
+        "scene_to_test",
+        scenes,
+        indirect=False,
+        ids=map(lambda s: s[1].__name__, scenes),
+    )
+    def test_opengl_scene(scene_to_test: Scene, tmpdir, show_diff, opengl):
+        class wrapped_scene(scene_to_test[1]):
+            def construct(self):
+                super().construct()
+                self.wait()
+
+        wrapped_scene.__name__ = scene_to_test[1].__name__
+
+        GraphicalUnitTester(
+            wrapped_scene,
+            name,
+            tmpdir,
+            rgb_atol=50,
+            opengl_enabled=opengl,
+            opengl_test=True,
+        ).test(show_diff=show_diff)

--- a/tests/test_graphical_units/test_opengl.py
+++ b/tests/test_graphical_units/test_opengl.py
@@ -41,6 +41,11 @@ for module in modules_to_test:
         ids=map(lambda s: s[1].__name__, scenes),
     )
     def test_opengl_scene(scene_to_test: Scene, tmpdir, show_diff, opengl):
+        # must add a wait() command to end of scene
+        #  this is a temporary workaround until image
+        #  rendering is supported in OpenGL, since
+        #  currently, if there are no animations,
+        #  the result is an empty image
         class wrapped_scene(scene_to_test[1]):
             def construct(self):
                 super().construct()

--- a/tests/test_scene_rendering/conftest.py
+++ b/tests/test_scene_rendering/conftest.py
@@ -2,8 +2,6 @@ from pathlib import Path
 
 import pytest
 
-from manim import config, tempconfig
-
 
 @pytest.fixture
 def manim_cfg_file():
@@ -17,6 +15,8 @@ def simple_scenes_path():
 
 @pytest.fixture
 def using_temp_config(tmpdir):
+    from manim import config, tempconfig
+
     """Standard fixture that makes tests use a standard_config.cfg with a temp dir."""
     with tempconfig(config.digest_file(Path(__file__).parent / "standard_config.cfg")):
         config.media_dir = tmpdir
@@ -25,6 +25,8 @@ def using_temp_config(tmpdir):
 
 @pytest.fixture
 def disabling_caching():
+    from manim import tempconfig
+
     with tempconfig({"disable_caching": True}):
         yield
 

--- a/tests/utils/GraphicalUnitTester.py
+++ b/tests/utils/GraphicalUnitTester.py
@@ -29,7 +29,18 @@ class GraphicalUnitTester:
         The scene tested
     """
 
-    def __init__(self, scene_class, module_tested, tmpdir, rgb_atol=0):
+    def __init__(
+        self,
+        scene_class,
+        module_tested,
+        tmpdir,
+        rgb_atol=0,
+        opengl_test=False,
+        opengl_enabled=True,
+    ):
+        self.opengl_test = opengl_test
+        self.opengl_enabled = opengl_enabled
+
         # Disable the the logs, (--quiet is broken) TODO
         logging.disable(logging.CRITICAL)
         tests_directory = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -117,6 +128,9 @@ class GraphicalUnitTester:
         plt.savefig(f"{self.scene}.png")
 
     def test(self, show_diff=False):
+        if self.opengl_test and not self.opengl_enabled:
+            return
+
         """Compare pre-rendered frame to the frame rendered during the test."""
         frame_data = self.scene.renderer.get_frame()
         expected_frame_data = self._load_data()


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
Add --opengl flag to pytest which runs pytest in OpenGL mode. Implement xtests for geometry.py which run test_geometry.py with metaclasses when the --opengl flag is enabled (and otherwise xpass).
<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->
With many incoming implementations of metaclasses, and exactly one test for OpenGL, there is a clear need to introduce testing. 

## Explanation for Changes
<!-- How do your changes improve the library? -->
This PR introduces xtests which run opengl rendering of existing graphical tests against existing control data (rendered in cairo). With sufficiently high `rgb_atol` (currently set to 50), this is useful in the following ways:

- Identifying bugs in the opengl implementation
- Quantifying exactly where opengl's rendering differs significantly from cairos (such as in issue [1529](https://github.com/ManimCommunity/manim/issues/1529))
- (As OpenGL implementation becomes more stable) Ensuring nothing has broken unexpectedly

## Usage

To run the new tests and get a report:

```
pytest tests/test_graphical_units/test_opengl.py --opengl -rx
```

Then for example, say that `tests/test_graphical_units/test_opengl.py::test_opengl_scene[LineTest]` fails (which it does, at the moment). You can then compare diffs with:

```
pytest tests/test_graphical_units/test_opengl.py::test_opengl_scene[LineTest] --show_diff --opengl
```

Which results in the following: (bug fixed in #1593)

![image](https://user-images.githubusercontent.com/16108792/120045104-369f0180-bfdd-11eb-8e87-2f225c067bce.png)

Hopefully you can see how this can be useful!

<!-- For PRs introducing new features, please adjust
the link below to reference the docs of your feature. -->
[Documentation Reference](https://manimce--####.org.readthedocs.build)
<!-- In the link above replace #### with you PR number.
You can also adjust the path to the module / class you worked on. This could look like adding
"/en/####/reference/manim.mobject.geometry.Arc.html" to the link for the Arc class.
Notice that the link will only work once the documentation is build which may take a few minutes.-->

## Further Comments
<!-- Optional: any further comments that might be useful for reviewers. -->
Documentation has not been written. If it seems people are interested in moving forward with this PR, I will be happy to fill in the documentation!

## Checklist
- [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [ ] I have written a descriptive PR title (see top of PR template for examples)
- [ ] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
