### PR TITLE
Depreciate FullScreenFadeRectangle and PictureInPictureFrame 

### DIFF
--- a/manim/mobject/frame.py
+++ b/manim/mobject/frame.py
@@ -8,6 +8,8 @@ __all__ = [
 ]
 
 
+from manim.utils.deprecation import deprecated
+
 from .. import config
 from ..constants import *
 from ..mobject.geometry import Rectangle
@@ -39,6 +41,11 @@ class FullScreenRectangle(ScreenRectangle):
         self.height = config["frame_height"]
 
 
+@deprecated(
+    since="v0.11.0",
+    until="v0.12.0",
+    message="This method is deprecated due to decluttering purpose.",
+)
 class FullScreenFadeRectangle(FullScreenRectangle):
     def __init__(self, stroke_width=0, fill_color=BLACK, fill_opacity=0.7, **kwargs):
         FullScreenRectangle.__init__(
@@ -50,6 +57,11 @@ class FullScreenFadeRectangle(FullScreenRectangle):
         )
 
 
+@deprecated(
+    since="v0.11.0",
+    until="v0.12.0",
+    message="This method is deprecated due to decluttering purpose.",
+)
 class PictureInPictureFrame(Rectangle):
     def __init__(self, height=3, aspect_ratio=16.0 / 9.0, **kwargs):
         Rectangle.__init__(self, width=aspect_ratio * height, height=height, **kwargs)


### PR DESCRIPTION
I think these two methods are not so important, that they should be a core feature.
In case that they are needed, they can be easily implemented by adjusting a Rectangle accordingly.