### PR TITLE
Bugfix in `arrange_in_grid()`

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2358,7 +2358,7 @@ class Mobject:
         # grid filling is handled bottom up for simplicity reasons.
         def reverse(maybe_list):
             if maybe_list is not None:
-                maybe_list = list(row_alignments)
+                maybe_list = list(maybe_list)
                 maybe_list.reverse()
                 return maybe_list
 

--- a/manim/mobject/opengl_mobject.py
+++ b/manim/mobject/opengl_mobject.py
@@ -667,7 +667,7 @@ class OpenGLMobject:
         # grid filling is handled bottom up for simplicity reasons.
         def reverse(maybe_list):
             if maybe_list is not None:
-                maybe_list = list(row_alignments)
+                maybe_list = list(maybe_list)
                 maybe_list.reverse()
                 return maybe_list
 


### PR DESCRIPTION
Just a small fix. With this, `row_heights` should be working again, which was previously broken.

Reason:
The `row_alignments` and `row_heights` have to be reversed. But since you cannot guarantee that those parameters are lists, you cannot simply `.reverse` them. So this little function makes them to a list and reverses them. There is no reason why `row_alignments` should pop up at all explicitly in that function.

Created via github.dev