### PR TITLE
Remove redundant warning in CLI parsing

### DIFF
--- a/manim/cli/render/commands.py
+++ b/manim/cli/render/commands.py
@@ -8,7 +8,6 @@ can specify options, and arguments for the render command.
 import json
 import sys
 from pathlib import Path
-from textwrap import dedent
 
 import click
 import cloup
@@ -42,27 +41,6 @@ def render(
 
     SCENES is an optional list of scenes in the file.
     """
-    for scene in args["scene_names"]:
-        if str(scene).startswith("-"):
-            logger.warning(
-                dedent(
-                    """\
-                Manim Community has moved to Click for the CLI.
-
-                This means that options in the CLI are provided BEFORE the positional
-                arguments for your FILE and SCENE(s):
-                `manim render [OPTIONS] [FILE] [SCENES]...`
-
-                For example:
-                New way - `manim -p -ql file.py SceneName1 SceneName2 ...`
-                Old way - `manim file.py SceneName1 SceneName2 ... -p -ql`
-
-                To see the help page for the new available options, run:
-                `manim render -h`
-                """
-                )
-            )
-            sys.exit()
 
     if args["use_opengl_renderer"]:
         logger.warning(


### PR DESCRIPTION
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
<!--changelog-end-->
Remove redundant warning in CLI parsing
There was a redundant warning about arguments parsing
which is never triggered.

## Motivation
Cleans code that is never used.

## Explanation for Changes
From https://github.com/ManimCommunity/manim/pull/1013 there were some changes after https://github.com/ManimCommunity/manim/pull/1013/commits/14fa079710bc99538834cfe7aca7c1509742dcf7 which actually fixed this issue but this warning simply remained and is removed in this PR>

[Documentation Reference](https://manimce--####.org.readthedocs.build)

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [x] My new functions/classes either have a docstring or are private
- [x] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [x] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [x] The PR title is descriptive enough
- [x] The PR is labeled correctly
- [x] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
