### PR TITLE
Fix indexing for non-whitespace tex arg separator

### DIFF
--- a/manim/mobject/svg/tex_mobject.py
+++ b/manim/mobject/svg/tex_mobject.py
@@ -500,7 +500,9 @@ class MathTex(SingleStringMathTex):
                 tex_template=self.tex_template,
             )
             num_submobs = len(sub_tex_mob.submobjects)
-            new_index = curr_index + num_submobs
+            new_index = (
+                curr_index + num_submobs + len("".join(self.arg_separator.split()))
+            )
             if num_submobs == 0:
                 # For cases like empty tex_strings, we want the corresponding
                 # part of the whole MathTex to be a VectorizedPoint

--- a/tests/test_texmobject.py
+++ b/tests/test_texmobject.py
@@ -27,3 +27,48 @@ def test_double_braces_testing(text_input, length_sub):
 def test_tex():
     Tex("The horse does not eat cucumber salad.")
     assert Path(config.media_dir, "Tex", "983949cac5bdd272.svg").exists()
+
+
+def test_tex_whitespace_arg():
+    """Check that correct number of submobjects are created per string with whitespace separator"""
+    separator = "\t"
+    str_part_1 = "Hello"
+    str_part_2 = "world"
+    str_part_3 = "It is"
+    str_part_4 = "me!"
+    tex = Tex(str_part_1, str_part_2, str_part_3, str_part_4, arg_separator=separator)
+    assert len(tex) == 4
+    assert len(tex[0]) == len("".join((str_part_1 + separator).split()))
+    assert len(tex[1]) == len("".join((str_part_2 + separator).split()))
+    assert len(tex[2]) == len("".join((str_part_3 + separator).split()))
+    assert len(tex[3]) == len("".join(str_part_4.split()))
+
+
+def test_tex_non_whitespace_arg():
+    """Check that correct number of submobjects are created per string with non_whitespace characters"""
+    separator = ","
+    str_part_1 = "Hello"
+    str_part_2 = "world"
+    str_part_3 = "It is"
+    str_part_4 = "me!"
+    tex = Tex(str_part_1, str_part_2, str_part_3, str_part_4, arg_separator=separator)
+    assert len(tex) == 4
+    assert len(tex[0]) == len("".join((str_part_1 + separator).split()))
+    assert len(tex[1]) == len("".join((str_part_2 + separator).split()))
+    assert len(tex[2]) == len("".join((str_part_3 + separator).split()))
+    assert len(tex[3]) == len("".join(str_part_4.split()))
+
+
+def test_tex_white_space_and_non_whitespace_args():
+    """Check that correct number of submobjects are created per string when mixing characters with whitespace"""
+    separator = ", \n . \t\t"
+    str_part_1 = "Hello"
+    str_part_2 = "world"
+    str_part_3 = "It is"
+    str_part_4 = "me!"
+    tex = Tex(str_part_1, str_part_2, str_part_3, str_part_4, arg_separator=separator)
+    assert len(tex) == 4
+    assert len(tex[0]) == len("".join((str_part_1 + separator).split()))
+    assert len(tex[1]) == len("".join((str_part_2 + separator).split()))
+    assert len(tex[2]) == len("".join((str_part_3 + separator).split()))
+    assert len(tex[3]) == len("".join(str_part_4.split()))


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
Fixes #1568

Fix issue when setting the arg_separator of a Tex object as a non-whitespace character(s). The method `break_up_by_substrings(self)` was not accounting for the separator when setting the index. 
<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->
Fixes Tex arg-separator functionality allowing non-whitespace characters to be used
## Explanation for Changes
<!-- How do your changes improve the library? -->
Fixes bug with Tex arg-separator
<!-- For PRs introducing new features, please adjust
the link below to reference the docs of your feature. -->
<!-- In the link above replace #### with you PR number.
You can also adjust the path to the module / class you worked on. This could look like adding
"/en/####/reference/manim.mobject.geometry.Arc.html" to the link for the Arc class.
Notice that the link will only work once the documentation is build which may take a few minutes.-->


## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->
Tested locally with different arg-separators including separators containing multiple characters
## Further Comments
<!-- Optional: any further comments that might be useful for reviewers. -->

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [x] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
