### PR TITLE
Fixed opengl overriding svg fill color

### DIFF
--- a/manim/mobject/opengl_mobject.py
+++ b/manim/mobject/opengl_mobject.py
@@ -81,7 +81,7 @@ class OpenGLMobject:
         self.data = getattr(self, "data", {})
         self.uniforms = getattr(self, "uniforms", {})
 
-        self.color = Color(color)
+        self.color = Color(color) if color else None
         self.opacity = opacity
         self.dim = dim  # TODO, get rid of this
         # Lighting parameters


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
When rendering svgs it needs to know if it should use colors set in the svg or colors passed as arguments. It can only do this if color defaults to None, otherwise it will not know if a user has specified a color. This behaviour already exists in cairo and this PR adds it to opengl. 

You can test the before / after behaviour with the below svg that sets colors

```py
class SvgTest(Scene):
    def construct(self):
        a = SVGMobject("../tests/test_graphical_units/img_svg_resources/aabbb.svg")
        self.add(a)
        self.interactive_embed()
```

Before:

<img width="632" alt="Screenshot 2021-09-08 at 11 56 43" src="https://user-images.githubusercontent.com/32387857/132497568-1d6946c0-d34d-4246-a181-6c196cfc63b5.png">

After:

<img width="635" alt="Screenshot 2021-09-08 at 11 57 02" src="https://user-images.githubusercontent.com/32387857/132497578-2c7e8a06-9654-49aa-b73f-ad8e3973ecdb.png">

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
