### PR TITLE
Fix LinearTransformationScene crashing on second animation

### DIFF
--- a/manim/renderer/cairo_renderer.py
+++ b/manim/renderer/cairo_renderer.py
@@ -153,7 +153,7 @@ class CairoRenderer:
         """
         if self.skip_animations and not ignore_skipping:
             return
-        if mobjects is None:
+        if not mobjects:
             mobjects = list_update(
                 scene.mobjects,
                 scene.foreground_mobjects,

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -101,8 +101,8 @@ class Scene:
 
         self.animations = None
         self.stop_condition = None
-        self.moving_mobjects = None
-        self.static_mobjects = None
+        self.moving_mobjects = []
+        self.static_mobjects = []
         self.time_progression = None
         self.duration = None
         self.last_t = None
@@ -905,8 +905,8 @@ class Scene:
 
         self.last_t = 0
         self.stop_condition = None
-        self.moving_mobjects = None
-        self.static_mobjects = None
+        self.moving_mobjects = []
+        self.static_mobjects = []
 
         if not config.renderer == "opengl":
             if len(self.animations) == 1 and isinstance(self.animations[0], Wait):


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
Fixed LinearTransformationScene crashing on multiple animations
<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->
Calling `apply_matrix` multiple times would result in `TypeError: 'NoneType' object is not iterable` as the playing an animation would set `moving_mobjects` to None. This PR makes it default back to an empty list to allow multiple transformations

## Explanation for Changes
<!-- How do your changes improve the library? -->
Fixes #1715

Fixes error to allow multiple animations in LinearTransformationScene

<!-- For PRs introducing new features, please adjust
the link below to reference the docs of your feature. -->
<!-- In the link above replace #### with you PR number.
You can also adjust the path to the module / class you worked on. This could look like adding
"/en/####/reference/manim.mobject.geometry.Arc.html" to the link for the Arc class.
Notice that the link will only work once the documentation is build which may take a few minutes.-->


## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->
Tested locally with the code in the original issue:

```py
class LinearTransformationSceneExample(LinearTransformationScene):
    def construct(self):
        matrix = [[0, -1], [1, 0]]
        self.apply_matrix(matrix)
        self.wait()
        self.apply_inverse(matrix)
        self.wait()
```


https://user-images.githubusercontent.com/32387857/124031084-c83fcb80-d9ee-11eb-997a-cea8672b78a1.mp4



## Further Comments
<!-- Optional: any further comments that might be useful for reviewers. -->
As this change involved setting moving_mobjects and static_mobjects as an empty list instead of None, I also changed cairo renderer to expect None or an empty list, seemed fine but not sure if this could cause any issues, or in general if there is an issue with defaulting to an empty list.

## Checklist
- [X] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [X] I have written a descriptive PR title (see top of PR template for examples)
- [X] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [x] The PR title is descriptive enough
- [x] The PR is labeled correctly
- [x] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
