### PR TITLE
Determine decimal places default by step size

### DIFF
--- a/manim/mobject/coordinate_systems.py
+++ b/manim/mobject/coordinate_systems.py
@@ -71,7 +71,7 @@ class CoordinateSystem:
     ):
         self.dimension = dimension
 
-        default_step = 1.0
+        default_step = 1
         if x_range is None:
             x_range = [
                 round(-config["frame_x_radius"]),

--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -53,7 +53,8 @@ class NumberLine(Line):
     tip_height : :class:`float`
         The height of the tip.
     include_numbers : :class:`bool`
-        Determines whether numbers are added to tick marks.
+        Determines whether numbers are added to tick marks. The number of decimal places is determined
+        by the step size, this default can be overridden by ``decimal_number_config``.
     label_direction : Union[:class:`list`, :class:`numpy.ndarray`]
         The specific position to which number mobjects are added on the line.
     line_to_number_buff : :class:`float`
@@ -104,11 +105,6 @@ class NumberLine(Line):
         **kwargs
     ):
         # avoid mutable arguments in defaults
-        if decimal_number_config is None:
-            decimal_number_config = {
-                "num_decimal_places": 0,
-                "font_size": 24,
-            }  # font_size does nothing
         if numbers_to_exclude is None:
             numbers_to_exclude = []
         if numbers_with_elongated_ticks is None:
@@ -118,13 +114,19 @@ class NumberLine(Line):
             x_range = [
                 round(-config["frame_x_radius"]),
                 round(config["frame_x_radius"]),
-                1.0,
+                1,
             ]
         elif len(x_range) == 2:
             # adds x_step if not specified. not sure how to feel about this. a user can't know default without peeking at source code
             x_range = [*x_range, 1]
 
         self.x_min, self.x_max, self.x_step = x_range
+        if decimal_number_config is None:
+            decimal_number_config = {
+                "num_decimal_places": self.decimal_places_from_step(),
+                "font_size": 24,
+            }  # font_size does nothing
+
         self.length = length
         self.unit_size = unit_size
         # ticks
@@ -299,6 +301,12 @@ class NumberLine(Line):
         self.add(numbers)
         self.numbers = numbers
         return numbers
+
+    def decimal_places_from_step(self):
+        step_as_str = str(self.x_step)
+        if "." not in step_as_str:
+            return 0
+        return len(step_as_str.split(".")[-1])
 
 
 class UnitInterval(NumberLine):

--- a/tests/test_number_line.py
+++ b/tests/test_number_line.py
@@ -10,3 +10,43 @@ def test_unit_vector():
     axis2 = NumberLine(width=12, x_min=-2, x_max=5)
     for axis in (axis1, axis2):
         assert np.linalg.norm(axis.get_unit_vector()) == axis.unit_size
+
+
+def test_decimal_determined_by_step():
+    """Checks that step size is considered when determining the number of decimal
+    places."""
+    axis = NumberLine(x_range=[-2, 2, 0.5])
+    expected_decimal_places = 1
+    actual_decimal_places = axis.decimal_number_config["num_decimal_places"]
+    assert actual_decimal_places == expected_decimal_places, (
+        "Expected 1 decimal place but got " + actual_decimal_places
+    )
+
+    axis2 = NumberLine(x_range=[-1, 1, 0.25])
+    expected_decimal_places = 2
+    actual_decimal_places = axis2.decimal_number_config["num_decimal_places"]
+    assert actual_decimal_places == expected_decimal_places, (
+        "Expected 1 decimal place but got " + actual_decimal_places
+    )
+
+
+def test_decimal_config_overrides_defaults():
+    """Checks that ``num_decimal_places`` is determined by step size and gets overridden by ``decimal_number_config``."""
+    axis = NumberLine(
+        x_range=[-2, 2, 0.5], decimal_number_config={"num_decimal_places": 0}
+    )
+    expected_decimal_places = 0
+    actual_decimal_places = axis.decimal_number_config["num_decimal_places"]
+    assert actual_decimal_places == expected_decimal_places, (
+        "Expected 1 decimal place but got " + actual_decimal_places
+    )
+
+
+def test_whole_numbers_step_size_default_to_0_decimal_places():
+    """Checks that ``num_decimal_places`` defaults to 0 when a whole number step size is passed."""
+    axis = NumberLine(x_range=[-2, 2, 1])
+    expected_decimal_places = 0
+    actual_decimal_places = axis.decimal_number_config["num_decimal_places"]
+    assert actual_decimal_places == expected_decimal_places, (
+        "Expected 1 decimal place but got " + actual_decimal_places
+    )


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
Fixes #1653 

Set default number of decimal places in NumberLine based on step size
<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->

It makes the NumberLine a bit more intuitive in determining what the user wants to do. If the user for example sets step size to 0.5, it is clear that they want their numbers to be at least to 1 decimal places. 

## Explanation for Changes
<!-- How do your changes improve the library? -->

These changes determine the default number of decimal places based on the step size, so the user doesn't need to manually set these. It doesn't impact the decimal config as the defaults set according to the step size can still be overridden by including the `decimal_number_config`

Taking the below code as an example:

```
class Example(Scene):

    def construct(self):
        axes = Axes(
            x_range=[-2, 2, 0.5],
            y_range=[-1, 1, 0.25],
            x_length=10,
            axis_config={"color": GREEN, "include_numbers": True},
            tips=False,
        )
        self.add(axes)
```

Currently it results in:

![Example_ManimCE_v0 6 0](https://user-images.githubusercontent.com/32387857/121515544-35aa9e80-c9e5-11eb-9092-41b6efaf0b78.png)


After these changes it will now show as:

![ForceDiagram_ManimCE_v0 6 0](https://user-images.githubusercontent.com/32387857/121515479-2297ce80-c9e5-11eb-9d08-d892693f78f8.png)


<!-- For PRs introducing new features, please adjust
the link below to reference the docs of your feature. -->
<!-- In the link above replace #### with you PR number.
You can also adjust the path to the module / class you worked on. This could look like adding
"/en/####/reference/manim.mobject.geometry.Arc.html" to the link for the Arc class.
Notice that the link will only work once the documentation is build which may take a few minutes.-->


## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->

## Further Comments
<!-- Optional: any further comments that might be useful for reviewers. -->

## Checklist
- [X] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [X] I have written a descriptive PR title (see top of PR template for examples)
- [X] I have written a changelog entry for the PR or deem it unnecessary
- [X] My new functions/classes either have a docstring or are private
- [X] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [X] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
