### PR TITLE
Fixed opengl compatibility issue for meth:`~Line.set_opacity`

### DIFF
--- a/manim/mobject/geometry.py
+++ b/manim/mobject/geometry.py
@@ -1088,15 +1088,6 @@ class Line(TipableVMobject):
     def set_length(self, length):
         return self.scale(length / self.get_length())
 
-    def set_opacity(self, opacity, family=True):
-        # Overwrite default, which would set
-        # the fill opacity
-        self.set_stroke(opacity=opacity)
-        if family:
-            for sm in self.submobjects:
-                sm.set_opacity(opacity, family)
-        return self
-
 
 class DashedLine(Line):
     """A dashed :class:`Line`.


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

Fixes #2059

This is more of a hack, but I didn't see any other less obtrusive approaches, but let me know if there are any better ideas to fix this. The problem was that `Line` overrides the base `set_opacity` method, and so doesn't trigger the `OpenGLVMobject` metaclass to trigger its own `set_opacity` method. I added kwargs that will just be ignored, and from what I can tell setting opacity is behaving the same for opengl and cairo after this fix.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
