### PR TITLE
docs: remove reference of `--plugins`

### DIFF
--- a/docs/source/installation/plugins.rst
+++ b/docs/source/installation/plugins.rst
@@ -79,18 +79,6 @@ For specifying multiple plugins, command separated values must be used.
     [CLI]
     plugins = manim_rubikscube, manim_plugintemplate
 
-Enabling Plugins through CLI
-
-.. code-block:: bash
-
-    manim basic.py --plugins=manim_plugintemplate
-
-For multiple plugins
-
-.. code-block:: bash
-
-    manim basic.py --plugins=manim_rubikscube,manim_plugintemplate
-
 Creating Plugins
 ****************
 Plugins are intended to extend Manim's core functionality. If you aren't sure


### PR DESCRIPTION
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->

<!--changelog-end-->

docs: remove reference of `--plugins`
`--plugins` flag isn't implemented but it was mentioned in the
documentation. I have removed it.

## Motivation
Don't mention unimplemented things.

[Documentation Reference](https://manimce--####.org.readthedocs.build)

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title (see top of PR template for examples)
- [x] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
