### PR TITLE
Added missing space in info message for :meth:`~.SceneFileWriter.clean_cache`

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -567,7 +567,7 @@ class SceneFileWriter:
                 modify_atime(file_path)
 
     def clean_cache(self):
-        """Will clean the cache by removing the partial_movie_files used by manim the longest ago."""
+        """Will clean the cache by removing the oldest partial_movie_files."""
         cached_partial_movies = [
             os.path.join(self.partial_movie_directory, file_name)
             for file_name in os.listdir(self.partial_movie_directory)
@@ -585,7 +585,7 @@ class SceneFileWriter:
             for file_to_delete in oldest_files_to_delete:
                 os.remove(file_to_delete)
             logger.info(
-                f"The partial movie directory is full (> {config['max_files_cached']} files). Therefore, manim has removed the {number_files_to_delete} least recently used file(s).",
+                f"The partial movie directory is full (> {config['max_files_cached']} files). Therefore, manim has removed the {number_files_to_delete} oldest file(s).",
                 "You can change this behaviour by changing max_files_cached in config.",
             )
 

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -585,7 +585,7 @@ class SceneFileWriter:
             for file_to_delete in oldest_files_to_delete:
                 os.remove(file_to_delete)
             logger.info(
-                f"The partial movie directory is full (> {config['max_files_cached']} files). Therefore, manim has removed {number_files_to_delete} file(s) used by it the longest ago.",
+                f"The partial movie directory is full (> {config['max_files_cached']} files). Therefore, manim has removed the {number_files_to_delete} least recently used file(s).",
                 "You can change this behaviour by changing max_files_cached in config.",
             )
 

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -585,8 +585,8 @@ class SceneFileWriter:
             for file_to_delete in oldest_files_to_delete:
                 os.remove(file_to_delete)
             logger.info(
-                f"The partial movie directory is full (> {config['max_files_cached']} files). Therefore, manim has removed {number_files_to_delete} file(s) used by it the longest ago."
-                + "You can change this behaviour by changing max_files_cached in config.",
+                f"The partial movie directory is full (> {config['max_files_cached']} files). Therefore, manim has removed {number_files_to_delete} file(s) used by it the longest ago.",
+                "You can change this behaviour by changing max_files_cached in config.",
             )
 
     def flush_cache_directory(self):


### PR DESCRIPTION
## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
This PR should fix the missing whitespace in an info message: `… ago.You can change this …`.
<!--changelog-end-->

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
Because this is such a tiny modification, I did not do any testing — I hope you don't mind.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
