### PR TITLE
Fix latex error summary

### DIFF
--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -195,7 +195,7 @@ def compile_tex(tex_file, tex_compiler, output_format):
                 if error_pos:
                     with open(tex_file, "r") as g:
                         tex = g.readlines()
-                        logger.error("LaTeX compilation error: {log[error_pos][2:])}")
+                        logger.error(f"LaTeX compilation error: {log[error_pos[0]][2:]}")
                         for log_index in error_pos:
                             index_line = log_index
                             context = "Context for error:\n\n"

--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -197,7 +197,7 @@ def compile_tex(tex_file, tex_compiler, output_format):
                         tex = g.readlines()
                         for log_index in error_pos:
                             logger.error(
-                                f"LaTeX compilation error: {log[error_pos[0]][2:]}"
+                                f"LaTeX compilation error: {log[log_index][2:]}"
                             )
                             index_line = log_index
                             context = "Context for error:\n\n"

--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -195,10 +195,10 @@ def compile_tex(tex_file, tex_compiler, output_format):
                 if error_pos:
                     with open(tex_file, "r") as g:
                         tex = g.readlines()
-                        logger.error(
-                            f"LaTeX compilation error: {log[error_pos[0]][2:]}"
-                        )
                         for log_index in error_pos:
+                            logger.error(
+                                f"LaTeX compilation error: {log[error_pos[0]][2:]}"
+                            )
                             index_line = log_index
                             context = "Context for error:\n\n"
 

--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -195,7 +195,9 @@ def compile_tex(tex_file, tex_compiler, output_format):
                 if error_pos:
                     with open(tex_file, "r") as g:
                         tex = g.readlines()
-                        logger.error(f"LaTeX compilation error: {log[error_pos[0]][2:]}")
+                        logger.error(
+                            f"LaTeX compilation error: {log[error_pos[0]][2:]}"
+                        )
                         for log_index in error_pos:
                             index_line = log_index
                             context = "Context for error:\n\n"


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
Fix f-string formatting introduced by #1564, which earlier produced a hardcoded value instead of the error summary 
<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->

Apparently, #1564 added extra log info for LaTeX errors, but for some reason, this line was added which prints `LaTeX compilation error: {log[error_pos][2:])}` instead of the actual error as I assume was intended:
https://github.com/ManimCommunity/manim/blob/e85599e9829460948ac63f620a9bc737e8b7a5c7/manim/utils/tex_file_writing.py#L198

With my change, it looks like this now:
![image](https://user-images.githubusercontent.com/65204531/120597954-51e99100-c463-11eb-9013-eb4b1af62663.png)


## Explanation for Changes
<!-- How do your changes improve the library? -->
Uses the first element of the `error_pos` list and adds the `f` modifier to the start of the string.

<!-- For PRs introducing new features, please adjust
the link below to reference the docs of your feature. -->
[Documentation Reference](https://manimce--####.org.readthedocs.build)
<!-- In the link above replace #### with you PR number.
You can also adjust the path to the module / class you worked on. This could look like adding
"/en/####/reference/manim.mobject.geometry.Arc.html" to the link for the Arc class.
Notice that the link will only work once the documentation is build which may take a few minutes.-->


## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->

```py
class TexErrorAttempt(Scene):
    def construct(self):
        self.add(Tex("\\int_x^x"))
```

![image](https://user-images.githubusercontent.com/65204531/120598306-bdcbf980-c463-11eb-9cf4-a99a678ee4bd.png)

## Further Comments
<!-- Optional: any further comments that might be useful for reviewers. -->
Alternatively, this could have been done by setting `error_pos` to the 0th index of its current value.

## Checklist
- [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [ ] I have written a descriptive PR title (see top of PR template for examples)
- [ ] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
