### PR TITLE
Update an example to use .animate instead of ApplyMethod

### DIFF
--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -62,13 +62,13 @@ screen, simply call the :meth:`~.Scene.remove` method from the containing
 
 .. manim:: CreatingMobjects
 
-   class CreatingMobjects(Scene):
-       def construct(self):
-           circle = Circle()
-           self.add(circle)
-           self.wait(1)
-           self.remove(circle)
-           self.wait(1)
+    class CreatingMobjects(Scene):
+        def construct(self):
+            circle = Circle()
+            self.add(circle)
+            self.wait(1)
+            self.remove(circle)
+            self.wait(1)
 
 
 Placing mobjects
@@ -80,18 +80,18 @@ circle, a square, and a triangle:
 
 .. manim:: Shapes
 
-   class Shapes(Scene):
-       def construct(self):
-           circle = Circle()
-           square = Square()
-           triangle = Triangle()
+    class Shapes(Scene):
+        def construct(self):
+            circle = Circle()
+            square = Square()
+            triangle = Triangle()
 
-           circle.shift(LEFT)
-           square.shift(UP)
-           triangle.shift(RIGHT)
+            circle.shift(LEFT)
+            square.shift(UP)
+            triangle.shift(RIGHT)
 
-           self.add(circle, square, triangle)
-           self.wait(1)
+            self.add(circle, square, triangle)
+            self.wait(1)
 
 By default, mobjects are placed at the center of coordinates, or *origin*, when
 they are first created.  They are also given some default colors.  Further, the
@@ -111,21 +111,21 @@ There are many other possible ways to place mobjects on the screen, for example
 
 .. manim:: MobjectPlacement
 
-   class MobjectPlacement(Scene):
-       def construct(self):
-           circle = Circle()
-           square = Square()
-           triangle = Triangle()
+    class MobjectPlacement(Scene):
+        def construct(self):
+            circle = Circle()
+            square = Square()
+            triangle = Triangle()
 
-           # place the circle two units left from the origin
-           circle.move_to(LEFT * 2)
-           # place the square to the left of the circle
-           square.next_to(circle, LEFT)
-           # align the left border of the triangle to the left border of the circle
-           triangle.align_to(circle, LEFT)
+            # place the circle two units left from the origin
+            circle.move_to(LEFT * 2)
+            # place the square to the left of the circle
+            square.next_to(circle, LEFT)
+            # align the left border of the triangle to the left border of the circle
+            triangle.align_to(circle, LEFT)
 
-           self.add(circle, square, triangle)
-           self.wait(1)
+            self.add(circle, square, triangle)
+            self.wait(1)
 
 The :meth:`.move_to` method uses absolute units (measured relative to the
 ``ORIGIN``), while :meth:`.next_to` uses relative units (measured from the
@@ -139,14 +139,14 @@ bounding box around it.
 
          .. code-block:: python
 
-            square = Square()
-            square.shift(LEFT)
+             square = Square()
+             square.shift(LEFT)
 
          can be replaced by
 
          .. code-block:: python
 
-            square = Square().shift(LEFT)
+             square = Square().shift(LEFT)
 
          Technically, this is possible because most methods calls return the modified mobject.
 
@@ -158,18 +158,18 @@ The following scene changes the default aesthetics of the mobjects.
 
 .. manim:: MobjectStyling
 
-   class MobjectStyling(Scene):
-       def construct(self):
-           circle = Circle().shift(LEFT)
-           square = Square().shift(UP)
-           triangle = Triangle().shift(RIGHT)
+    class MobjectStyling(Scene):
+        def construct(self):
+            circle = Circle().shift(LEFT)
+            square = Square().shift(UP)
+            triangle = Triangle().shift(RIGHT)
 
-           circle.set_stroke(color=GREEN, width=20)
-           square.set_fill(YELLOW, opacity=1.0)
-           triangle.set_fill(PINK, opacity=0.5)
+            circle.set_stroke(color=GREEN, width=20)
+            square.set_fill(YELLOW, opacity=1.0)
+            triangle.set_fill(PINK, opacity=0.5)
 
-           self.add(circle, square, triangle)
-           self.wait(1)
+            self.add(circle, square, triangle)
+            self.wait(1)
 
 This scene uses two of the main functions that change the visual style of a
 mobject: :meth:`.set_stroke` and :meth:`.set_fill`.  The former changes the
@@ -193,18 +193,18 @@ previous section, except for exactly one line.
 
 .. manim:: MobjectZOrder
 
-   class MobjectZOrder(Scene):
-       def construct(self):
-           circle = Circle().shift(LEFT)
-           square = Square().shift(UP)
-           triangle = Triangle().shift(RIGHT)
+    class MobjectZOrder(Scene):
+        def construct(self):
+            circle = Circle().shift(LEFT)
+            square = Square().shift(UP)
+            triangle = Triangle().shift(RIGHT)
 
-           circle.set_stroke(color=GREEN, width=20)
-           square.set_fill(YELLOW, opacity=1.0)
-           triangle.set_fill(PINK, opacity=0.5)
+            circle.set_stroke(color=GREEN, width=20)
+            square.set_fill(YELLOW, opacity=1.0)
+            triangle.set_fill(PINK, opacity=0.5)
 
-           self.add(triangle, square, circle)
-           self.wait(1)
+            self.add(triangle, square, circle)
+            self.wait(1)
 
 The only difference here (besides the scene name) is the order in which the
 mobjects are added to the scene.  In ``MobjectStyling``, we added them as
@@ -225,21 +225,21 @@ your scene by calling the :meth:`~.Scene.play` method.
 
 .. manim:: SomeAnimations
 
-   class SomeAnimations(Scene):
-       def construct(self):
-           square = Square()
-           self.add(square)
+    class SomeAnimations(Scene):
+        def construct(self):
+            square = Square()
+            self.add(square)
 
-           # some animations display mobjects, ...
-           self.play(FadeIn(square))
+            # some animations display mobjects, ...
+            self.play(FadeIn(square))
 
-           # ... some move or rotate mobjects around...
-           self.play(Rotate(square, PI/4))
+            # ... some move or rotate mobjects around...
+            self.play(Rotate(square, PI/4))
 
-           # some animations remove mobjects from the screen
-           self.play(FadeOut(square))
+            # some animations remove mobjects from the screen
+            self.play(FadeOut(square))
 
-           self.wait(1)
+            self.wait(1)
 
 Put simply, animations are procedures that interpolate between two mobjects.
 For example, :code:`FadeIn(square)` starts with a fully transparent version of
@@ -286,12 +286,12 @@ Use the :code:`run_time` argument to control the duration.
 
 .. manim:: RunTime
 
-   class RunTime(Scene):
-       def construct(self):
-           square = Square()
-           self.add(square)
-           self.play(square.animate().shift(UP), run_time=3)
-           self.wait(1)
+    class RunTime(Scene):
+        def construct(self):
+            square = Square()
+            self.add(square)
+            self.play(square.animate().shift(UP), run_time=3)
+            self.wait(1)
 
 Creating a custom animation
 ===========================

--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -256,28 +256,25 @@ Animating methods
 
 Any property of a mobject that can be changed can be animated.  In fact, any
 method that changes a mobject's property can be used as an animation, through
-the use of :class:`.ApplyMethod`.
+the use of :meth:`.animate`.
 
-.. manim:: ApplyMethodExample
+.. manim:: AnimateExample
+    :ref_classes: Animation
 
-   class ApplyMethodExample(Scene):
-       def construct(self):
-           square = Square().set_fill(RED, opacity=1.0)
-           self.add(square)
+    class AnimateExample(Scene):
+        def construct(self):
+            square = Square().set_fill(RED, opacity=1.0)
+            self.add(square)
 
-           # animate the change of color
-           self.play(ApplyMethod(square.set_fill, WHITE))
-           self.wait(1)
+            # animate the change of color
+            self.play(square.animate().set_fill(WHITE))
+            self.wait(1)
 
-           # animate the change of position
-           self.play(ApplyMethod(square.shift, UP))
-           self.wait(1)
+            # animate the change of position
+            self.play(square.animate().shift(UP))
+            self.wait(1)
 
-:meth:`.ApplyMethod` receives one mandatory argument which is the method of the
-mobject to animate (e.g. :code:`square.set_fill` or :code:`square.shift`), and
-any number of optional arguments which are then passed to the method call.  For
-example, :code:`ApplyMethod(square.shift, UP)` executes
-:code:`square.shift(UP)`, but animates it instead of applying it immediately.
+:meth:`.animate` is a method of mobjects that will animate the function comes afterward.  For example, :code:`square.set_fill(WHITE)` sets the fill color of the square, while :code:`sqaure.animate().set_fill(WHITE)` animates this action.
 
 Animation run time
 ==================

--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -271,7 +271,7 @@ the use of :meth:`.animate`.
             self.wait(1)
 
             # animate the change of position and the rotation at the same time
-            self.play(square.animate().shift(UP).rotate(PI / 2))
+            self.play(square.animate().shift(UP).rotate(PI / 3))
             self.wait(1)
 
 :meth:`.animate` is a property of all mobjects that animates the methods that come 

--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -267,7 +267,7 @@ the use of :meth:`.animate`.
             self.add(square)
 
             # animate the change of color
-            self.play(square.animate().set_fill(WHITE))
+            self.play(square.animate.set_fill(WHITE))
             self.wait(1)
 
             # animate the change of position and the rotation at the same time

--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -290,7 +290,7 @@ Use the :code:`run_time` argument to control the duration.
        def construct(self):
            square = Square()
            self.add(square)
-	   self.play(ApplyMethod(square.shift, UP), run_time=3)
+	   self.play(square.animate().shift(UP), run_time=3)
 	   self.wait(1)
 
 Creating a custom animation

--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -274,7 +274,7 @@ the use of :meth:`.animate`.
             self.play(square.animate().shift(UP).rotate(PI / 2))
             self.wait(1)
 
-:meth:`.animate` is a method of mobjects that will animate methods that come 
+:meth:`.animate` is a property of all mobjects that animates the methods that come 
 afterward. For example, :code:`square.set_fill(WHITE)` sets the fill color of
 the square, while :code:`sqaure.animate().set_fill(WHITE)` animates this action.
 

--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -274,7 +274,9 @@ the use of :meth:`.animate`.
             self.play(square.animate().shift(UP))
             self.wait(1)
 
-:meth:`.animate` is a method of mobjects that will animate the function comes afterward.  For example, :code:`square.set_fill(WHITE)` sets the fill color of the square, while :code:`sqaure.animate().set_fill(WHITE)` animates this action.
+:meth:`.animate` is a method of mobjects that will animate the function comes
+afterward.  For example, :code:`square.set_fill(WHITE)` sets the fill color of
+the square, while :code:`sqaure.animate().set_fill(WHITE)` animates this action.
 
 Animation run time
 ==================

--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -271,7 +271,7 @@ the use of :meth:`.animate`.
             self.wait(1)
 
             # animate the change of position and the rotation at the same time
-            self.play(square.animate().shift(UP).rotate(PI / 3))
+            self.play(square.animate.shift(UP).rotate(PI / 3))
             self.wait(1)
 
 :meth:`.animate` is a property of all mobjects that animates the methods that come 

--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -276,7 +276,7 @@ the use of :meth:`.animate`.
 
 :meth:`.animate` is a property of all mobjects that animates the methods that come 
 afterward. For example, :code:`square.set_fill(WHITE)` sets the fill color of
-the square, while :code:`sqaure.animate().set_fill(WHITE)` animates this action.
+the square, while :code:`sqaure.animate.set_fill(WHITE)` animates this action.
 
 Animation run time
 ==================

--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -290,8 +290,8 @@ Use the :code:`run_time` argument to control the duration.
        def construct(self):
            square = Square()
            self.add(square)
-	   self.play(square.animate().shift(UP), run_time=3)
-	   self.wait(1)
+           self.play(square.animate().shift(UP), run_time=3)
+           self.wait(1)
 
 Creating a custom animation
 ===========================

--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -270,12 +270,12 @@ the use of :meth:`.animate`.
             self.play(square.animate().set_fill(WHITE))
             self.wait(1)
 
-            # animate the change of position
-            self.play(square.animate().shift(UP))
+            # animate the change of position and the rotation at the same time
+            self.play(square.animate().shift(UP).rotate(PI / 2))
             self.wait(1)
 
-:meth:`.animate` is a method of mobjects that will animate the function comes
-afterward.  For example, :code:`square.set_fill(WHITE)` sets the fill color of
+:meth:`.animate` is a method of mobjects that will animate methods that come 
+afterward. For example, :code:`square.set_fill(WHITE)` sets the fill color of
 the square, while :code:`sqaure.animate().set_fill(WHITE)` animates this action.
 
 Animation run time

--- a/docs/source/tutorials/building_blocks.rst
+++ b/docs/source/tutorials/building_blocks.rst
@@ -290,7 +290,7 @@ Use the :code:`run_time` argument to control the duration.
         def construct(self):
             square = Square()
             self.add(square)
-            self.play(square.animate().shift(UP), run_time=3)
+            self.play(square.animate.shift(UP), run_time=3)
             self.wait(1)
 
 Creating a custom animation


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Following the issue #1725 , this change revised the example using the `mobject.animate` method instead of `ApplyMethod`.  The explanation text are also changed accordingly.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. --> 
[Animating methods in Manim's building blocks](https://docs.manim.community/en/stable/tutorials/building_blocks.html#animating-methods)


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
