### PR TITLE
Deprecated redundant methods of Mobject

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -591,7 +591,7 @@ Special Camera Settings
                u_range=[-2, +2]
            )
 
-           gauss_plane.scale_about_point(2, ORIGIN)
+           gauss_plane.scale(2, about_point=ORIGIN)
            gauss_plane.set_style(fill_opacity=1,stroke_color=GREEN)
            gauss_plane.set_fill_by_checkerboard(ORANGE, BLUE, opacity=0.5)
            axes = ThreeDAxes()

--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -160,7 +160,7 @@ class Indicate(Transform):
 
     def create_target(self) -> "Mobject":
         target = self.mobject.copy()
-        target.scale_in_place(self.scale_factor)
+        target.scale(self.scale_factor)
         target.set_color(self.color)
         return target
 

--- a/manim/mobject/coordinate_systems.py
+++ b/manim/mobject/coordinate_systems.py
@@ -1327,7 +1327,7 @@ class CoordinateSystem:
 
         if include_secant_line:
             group.secant_line = Line(p1, p2, color=secant_line_color)
-            group.secant_line.scale_in_place(
+            group.secant_line.scale(
                 secant_line_length / group.secant_line.get_length(),
             )
             group.add(group.secant_line)

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1268,14 +1268,17 @@ class Mobject:
             mob.points += about_point
         return self
 
+    @deprecated
     def rotate_in_place(self, angle, axis=OUT):
         # redundant with default behavior of rotate now.
         return self.rotate(angle, axis=axis)
 
+    @deprecated
     def scale_in_place(self, scale_factor, **kwargs):
         # Redundant with default behavior of scale now.
         return self.scale(scale_factor, **kwargs)
 
+    @deprecated
     def scale_about_point(self, scale_factor, point):
         # Redundant with default behavior of scale now.
         return self.scale(scale_factor, about_point=point)
@@ -1385,6 +1388,7 @@ class Mobject:
     def stretch_about_point(self, factor, dim, point):
         return self.stretch(factor, dim, about_point=point)
 
+    @deprecated
     def stretch_in_place(self, factor, dim):
         # Now redundant with stretch
         return self.stretch(factor, dim)

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1581,7 +1581,7 @@ class Mobject:
     ):
         self.replace(mobject, dim_to_match, stretch)
         length = mobject.length_over_dim(dim_to_match)
-        self.scale_in_place((length + buff) / length)
+        self.scale((length + buff) / length)
         return self
 
     def put_start_and_end_on(self, start, end):

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1271,6 +1271,7 @@ class Mobject:
     @deprecated(
         since="v0.11.0",
         until="v0.12.0",
+        replacement="rotate"
     )
     def rotate_in_place(self, angle, axis=OUT):
         # redundant with default behavior of rotate now.
@@ -1279,6 +1280,7 @@ class Mobject:
     @deprecated(
         since="v0.11.0",
         until="v0.12.0",
+        replacement="scale"
     )
     def scale_in_place(self, scale_factor, **kwargs):
         # Redundant with default behavior of scale now.
@@ -1287,6 +1289,7 @@ class Mobject:
     @deprecated(
         since="v0.11.0",
         until="v0.12.0",
+        replacement="scale"
     )
     def scale_about_point(self, scale_factor, point):
         # Redundant with default behavior of scale now.

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1400,7 +1400,11 @@ class Mobject:
     def stretch_about_point(self, factor, dim, point):
         return self.stretch(factor, dim, about_point=point)
 
-    @deprecated
+    @deprecated(
+        since="v0.11.0",
+        until="v0.12.0",
+        replacement="stretch",
+    )
     def stretch_in_place(self, factor, dim):
         # Now redundant with stretch
         return self.stretch(factor, dim)

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1271,7 +1271,7 @@ class Mobject:
     @deprecated(
         since="v0.11.0",
         until="v0.12.0",
-        replacement="rotate"
+        replacement="rotate",
     )
     def rotate_in_place(self, angle, axis=OUT):
         # redundant with default behavior of rotate now.
@@ -1280,7 +1280,7 @@ class Mobject:
     @deprecated(
         since="v0.11.0",
         until="v0.12.0",
-        replacement="scale"
+        replacement="scale",
     )
     def scale_in_place(self, scale_factor, **kwargs):
         # Redundant with default behavior of scale now.
@@ -1289,7 +1289,7 @@ class Mobject:
     @deprecated(
         since="v0.11.0",
         until="v0.12.0",
-        replacement="scale"
+        replacement="scale",
     )
     def scale_about_point(self, scale_factor, point):
         # Redundant with default behavior of scale now.

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1268,17 +1268,26 @@ class Mobject:
             mob.points += about_point
         return self
 
-    @deprecated
+    @deprecated(
+        since="v0.11.0",
+        until="v0.12.0",
+    )
     def rotate_in_place(self, angle, axis=OUT):
         # redundant with default behavior of rotate now.
         return self.rotate(angle, axis=axis)
 
-    @deprecated
+    @deprecated(
+        since="v0.11.0",
+        until="v0.12.0",
+    )
     def scale_in_place(self, scale_factor, **kwargs):
         # Redundant with default behavior of scale now.
         return self.scale(scale_factor, **kwargs)
 
-    @deprecated
+    @deprecated(
+        since="v0.11.0",
+        until="v0.12.0",
+    )
     def scale_about_point(self, scale_factor, point):
         # Redundant with default behavior of scale now.
         return self.scale(scale_factor, about_point=point)

--- a/manim/mobject/svg/opengl_text_mobject.py
+++ b/manim/mobject/svg/opengl_text_mobject.py
@@ -20,7 +20,7 @@ Examples
     class TextAlignment(Scene):
         def construct(self):
             title = Text("K-means clustering and Logistic Regression", color=WHITE)
-            title.scale_in_place(0.75)
+            title.scale(0.75)
             self.add(title.to_edge(UP))
 
             t1 = Text("1. Measuring").set_color(WHITE)
@@ -35,7 +35,7 @@ Examples
             t4 = Text("4. Prediction").set_color(WHITE)
             t4.next_to(t3, direction=DOWN, aligned_edge=LEFT)
 
-            x = VGroup(t1, t2, t3, t4).scale_in_place(0.7)
+            x = VGroup(t1, t2, t3, t4).scale(0.7)
             x.set_opacity(0.5)
             x.submobjects[1].set_opacity(1)
             self.add(x)

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -29,7 +29,7 @@ Examples
     class TextAlignment(Scene):
         def construct(self):
             title = Text("K-means clustering and Logistic Regression", color=WHITE)
-            title.scale_in_place(0.75)
+            title.scale(0.75)
             self.add(title.to_edge(UP))
 
             t1 = Text("1. Measuring").set_color(WHITE)
@@ -40,7 +40,7 @@ Examples
 
             t4 = Text("4. Prediction").set_color(WHITE)
 
-            x = VGroup(t1, t2, t3, t4).arrange(direction=DOWN, aligned_edge=LEFT).scale_in_place(0.7).next_to(ORIGIN,DR)
+            x = VGroup(t1, t2, t3, t4).arrange(direction=DOWN, aligned_edge=LEFT).scale(0.7).next_to(ORIGIN,DR)
             x.set_opacity(0.5)
             x.submobjects[1].set_opacity(1)
             self.add(x)

--- a/manim/scene/vector_space_scene.py
+++ b/manim/scene/vector_space_scene.py
@@ -1006,7 +1006,7 @@ class LinearTransformationScene(VectorScene):
             v.target = Vector(func(v.get_end()), color=v.get_color())
             norm = np.linalg.norm(v.target.get_end())
             if norm < 0.1:
-                v.target.get_tip().scale_in_place(norm)
+                v.target.get_tip().scale(norm)
         return self.get_piece_movement(self.moving_vectors)
 
     def get_transformable_label_movement(self):


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->
- deprecated some methods that aren't unique
  - `.rotate_in_place`
  - `.scale_in_place`
  - `.scale_about_point`
- Removed the usage of said functions in other classes
## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Initially I noticed `Indicate()` animation wasn't working in OpenGL because of no `.scale_in_place()` method. Then i realized they shouldn't even be used.
## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
