### PR TITLE
Add support for webm and jupyter transparency

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -1166,7 +1166,6 @@ class ManimConfig(MutableMapping):
         doc="Enable GUI interaction.",
     )
 
-
     def get_dir(self, key: str, **kwargs: str) -> Path:
         """Resolve a config option that stores a directory.
 

--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -875,6 +875,10 @@ class ManimConfig(MutableMapping):
             val,
             [None, "png", "gif", "mp4", "mov", "webm"],
         )
+        if self.format == "webm":
+            logging.getLogger("manim").warning(
+                "Output format set as webm, this can be slower than other formats"
+            )
 
     ffmpeg_loglevel = property(
         lambda self: self._d["ffmpeg_loglevel"],

--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -846,7 +846,7 @@ class ManimConfig(MutableMapping):
 
     @property
     def format(self):
-        """File format; "png", "gif", "mp4", or "mov"."""
+        """File format; "png", "gif", "mp4", "webm" or "mov"."""
         return self._d["format"]
 
     @format.setter
@@ -855,7 +855,7 @@ class ManimConfig(MutableMapping):
         self._set_from_list(
             "format",
             val,
-            [None, "png", "gif", "mp4", "mov"],
+            [None, "png", "gif", "mp4", "mov", "webm"],
         )
 
     ffmpeg_loglevel = property(
@@ -990,9 +990,9 @@ class ManimConfig(MutableMapping):
     movie_file_extension = property(
         lambda self: self._d["movie_file_extension"],
         lambda self, val: self._set_from_list(
-            "movie_file_extension", val, [".mp4", ".mov"]
+            "movie_file_extension", val, [".mp4", ".mov", ".webm"]
         ),
-        doc="Either .mp4 or .mov (no flag).",
+        doc="Either .mp4, .webm or .mov (no flag).",
     )
 
     background_opacity = property(
@@ -1038,12 +1038,11 @@ class ManimConfig(MutableMapping):
     def transparent(self, val: bool) -> None:
         if val:
             self.png_mode = "RGBA"
-            self.movie_file_extension = ".mov"
             self.background_opacity = 0.0
         else:
             self.png_mode = "RGB"
-            self.movie_file_extension = ".mp4"
             self.background_opacity = 1.0
+        self.resolve_movie_file_extension(val)
 
     @property
     def dry_run(self):
@@ -1128,6 +1127,14 @@ class ManimConfig(MutableMapping):
         lambda self, val: self._set_dir("media_dir", val),
         doc="Main output directory.  See :meth:`ManimConfig.get_dir`.",
     )
+
+    def resolve_movie_file_extension(self, is_transparent):
+        if is_transparent:
+            self.movie_file_extension = ".webm" if self.format == "webm" else ".mov"
+        elif self.format == "webm":
+            self.movie_file_extension = ".webm"
+        else:
+            self.movie_file_extension = ".mp4"
 
     def get_dir(self, key: str, **kwargs: str) -> Path:
         """Resolve a config option that stores a directory.

--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -1010,7 +1010,7 @@ class ManimConfig(MutableMapping):
         lambda self, val: self._set_from_list(
             "movie_file_extension", val, [".mp4", ".mov", ".webm"]
         ),
-        doc="Either .mp4, .webm or .mov (no flag).",
+        doc="Either .mp4, .webm or .mov.",
     )
 
     background_opacity = property(
@@ -1151,6 +1151,8 @@ class ManimConfig(MutableMapping):
             self.movie_file_extension = ".webm" if self.format == "webm" else ".mov"
         elif self.format == "webm":
             self.movie_file_extension = ".webm"
+        elif self.format == "mov":
+            self.movie_file_extension = ".mov"
         else:
             self.movie_file_extension = ".mp4"
 

--- a/manim/cli/render/render_options.py
+++ b/manim/cli/render/render_options.py
@@ -52,7 +52,7 @@ render_options = option_group(
     ),
     option(
         "--format",
-        type=click.Choice(["png", "gif", "mp4"], case_sensitive=False),
+        type=click.Choice(["png", "gif", "mp4", "webm"], case_sensitive=False),
     ),
     option("-s", "--save_last_frame", is_flag=True),
     option(

--- a/manim/cli/render/render_options.py
+++ b/manim/cli/render/render_options.py
@@ -49,7 +49,7 @@ render_options = option_group(
     ),
     option(
         "--format",
-        type=click.Choice(["png", "gif", "mp4", "webm"], case_sensitive=False),
+        type=click.Choice(["png", "gif", "mp4", "webm", "mov"], case_sensitive=False),
     ),
     option("-s", "--save_last_frame", is_flag=True),
     option(

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -23,6 +23,7 @@ from ..utils.file_ops import (
     guarantee_existence,
     is_gif_format,
     is_png_format,
+    is_webm_format,
     modify_atime,
     write_to_movie,
 )
@@ -392,7 +393,10 @@ class SceneFileWriter(object):
         ]
         if config.renderer == "opengl":
             command += ["-vf", "vflip"]
-        if config["transparent"]:
+        if is_webm_format():
+            command += ["-vcodec", "libvpx-vp9", "-auto-alt-ref", "0"]
+        # .mov format
+        elif config["transparent"]:
             command += ["-vcodec", "qtrle"]
         else:
             command += ["-vcodec", "libx264", "-pix_fmt", "yuv420p"]

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -22,7 +22,6 @@ from ..utils.file_ops import (
     add_version_before_extension,
     guarantee_existence,
     is_gif_format,
-    is_mov_format,
     is_png_format,
     is_webm_format,
     modify_atime,

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -22,6 +22,7 @@ from ..utils.file_ops import (
     add_version_before_extension,
     guarantee_existence,
     is_gif_format,
+    is_mov_format,
     is_png_format,
     is_webm_format,
     modify_atime,

--- a/manim/utils/file_ops.py
+++ b/manim/utils/file_ops.py
@@ -9,6 +9,8 @@ __all__ = [
     "is_mp4_format",
     "is_gif_format",
     "is_png_format",
+    "is_webm_format",
+    "is_mov_format",
     "write_to_movie",
 ]
 
@@ -63,6 +65,19 @@ def is_webm_format() -> bool:
     return config["format"] == "webm"
 
 
+def is_mov_format() -> bool:
+    """
+    Determines if output format is .mov
+
+    Returns
+    -------
+    class:`bool`
+        ``True`` if format is set as mov
+
+    """
+    return config["format"] == "mov"
+
+
 def is_png_format() -> bool:
     """
     Determines if output format is .png
@@ -94,6 +109,7 @@ def write_to_movie() -> bool:
         or is_mp4_format()
         or is_gif_format()
         or is_webm_format()
+        or is_mov_format()
     )
 
 

--- a/manim/utils/file_ops.py
+++ b/manim/utils/file_ops.py
@@ -50,6 +50,19 @@ def is_gif_format() -> bool:
     return config["format"] == "gif"
 
 
+def is_webm_format() -> bool:
+    """
+    Determines if output format is .webm
+
+    Returns
+    -------
+    class:`bool`
+        ``True`` if format is set as webm
+
+    """
+    return config["format"] == "webm"
+
+
 def is_png_format() -> bool:
     """
     Determines if output format is .png
@@ -76,7 +89,12 @@ def write_to_movie() -> bool:
     """
     if is_png_format():
         return False
-    return config["write_to_movie"] or is_mp4_format() or is_gif_format()
+    return (
+        config["write_to_movie"]
+        or is_mp4_format()
+        or is_gif_format()
+        or is_webm_format()
+    )
 
 
 def add_extension_if_not_present(file_name, extension):

--- a/manim/utils/ipython_magic.py
+++ b/manim/utils/ipython_magic.py
@@ -102,7 +102,7 @@ else:
             if not len(args) or "-h" in args or "--help" in args or "--version" in args:
                 main(args, standalone_mode=False, prog_name="manim")
                 return
-            modified_args = ["--jupyter"] + args[:-1] + [""] + [args[-1]]
+            modified_args = self.add_additional_args(args)
             args = main(modified_args, standalone_mode=False, prog_name="manim")
             with tempconfig(local_ns.get("config", {})):
                 config.digest_args(args)
@@ -135,6 +135,13 @@ else:
                         embed=video_embed,
                     )
                 )
+
+        def add_additional_args(self, args):
+            additional_args = ["--jupyter"]
+            # Use webm to support transparency
+            if "-t" in args and "--format" not in args:
+                additional_args += ["--format", "webm"]
+            return additional_args + args[:-1] + [""] + [args[-1]]
 
 
 def _video_hash(path):

--- a/tests/test_scene_rendering/test_cli_flags.py
+++ b/tests/test_scene_rendering/test_cli_flags.py
@@ -363,3 +363,72 @@ def test_images_are_created_when_png_format_set(
 
     expected_png_path = tmp_path / "images" / "simple_scenes" / "SquareToCircle0.png"
     assert expected_png_path.exists(), "png file not found at " + str(expected_png_path)
+
+
+@pytest.mark.slow
+def test_webm_format_output(tmp_path, manim_cfg_file, simple_scenes_path):
+    """Test only webm created when --format webm is set"""
+    scene_name = "SquareToCircle"
+    command = [
+        sys.executable,
+        "-m",
+        "manim",
+        "-ql",
+        "--media_dir",
+        str(tmp_path),
+        "--format",
+        "webm",
+        simple_scenes_path,
+        scene_name,
+    ]
+    out, err, exit_code = capture(command)
+    assert exit_code == 0, err
+
+    unexpected_mp4_path = (
+        tmp_path / "videos" / "simple_scenes" / "480p15" / "SquareToCircle.mp4"
+    )
+    assert not unexpected_mp4_path.exists(), "unexpected mp4 file found at " + str(
+        unexpected_mp4_path
+    )
+
+    expected_webm_path = (
+        tmp_path / "videos" / "simple_scenes" / "480p15" / "SquareToCircle.webm"
+    )
+    assert expected_webm_path.exists(), "expected webm file not found at " + str(
+        expected_webm_path
+    )
+
+
+@pytest.mark.slow
+def test_default_format_output_for_transparent_flag(
+    tmp_path, manim_cfg_file, simple_scenes_path
+):
+    """Test .mov is created by default when transparent flag is set"""
+    scene_name = "SquareToCircle"
+    command = [
+        sys.executable,
+        "-m",
+        "manim",
+        "-ql",
+        "--media_dir",
+        str(tmp_path),
+        "-t",
+        simple_scenes_path,
+        scene_name,
+    ]
+    out, err, exit_code = capture(command)
+    assert exit_code == 0, err
+
+    unexpected_webm_path = (
+        tmp_path / "videos" / "simple_scenes" / "480p15" / "SquareToCircle.webm"
+    )
+    assert not unexpected_webm_path.exists(), "unexpected webm file found at " + str(
+        unexpected_webm_path
+    )
+
+    expected_mov_path = (
+        tmp_path / "videos" / "simple_scenes" / "480p15" / "SquareToCircle.mov"
+    )
+    assert expected_mov_path.exists(), "expected .mov file not found at " + str(
+        expected_mov_path
+    )

--- a/tests/test_scene_rendering/test_cli_flags.py
+++ b/tests/test_scene_rendering/test_cli_flags.py
@@ -432,3 +432,37 @@ def test_default_format_output_for_transparent_flag(
     assert expected_mov_path.exists(), "expected .mov file not found at " + str(
         expected_mov_path
     )
+
+
+@pytest.mark.slow
+def test_mov_can_be_set_as_output_format(tmp_path, manim_cfg_file, simple_scenes_path):
+    """Test .mov is created by when set using --format mov arg"""
+    scene_name = "SquareToCircle"
+    command = [
+        sys.executable,
+        "-m",
+        "manim",
+        "-ql",
+        "--media_dir",
+        str(tmp_path),
+        "--format",
+        "mov",
+        simple_scenes_path,
+        scene_name,
+    ]
+    out, err, exit_code = capture(command)
+    assert exit_code == 0, err
+
+    unexpected_webm_path = (
+        tmp_path / "videos" / "simple_scenes" / "480p15" / "SquareToCircle.webm"
+    )
+    assert not unexpected_webm_path.exists(), "unexpected webm file found at " + str(
+        unexpected_webm_path
+    )
+
+    expected_mov_path = (
+        tmp_path / "videos" / "simple_scenes" / "480p15" / "SquareToCircle.mov"
+    )
+    assert expected_mov_path.exists(), "expected .mov file not found at " + str(
+        expected_mov_path
+    )


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
- Add webm support via --format argument
- Handle transparency in jupyter by using webm format instead of mov
<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->
Currently .mov isn't supported in the main browsers and we currently have no other options that support transparency. Webm
has alpha channel support and more support in browsers for web rendering
## Explanation for Changes
<!-- How do your changes improve the library? -->
Allows webm to be used as an alternative format that supports alpha channels to .mov 
<!-- For PRs introducing new features, please adjust
the link below to reference the docs of your feature. -->
<!-- In the link above replace #### with you PR number.
You can also adjust the path to the module / class you worked on. This could look like adding
"/en/####/reference/manim.mobject.geometry.Arc.html" to the link for the Arc class.
Notice that the link will only work once the documentation is build which may take a few minutes.-->


## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->
Added tests for the new formats and checks that -t flag still defaults to .mov when `--format webm` is not specified. Currently I haven't been able to find a good way of testing video outputs with jupyter, we can't use a temporary path because the ManimMagic class only uses relative paths:

```py
local_path = Path(config["output_file"]).relative_to(Path.cwd())
```

## Further Comments
<!-- Optional: any further comments that might be useful for reviewers. -->

## Checklist
- [X] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [X] I have written a descriptive PR title (see top of PR template for examples)
- [X] I have written a changelog entry for the PR or deem it unnecessary
- [X] My new functions/classes either have a docstring or are private
- [X] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [X] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [x] The PR title is descriptive enough
- [x] The PR is labeled correctly
- [x] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
