### PR TITLE
Remove duplicated imports in some documentation examples

### DIFF
--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -327,7 +327,6 @@ class Graph(VMobject, metaclass=ConvertToOpenGL):
 
     .. manim:: Tree
 
-        from manim import *
         import networkx as nx
 
         class Tree(Scene):

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2417,7 +2417,10 @@ class Mobject:
     def sort(self, point_to_num_func=lambda p: p[0], submob_func=None):
         """Sorts the list of :attr:`submobjects` by a function defined by ``submob_func``."""
         if submob_func is None:
-            def submob_func(m): return point_to_num_func(m.get_center())
+
+            def submob_func(m):
+                return point_to_num_func(m.get_center())
+
         self.submobjects.sort(key=submob_func)
         return self
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2417,7 +2417,7 @@ class Mobject:
     def sort(self, point_to_num_func=lambda p: p[0], submob_func=None):
         """Sorts the list of :attr:`submobjects` by a function defined by ``submob_func``."""
         if submob_func is None:
-            submob_func = lambda m: point_to_num_func(m.get_center())
+            def submob_func(m): return point_to_num_func(m.get_center())
         self.submobjects.sort(key=submob_func)
         return self
 
@@ -2824,8 +2824,6 @@ def override_animate(method):
     --------
 
     .. manim:: AnimationOverrideExample
-
-        from manim import Circle, Scene, Create, Text, Uncreate, VGroup
 
         class CircleWithContent(VGroup):
             def __init__(self, content):

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2417,10 +2417,7 @@ class Mobject:
     def sort(self, point_to_num_func=lambda p: p[0], submob_func=None):
         """Sorts the list of :attr:`submobjects` by a function defined by ``submob_func``."""
         if submob_func is None:
-
-            def submob_func(m):
-                return point_to_num_func(m.get_center())
-
+            submob_func = lambda m: point_to_num_func(m.get_center())
         self.submobjects.sort(key=submob_func)
         return self
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->

Removed duplicate import.

<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

Checked all the docstrings of the files in */manim* that makeup reference manual. Removed the only redundant import. The other duplicate mentioned in the issue is necessary for the decorator @animation_override. There were no other unnecessary imports found.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. --> 

[Example Tree](https://docs.manim.community/en/stable/reference/manim.mobject.graph.Graph.html)

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
