### PR TITLE
Added config to enable opengl wireframe for debugging

### DIFF
--- a/docs/source/tutorials/configuration.rst
+++ b/docs/source/tutorials/configuration.rst
@@ -353,7 +353,7 @@ A list of all config options
    'tex_template', 'tex_template_file', 'text_dir', 'top', 'transparent',
    'upto_animation_number', 'use_opengl_renderer', 'use_webgl_renderer',
    'verbosity', 'video_dir', 'webgl_renderer_path', 'window_position',
-    'window_monitor', 'window_size', 'write_all', 'write_to_movie']
+    'window_monitor', 'window_size', 'write_all', 'write_to_movie', 'enable_wireframe']
 
 
 A list of all CLI flags

--- a/manim/_config/default.cfg
+++ b/manim/_config/default.cfg
@@ -144,6 +144,9 @@ disable_caching = False
 # Disable the warning when there are too much submobjects to hash.
 disable_caching_warning = False
 
+# --enable_wireframe
+enable_wireframe = False
+
 # Default tex_template
 # --tex_template
 tex_template =

--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -245,6 +245,7 @@ class ManimConfig(MutableMapping):
         "custom_folders",
         "disable_caching",
         "disable_caching_warning",
+        "enable_wireframe",
         "ffmpeg_loglevel",
         "format",
         "flush_cache",
@@ -539,6 +540,7 @@ class ManimConfig(MutableMapping):
             "fullscreen",
             "use_projection_fill_shaders",
             "use_projection_stroke_shaders",
+            "enable_wireframe",
         ]:
             setattr(self, key, parser["CLI"].getboolean(key, fallback=False))
 
@@ -687,6 +689,7 @@ class ManimConfig(MutableMapping):
             "use_projection_fill_shaders",
             "use_projection_stroke_shaders",
             "zero_pad",
+            "enable_wireframe",
         ]:
             if hasattr(args, key):
                 attr = getattr(args, key)
@@ -880,6 +883,12 @@ class ManimConfig(MutableMapping):
         lambda self: self._d["save_as_gif"],
         lambda self, val: self._set_boolean("save_as_gif", val),
         doc="Whether to save the rendered scene in .gif format (-i).",
+    )
+
+    enable_wireframe = property(
+        lambda self: self._d["enable_wireframe"],
+        lambda self, val: self._set_boolean("enable_wireframe", val),
+        doc="Enable wireframe debugging mode in opengl.",
     )
 
     @property

--- a/manim/cli/render/global_options.py
+++ b/manim/cli/render/global_options.py
@@ -78,4 +78,10 @@ global_options = option_group(
         help="Expand the window to its maximum possible size.",
         default=None,
     ),
+    option(
+        "--enable_wireframe",
+        is_flag=True,
+        help="Enable wireframe debugging mode in opengl.",
+        default=None,
+    ),
 )

--- a/manim/renderer/opengl_renderer.py
+++ b/manim/renderer/opengl_renderer.py
@@ -260,6 +260,7 @@ class OpenGLRenderer:
                 self.frame_buffer_object = self.get_frame_buffer_object(self.context, 0)
                 self.frame_buffer_object.use()
             self.context.enable(moderngl.BLEND)
+            self.context.wireframe = config["enable_wireframe"]
             self.context.blend_func = (
                 moderngl.SRC_ALPHA,
                 moderngl.ONE_MINUS_SRC_ALPHA,


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

It is useful when debugging opengl to see the vertices and edges of objects, this adds a config option to enable wireframe mode in opengl

```py
class Test(Scene):
    def construct(self):
        a = Dot(radius=2)
        self.add(a)
        self.interactive_embed()
```

__Normal mode__

<img width="628" alt="Screenshot 2021-09-11 at 19 30 48" src="https://user-images.githubusercontent.com/32387857/132957847-79ba0541-1295-48d5-8bb4-8e229dfb6db2.png">

__wireframe mode__

<img width="626" alt="Screenshot 2021-09-11 at 19 31 11" src="https://user-images.githubusercontent.com/32387857/132957853-b75fc35f-209c-41fc-a5bd-503bd5732d0e.png">

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
