### PR TITLE
Fix oversized code window with opengl renderer

### DIFF
--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -476,6 +476,8 @@ class Text(SVGMobject):
         self.text = text
         if self.disable_ligatures:
             self.submobjects = [*self.gen_chars()]
+            if config.renderer == "opengl":
+                self.assemble_family()
         self.chars = self.get_group_class()(*self.submobjects)
         self.text = text_without_tabs.replace(" ", "").replace("\n", "")
         if config.renderer == "opengl":

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -475,9 +475,10 @@ class Text(SVGMobject):
         )
         self.text = text
         if self.disable_ligatures:
-            self.submobjects = [*self.gen_chars()]
             if config.renderer == "opengl":
-                self.assemble_family()
+                self.set_submobjects(self.gen_chars())
+            else:
+                self.submobjects = [*self.gen_chars()]
         self.chars = self.get_group_class()(*self.submobjects)
         self.text = text_without_tabs.replace(" ", "").replace("\n", "")
         if config.renderer == "opengl":


### PR DESCRIPTION
<!--
Thanks for your contribution to ManimCommunity!

Before filling in the details, ensure:
- Your local changes are up-to-date with ManimCommunity/manim
  
- The title of your PR gives a descriptive summary to end-users. Some examples:
  - Fixed last animations not running to completion
  - Added gradient support and documentation for SVG files
  Examples of what *NOT* to do:
  - "fixed that styling issue" - not descriptive enough
  - "fixed issue #XYZ" - end-user needs to do further research
-->
## Changelog / Overview
<!-- Optional (Recommended): a detailed overview of the PR for the upcoming
release's changelog entry. Useful for when the PR title isn't enough. 

DO NOT REMOVE THE FOLLOWING CHANGELOG LINES, EVEN IF YOU DON'T USE THEM.-->
<!--changelog-start-->
Fixed oversized Code window when using the opengl renderer
<!--changelog-end-->

## Motivation
<!-- In what way do your changes improve the library? -->
Fixes window that wasn't scaled correctly when using Code mobject

## Explanation for Changes
<!-- How do your changes improve the library? -->
Fixes #1834

When using `Code` mobject it sets the `disable_ligatures` flag on the `Text` mobject. When this happens it assigns to `self.submobjects`, this includes some additional `Dot` submobjects but when `self.get_family()` is called these additional objects are not included and so do not get scaled with the others. It wasn't an issue in cairo as it seems to get the family dynamically from the submobjects.

I am not sure if a better solution would be to call `assemble_family()` anytime there is an update to `submobjects`?

## Documentation Reference
<!-- Please include links to the affected documentation pages below. --> 


## Testing Status
<!-- Optional (Recommended): your computer specs and what tests you ran with
their results, if any. This section is also intended for other
testing-related comments. -->

Tested locally with with the below code and resulted in below output.

```py
class CodeFromString(Scene):
    def construct(self):
        code = '''from manim import Scene, Square

        class FadeInSquare(Scene):
            def construct(self):
                s = Square()
                self.play(FadeIn(s))
                self.play(s.animate.scale(2))
                self.wait()
        '''
        rendered_code = Code(code=code, tab_width=4, background="window",
                             language="Python", font="Monospace", scale_factor=0.3)
        self.add(rendered_code)

        self.interactive_embed()
```

<img width="633" alt="Screenshot 2021-07-30 at 17 07 36" src="https://user-images.githubusercontent.com/32387857/127681121-ebbad95a-e7de-4570-a7f9-d59af5821aba.png">


## Further Comments
<!-- Optional: any further comments that might be useful for reviewers. -->

## Checklist
- [X] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [X] I have written a descriptive PR title (see top of PR template for examples)
- [X] I have written a changelog entry for the PR or deem it unnecessary
- [ ] My new functions/classes either have a docstring or are private
- [ ] My new functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] My new documentation builds, looks correctly formatted, and adds no additional build warnings
<!-- Once again, thanks for contributing to ManimCommunity! -->


<!-- Do not modify the lines below. These are for the reviewers of your PR -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough
- [ ] The PR is labeled correctly
- [ ] The changelog entry is completed if necessary
- [ ] Newly added functions/classes either have a docstring or are private
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
