### PR TITLE
Fix bug where `~.NumberLine.add_labels()`  cannot accept non-mobject labels. 

### DIFF
--- a/manim/mobject/number_line.py
+++ b/manim/mobject/number_line.py
@@ -397,11 +397,11 @@ class NumberLine(Line):
 
         labels = VGroup()
         for x, label in dict_values.items():
+            label = self.create_label_tex(label)
             if hasattr(label, "font_size"):
                 label.font_size = font_size
             else:
                 raise AttributeError(f"{label} is not compatible with add_labels.")
-            label = self.create_label_tex(label)
             label.next_to(self.number_to_point(x), direction=direction, buff=buff)
             labels.add(label)
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

Fixes bug where `.add_labels()` was adjusting the `font_size` of the inputs before a label could be created via `create_label_tex`. 
This PR just switches the order so that `create_label_tex`  precedes setting `font_size`.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Allows code such as this:

```py
class te(Scene):
    def construct(self):
        self.camera.background_color = WHITE
        a = NumberLine().set_color(BLACK)
        a.add_labels(dict(zip(range(5), range(5))), font_size=12).set_color(BLACK)
        self.add(a)
```

whereas it previously errored with:

```py
(manim-zPbAr8g6-py3.9) PS C:\Users\laith\Documents\GitHub\hydro_manim> manim -p mkt.py te  
Manim Community v0.9.0

╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ C:\Users\laith\Documents\GitHub\hydro_manim\manim\cli\render\commands.py:135 in render           │
│                                                                                                  │
│   132 │   │   for SceneClass in scene_classes_from_file(file):                                   │
│   133 │   │   │   try:                                                                           │
│   134 │   │   │   │   scene = SceneClass()                                                       │
│ ❱ 135 │   │   │   │   scene.render()                                                             │
│   136 │   │   │   except Exception:                                                              │
│   137 │   │   │   │   error_console.print_exception()                                            │
│   138 │   │   │   │   sys.exit(1)                                                                │
│                                                                                                  │
│ C:\Users\laith\Documents\GitHub\hydro_manim\manim\scene\scene.py:215 in render                   │
│                                                                                                  │
│    212 │   │   """                                                                               │
│    213 │   │   self.setup()                                                                      │
│    214 │   │   try:                                                                              │
│ ❱  215 │   │   │   self.construct()                                                              │
│    216 │   │   except EndSceneEarlyException:                                                    │
│    217 │   │   │   pass                                                                          │
│    218 │   │   except RerunSceneException as e:                                                  │
│                                                                                                  │
│ C:\Users\laith\Documents\GitHub\hydro_manim\mkt.py:2994 in construct                             │
│                                                                                                  │
│   2991 │   def construct(self):                                                                  │
│   2992 │   │   self.camera.background_color = WHITE                                              │
│   2993 │   │   a = NumberLine().set_color(BLACK)                                                 │
│ ❱ 2994 │   │   a.add_labels(dict(zip(range(5), ["h" for _ in range(5)])), font_size=20).set_col  │
│   2995 │   │   self.add(a)                                                                       │
│   2996                                                                                           │
│   2997                                                                                           │
│                                                                                                  │
│ C:\Users\laith\Documents\GitHub\hydro_manim\manim\mobject\number_line.py:402 in add_labels       │
│                                                                                                  │
│   399 │   │   │   if hasattr(label, "font_size"):                                                │
│   400 │   │   │   │   label.font_size = font_size                                                │
│   401 │   │   │   else:                                                                          │
│ ❱ 402 │   │   │   │   raise AttributeError(f"{label} is not compatible with add_labels.")        │
│   403 │   │   │   label = self.create_label_tex(label)                                           │
│   404 │   │   │   label.next_to(self.number_to_point(x), direction=direction, buff=buff)         │
│   405 │   │   │   labels.add(label)                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: h is not compatible with add_labels.
```

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
