### PR TITLE
Fix ``custom_config`` not working in ``frames_comparison``

### DIFF
--- a/tests/test_graphical_units/testing/frames_comparison.py
+++ b/tests/test_graphical_units/testing/frames_comparison.py
@@ -117,7 +117,7 @@ def frames_comparison(
             )
 
             # Isolate the config used for the test, to avoid a modifying the global config during the test run.
-            with tempconfig({**custom_config, **config_tests}):
+            with tempconfig({**config_tests, **custom_config}):
                 real_test()
 
         parameters = list(old_sig.parameters.values())


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Fix arguments passed into custom_config not working in graphical unit tests.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
On line 120 in `frames_comparison.py`, tempconfig is passed a dict with `config_tests` passed after `custom_config`. This seems like a mistake since `config_tests` contains many important config options and thus overrides `custom_config`. This PR reverses the order. In particular, this PR allows for a fix on the OpenGL test (which should now work by passing `renderer_class=OpenGLRenderer` and `renderer="opengl"`).



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
