### PR TITLE
Clean up when OpenGL renderer raises an error using IPython

### DIFF
--- a/manim/utils/ipython_magic.py
+++ b/manim/utils/ipython_magic.py
@@ -123,17 +123,18 @@ else:
                         )
                         config.renderer = "cairo"
 
-                SceneClass = local_ns[config["scene_names"][0]]
-                scene = SceneClass(renderer)
-                scene.render()
+                try:
+                    SceneClass = local_ns[config["scene_names"][0]]
+                    scene = SceneClass(renderer=renderer)
+                    scene.render()
+                finally:
+                    # Shader cache becomes invalid as the context is destroyed
+                    shader_program_cache.clear()
 
-                # Shader cache becomes invalid as the context is destroyed
-                shader_program_cache.clear()
-
-                # Close OpenGL window here instead of waiting for the main thread to
-                # finish causing the window to stay open and freeze
-                if renderer is not None and renderer.window is not None:
-                    renderer.window.close()
+                    # Close OpenGL window here instead of waiting for the main thread to
+                    # finish causing the window to stay open and freeze
+                    if renderer is not None and renderer.window is not None:
+                        renderer.window.close()
 
                 if config["output_file"] is None:
                     logger.info("No output file produced")


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
When an error was raised, the preview window would stay open as the code to close it wouldn't be run. The only way to close it then was to restart the IPython kernel.

Also, the renderer is now passed as a keyword argument to not break scene classes with different constructors.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. --> 


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
