### PR TITLE
Fix :class:`~.DecimalNumber` not working properly when the number of digits changes

### DIFF
--- a/manim/mobject/numbers.py
+++ b/manim/mobject/numbers.py
@@ -190,7 +190,10 @@ class DecimalNumber(VMobject, metaclass=ConvertToOpenGL):
         new_decimal.scale(self[-1].height / new_decimal[-1].height)
         new_decimal.move_to(self, self.edge_to_fix)
         new_decimal.match_style(self)
-        self.become(new_decimal)
+        old_family = self.get_family()
+        self.set_submobjects(new_decimal.submobjects)
+        for mobj in old_family:
+            mobj.clear_points()
 
         self.number = number
         return self


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
Fixes #1761
<!--changelog-end-->


## Explanation for Changes
<!-- How do your changes improve the library? -->
PR #1585 introduced changes to `DecimalNumber` which turns out to be unsafe. This PR revert these changes while ensuring OpenGL compatibility.


## Checklist
- [ ] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [ ] I have written a descriptive PR title (see top of PR template for examples)
- [ ] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
