### PR TITLE
Avoid using deprecated get_points and fix :class:~.OpenGLPMPoint color

### DIFF
--- a/manim/mobject/types/opengl_point_cloud_mobject.py
+++ b/manim/mobject/types/opengl_point_cloud_mobject.py
@@ -114,7 +114,7 @@ class OpenGLPMobject(OpenGLMobject):
 
     def filter_out(self, condition):
         for mob in self.family_members_with_points():
-            to_keep = ~np.apply_along_axis(condition, 1, mob.get_points())
+            to_keep = ~np.apply_along_axis(condition, 1, mob.points)
             for key in mob.data:
                 mob.data[key] = mob.data[key][to_keep]
         return self
@@ -124,7 +124,7 @@ class OpenGLPMobject(OpenGLMobject):
         function is any map from R^3 to R
         """
         for mob in self.family_members_with_points():
-            indices = np.argsort(np.apply_along_axis(function, 1, mob.get_points()))
+            indices = np.argsort(np.apply_along_axis(function, 1, mob.points))
             for key in mob.data:
                 mob.data[key] = mob.data[key][indices]
         return self
@@ -136,7 +136,7 @@ class OpenGLPMobject(OpenGLMobject):
 
     def point_from_proportion(self, alpha):
         index = alpha * (self.get_num_points() - 1)
-        return self.get_points()[int(index)]
+        return self.points[int(index)]
 
     def pointwise_become_partial(self, pmobject, a, b):
         lower_index = int(a * pmobject.get_num_points())
@@ -146,7 +146,7 @@ class OpenGLPMobject(OpenGLMobject):
         return self
 
     def get_shader_data(self):
-        shader_data = np.zeros(len(self.get_points()), dtype=self.shader_dtype)
+        shader_data = np.zeros(len(self.points), dtype=self.shader_dtype)
         self.read_data_to_shader(shader_data, "point", "points")
         self.read_data_to_shader(shader_data, "color", "rgbas")
         return shader_data
@@ -166,7 +166,7 @@ class OpenGLPGroup(OpenGLPMobject):
 
 
 class OpenGLPMPoint(OpenGLPMobject):
-    def __init__(self, location=ORIGIN, stroke_width=4.0, color=BLACK, **kwargs):
+    def __init__(self, location=ORIGIN, stroke_width=4.0, **kwargs):
         self.location = location
         super().__init__(stroke_width=stroke_width, **kwargs)
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

I noticed that there were some cases where the deprecated `get_points()` was being used, and color was only using the default so this PR fixes those.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
