### PR TITLE
Added opengl compatibility for :meth:`~Cylinder.add_bases`.

### DIFF
--- a/manim/mobject/three_dimensions.py
+++ b/manim/mobject/three_dimensions.py
@@ -630,22 +630,26 @@ class Cylinder(Surface):
 
     def add_bases(self):
         """Adds the end caps of the cylinder."""
+        color = self.color if config["renderer"] == "opengl" else self.fill_color
+        opacity = self.opacity if config["renderer"] == "opengl" else self.fill_opacity
+        u_min = self.u_range[0] if config["renderer"] == "opengl" else self.u_min
+        u_max = self.u_range[1] if config["renderer"] == "opengl" else self.u_max
         self.base_top = Circle(
             radius=self.radius,
-            color=self.fill_color,
-            fill_opacity=self.fill_opacity,
+            color=color,
+            fill_opacity=opacity,
             shade_in_3d=True,
             stroke_width=0,
         )
-        self.base_top.shift(self.u_max * IN)
+        self.base_top.shift(u_max * IN)
         self.base_bottom = Circle(
             radius=self.radius,
-            color=self.fill_color,
-            fill_opacity=self.fill_opacity,
+            color=color,
+            fill_opacity=opacity,
             shade_in_3d=True,
             stroke_width=0,
         )
-        self.base_bottom.shift(self.u_min * IN)
+        self.base_bottom.shift(u_min * IN)
         self.add(self.base_top, self.base_bottom)
 
     def _rotate_to_direction(self):


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

Fixes #1995

Line3D was failing due to opengl compatibility issues in `base_classes` method as the underlying opengl bases classes do not have `fill_color` and `fill_opacity`. Added some fixes for this and removed the deprecated `u_min`, `u_max`, `v_min` and `v_max` fields.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
