### PR TITLE
Fixed opengl shift animation for :class:~.Text

### DIFF
--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -221,9 +221,7 @@ class Animation:
         return self.mobject, self.starting_mobject
 
     def get_all_families_zipped(self) -> Iterable[Tuple]:
-        return zip(
-            *(mob.family_members_with_points() for mob in self.get_all_mobjects())
-        )
+        return zip(*(mob.get_family() for mob in self.get_all_mobjects()))
 
     def update_mobjects(self, dt: float) -> None:
         """

--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -1,7 +1,7 @@
 """Animate mobjects."""
 
 
-from .. import logger
+from .. import config, logger
 from ..mobject import mobject, opengl_mobject
 from ..mobject.mobject import Mobject
 from ..mobject.opengl_mobject import OpenGLMobject
@@ -221,7 +221,11 @@ class Animation:
         return self.mobject, self.starting_mobject
 
     def get_all_families_zipped(self) -> Iterable[Tuple]:
-        return zip(*(mob.get_family() for mob in self.get_all_mobjects()))
+        if config["renderer"] == "opengl":
+            return zip(*(mob.get_family() for mob in self.get_all_mobjects()))
+        return zip(
+            *(mob.family_members_with_points() for mob in self.get_all_mobjects())
+        )
 
     def update_mobjects(self, dt: float) -> None:
         """

--- a/manim/animation/transform.py
+++ b/manim/animation/transform.py
@@ -138,7 +138,7 @@ class Transform(Animation):
             self.starting_mobject,
             self.target_copy,
         ]
-        return zip(*(mob.family_members_with_points() for mob in mobs))
+        return zip(*(mob.get_family() for mob in mobs))
 
     def interpolate_submobject(
         self,

--- a/manim/animation/transform.py
+++ b/manim/animation/transform.py
@@ -138,7 +138,9 @@ class Transform(Animation):
             self.starting_mobject,
             self.target_copy,
         ]
-        return zip(*(mob.get_family() for mob in mobs))
+        if config["renderer"] == "opengl":
+            return zip(*(mob.get_family() for mob in mobs))
+        return zip(*(mob.family_members_with_points() for mob in mobs))
 
     def interpolate_submobject(
         self,


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Fixes #1937

The reason for the above issue was that `Text` will not be returned when calling `family_members_with_points`, therefore when an animation takes place it is not being updated correctly during interpolation. 

There is some safety checks already in place to that makes me think this should be a safe change https://github.com/ManimCommunity/manim/blob/58092a71a9b6d162024fa235dc696e8b9bad3a9d/manim/mobject/opengl_mobject.py#L1654. Manimgl also changed to this approach a while back

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

Tested with animation examples on website


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
