### PR TITLE
Fixed -a flag for opengl

### DIFF
--- a/manim/cli/render/commands.py
+++ b/manim/cli/render/commands.py
@@ -105,8 +105,8 @@ def render(
             while keep_running:
                 for SceneClass in scene_classes_from_file(file):
                     scene = SceneClass(renderer)
-                    status = scene.render()
-                    if status or config["write_all"]:
+                    rerun = scene.render()
+                    if rerun or config["write_all"]:
                         renderer.num_plays = 0
                         continue
                     else:

--- a/manim/cli/render/commands.py
+++ b/manim/cli/render/commands.py
@@ -106,11 +106,15 @@ def render(
                 for SceneClass in scene_classes_from_file(file):
                     scene = SceneClass(renderer)
                     status = scene.render()
-                    if status:
+                    if status or config["write_all"]:
+                        renderer.num_plays = 0
                         continue
                     else:
                         keep_running = False
                         break
+                if config["write_all"]:
+                    keep_running = False
+
         except Exception:
             error_console.print_exception()
             sys.exit(1)


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

Fixes #2009

When using the `-a` flag the opengl renderer was not outputting all scenes, this fixes it, but only made applicable to non-interactive mode.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

Only tests for this exist for cairo, opengl tests will be added in #2008

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
