### PR TITLE
Allow to suspend and resume updating smoothly

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -44,6 +44,7 @@ from ..utils.color import (
 from ..utils.exceptions import MultiAnimationOverrideException
 from ..utils.iterables import list_update, remove_list_redundancies
 from ..utils.paths import straight_path
+from ..utils.rate_functions import linear
 from ..utils.simple_functions import get_parameters
 from ..utils.space_ops import (
     angle_between_vectors,


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Modification of `update`, `suspend_updating` and `resume_updating` functions of Mobjects to be able to suspend and resume updating smoothly instead of instantaneously.
Deletion of the attribute `updating_suspended` of Mobject.
Addition of the attributes `updating_speed` which represent the speed of the updater (0 for stopped, 1 for full speed, in between for intermediate speeds).
Addition of the attribute `updating_variation` which represent the acceleration of the updating (deceleration if negative).
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
When dealing with objects with updaters, I sometimes need to temporary suspend the animation to enhance a specific point for example. Until now, the only way was to use `my_object.suspend_updating()`, which interrupts the animation too abruptly. I wanted a way to better control this interruption.
With this PR, we are now able to do things like:
```py
my_object.suspend_updating()
my_object.suspend_updating(run_time=3)
my_object.suspend_updating(recursive=False, run_time=3)
my_object.suspend_updating(run_time=5, rate_func=smooth)
```
And of course the same parameters are usable with `resume_updating`.

https://user-images.githubusercontent.com/71326140/128544715-41f9c047-6e62-42de-9328-ef019427412b.mp4

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. --> 
https://docs.manim.community/en/stable/reference/manim.mobject.mobject.Mobject.html?highlight=suspend_updating#manim.mobject.mobject.Mobject.suspend_updating
https://docs.manim.community/en/stable/reference/manim.mobject.mobject.Mobject.html?highlight=suspend_updating#manim.mobject.mobject.Mobject.resume_updating
https://docs.manim.community/en/stable/reference/manim.mobject.mobject.Mobject.html?highlight=suspend_updating#manim.mobject.mobject.Mobject.update

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
I'm facing issues when the flag `--disable_caching` is not passed. It looks like the renderer doesn't make well the link between animations. I don't know how to fix this tho...
The issue is easily reproducible, run a scene with a smooth suspending of its updaters, then render it again with a changed `run_time` parameter (without passing the flag `--disable_caching`).

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
