### PR TITLE
Added depreciation warning for GraphicalUnitTester.test

### DIFF
--- a/tests/utils/GraphicalUnitTester.py
+++ b/tests/utils/GraphicalUnitTester.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from manim import config, tempconfig
 from manim.renderer.opengl_renderer import OpenGLRenderer
+from manim.utils.deprecation import deprecated
 
 
 class GraphicalUnitTester:
@@ -119,6 +120,11 @@ class GraphicalUnitTester:
         plt.show()
         plt.savefig(f"{self.scene}.png")
 
+    @deprecated(
+        until="0.12",
+        replacement="frames_comparison",
+        message="The way scene are tested has changed. Refer to the latest doc.",
+    )
     def test(self, show_diff=False):
         """Compare pre-rendered frame to the frame rendered during the test."""
         frame_data = self.scene.renderer.get_frame()

--- a/tests/utils/GraphicalUnitTester.py
+++ b/tests/utils/GraphicalUnitTester.py
@@ -121,7 +121,8 @@ class GraphicalUnitTester:
         plt.savefig(f"{self.scene}.png")
 
     @deprecated(
-        until="0.12",
+        since="v0.11.0",
+        until="v0.12.0",
         replacement="frames_comparison",
         message="The way scenes are tested has changed. Refer to the latest doc.",
     )

--- a/tests/utils/GraphicalUnitTester.py
+++ b/tests/utils/GraphicalUnitTester.py
@@ -123,7 +123,7 @@ class GraphicalUnitTester:
     @deprecated(
         until="0.12",
         replacement="frames_comparison",
-        message="The way scene are tested has changed. Refer to the latest doc.",
+        message="The way scenes are tested has changed. Refer to the latest doc.",
     )
     def test(self, show_diff=False):
         """Compare pre-rendered frame to the frame rendered during the test."""


### PR DESCRIPTION


<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Added a depreciation warning for GraphicalUnitTester. it's kind of useless since tests are dev-oriented, but I didn't want to remove it directly. 
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
