### PR TITLE
Fix last frame of the video not rendered

### DIFF
--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -837,7 +837,7 @@ class Scene:
             times = [run_time]
         else:
             step = 1 / config["frame_rate"]
-            times = np.arange(0, run_time, step)
+            times = np.arange(step, run_time + step, step)
         time_progression = tqdm(
             times,
             desc=description,


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Closes #183 
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
The t values were generated from [0, 1) and with a step of 1/15 the last t value would be 0.93333
That meant, the first frame of the video would be blank, last frame (of the video) not rendered.

This PR makes the t value generate from (0, 1] so with step of 1/15, last t value is 1, but first t value = 0.066667
That means, the first frame is now no longer blank, and last frame (of the whole video) is also rendered properly.
## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. --> 


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
