### PR TITLE
Fix: use weight instead of style for BOLD Text/MarkupText in docs

### DIFF
--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -361,7 +361,7 @@ class Text(SVGMobject):
                 chin = Text(
                     "見 角 言 谷  辛 辰 辵 邑 酉 釆 里!", t2c={"見 角 言": BLUE}
                 )  # works same as ``Text``.
-                mess = Text("Multi-Language", style=BOLD)
+                mess = Text("Multi-Language", weight=BOLD)
                 russ = Text("Здравствуйте मस नम म ", font="sans-serif")
                 hin = Text("नमस्ते", font="sans-serif")
                 arb = Text(
@@ -871,7 +871,7 @@ class MarkupText(SVGMobject):
                 chin = MarkupText(
                     '見 角 言 谷  辛 <span fgcolor="blue">辰 辵 邑</span> 酉 釆 里!'
                 )  # works as in ``Text``.
-                mess = MarkupText("Multi-Language", style=BOLD)
+                mess = MarkupText("Multi-Language", weight=BOLD)
                 russ = MarkupText("Здравствуйте मस नम म ", font="sans-serif")
                 hin = MarkupText("नमस्ते", font="sans-serif")
                 japanese = MarkupText("臂猿「黛比」帶著孩子", font="sans-serif")


### PR DESCRIPTION
## Changelog / Overview

As @jsonvillanueva pointed out in https://github.com/ManimCommunity/manim/pull/1652, there is currently a mistake in the examples for `Text` and `MarkupText` where the non-existent parameter `style = BOLD` is used instead of `weight = BOLD`.

This short PR fixes those mistakes.

[Documentation Reference (Text)](https://manimce--1673.org.readthedocs.build/en/1673/reference/manim.mobject.svg.text_mobject.Text.html)
[Documentation Reference (MarkupText)](https://manimce--1673.org.readthedocs.build/en/1673/reference/manim.mobject.svg.text_mobject.MarkupText.html) 


## Testing Status

Local tests pass.

## Checklist
- [X] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [X] I have written a descriptive PR title (see top of PR template for examples)
- [X] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [X] My new documentation builds, looks correctly formatted, and adds no additional build warnings


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
