### PR TITLE
Revert default template and add new templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,3 @@
----
-name: Default pull request
-about: The default template for general purpose pull requests.
----
-
 <!--
 Thanks for your contribution to ManimCommunity!
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,6 @@
 ---
 name: Default pull request
-title: ""
-labels: ""
-assignees: ''
+about: The default template for general purpose pull requests.
 ---
 
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,32 @@
+---
+name: Bug fix
+about: For bug fixes
+labels: bugfix
+---
+
+<!-- Thank you for contributing to ManimCommunity!
+Before filling in the details, ensure:
+- The title of your PR gives a descriptive summary to end-users. Some examples:
+  - Fixed last animations not running to completion
+  - Added gradient support and documentation for SVG files
+-->
+
+## Changelog 
+<!-- Optional: more descriptive changelog entry than just the title for the upcoming
+release. Write RST between the following start and end comments.-->
+<!--changelog-start-->
+<!--changelog-end-->
+
+## Summary of Changes
+
+
+## Checklist
+- [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
+- [ ] I have written a descriptive PR title (see top of PR template for examples)
+- [ ] I have added a test case to prevent software regression
+
+<!-- Do not modify the lines below. These are for the reviewers of your PR -->
+## Reviewer Checklist
+- [ ] The PR title is descriptive enough
+- [ ] The PR is labeled appropriately
+- [ ] Regression test(s) are implemented

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,9 +1,3 @@
----
-name: Bug fix
-about: For bug fixes
-labels: bugfix
----
-
 <!-- Thank you for contributing to ManimCommunity!
 Before filling in the details, ensure:
 - The title of your PR gives a descriptive summary to end-users. Some examples:

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,9 +1,3 @@
----
-name: Documentation
-about: Contributions to our documentation https://docs.manim.community
-labels: documentation
----
-
 <!-- Thank you for contributing to ManimCommunity!
 Before filling in the details, ensure:
 - The title of your PR gives a descriptive summary to end-users. Some examples:

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,0 +1,30 @@
+---
+name: Documentation
+about: Contributions to our documentation https://docs.manim.community
+labels: documentation
+---
+
+<!-- Thank you for contributing to ManimCommunity!
+Before filling in the details, ensure:
+- The title of your PR gives a descriptive summary to end-users. Some examples:
+  - Fixed last animations not running to completion
+  - Added gradient support and documentation for SVG files
+-->
+## Summary of Changes
+
+## Changelog 
+<!-- Optional: more descriptive changelog entry than just the title for the upcoming
+release. Write RST between the following start and end comments.-->
+<!--changelog-start-->
+<!--changelog-end-->
+
+## Checklist
+- [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
+- [ ] I have written a descriptive PR title (see top of PR template for examples)
+- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
+
+<!-- Do not modify the lines below. These are for the reviewers of your PR -->
+## Reviewer Checklist
+- [ ] The PR title is descriptive enough
+- [ ] The PR is labeled appropriately
+- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings

--- a/.github/PULL_REQUEST_TEMPLATE/hackathon.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hackathon.md
@@ -1,9 +1,3 @@
----
-name: Hackathon 2021
-about: For participation in the Manim Community Hackathon
-labels: hackathon
----
-
 Thanks for your contribution for the manim community hackathon!
 
 Please make sure your pull request has a meaningful title.

--- a/.github/PULL_REQUEST_TEMPLATE/hackathon.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hackathon.md
@@ -1,8 +1,7 @@
 ---
 name: Hackathon 2021
-title: ""
+about: For participation in the Manim Community Hackathon
 labels: hackathon
-assignees: ''
 ---
 
 Thanks for your contribution for the manim community hackathon!


### PR DESCRIPTION
Unfortunately it appears GitHub PRs don't have the same functionality as GitHub Issues when it comes to creating a selection from the list of available templates. It appears GitHub requires us to use query parameters following a `?` in the URI as per this SO post and the article it refers to.

This PR reverts our default template and includes some new templates which can be referred to by adding the parmeter: `?template=X.md` where X represents one of the template files in the `.github/PULL_REQUEST_TEMPLATE/` directory. 

Additionally, there are some other query parameters worth mentioning; in particular, labels. Here's the [article](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/about-automation-for-issues-and-pull-requests-with-query-parameters#supported-query-parameters) for reference.