### PR TITLE
 Corrected user-wide Config Paths for *NIX

### DIFF
--- a/docs/source/tutorials/configuration.rst
+++ b/docs/source/tutorials/configuration.rst
@@ -213,8 +213,8 @@ The user-wide config file lives in a special folder, depending on the operating
 system.
 
 * Windows: :code:`UserDirectory`/AppData/Roaming/Manim/manim.cfg
-* MacOS: :code:`UserDirectory`/config/manim/manim.cfg
-* Linux: :code:`UserDirectory`/config/manim/manim.cfg
+* MacOS: :code:`UserDirectory`/.config/manim/manim.cfg
+* Linux: :code:`UserDirectory`/.config/manim/manim.cfg
 
 Here, :code:`UserDirectory` is the user's home folder.
 


### PR DESCRIPTION
## Overview: What does this pull request change?
Effecting documentation: [https://docs.manim.community/en/stable/tutorials/configuration.html](https://docs.manim.community/en/stable/tutorials/configuration.html)

Tested config in `~/.config/manim/manim.cfg` and `~/config/manim/manim.cfg` on Debian.
The config in `config` doesn't get respected, while the one in `.config` does.

## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
