### PR TITLE
Added OpenGL compatibility for :class:`~.Cube`.

### DIFF
--- a/manim/mobject/three_dimensions.py
+++ b/manim/mobject/three_dimensions.py
@@ -401,6 +401,8 @@ class Cube(VGroup):
 
             self.add(face)
 
+    init_points = generate_points
+
 
 class Prism(Cube):
     """A cuboid.


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
Adds `init_points` = `generate_points` to `Cube`. This is the same approach used for opengl compatibility in `geometry.py`. Previously did not render the points of the `Cube` and resulted in a blank screen.

```py
class Draw(Scene):
    def construct(self):
        self.add(Cube())
        self.interactive_embed()
```

![image](https://user-images.githubusercontent.com/70682032/134401951-41390549-9d93-4da0-a7db-ca84ee32a3d4.png)


<!--changelog-start-->

<!--changelog-end-->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
N/A

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
N/A


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
