### PR TITLE
Fixed fitting issue in :meth:`~Table.add_highlighted_cell`

### DIFF
--- a/manim/mobject/table.py
+++ b/manim/mobject/table.py
@@ -67,7 +67,7 @@ from typing import Callable, Iterable, List, Optional, Sequence, Union
 
 from colour import Color
 
-from .. import config
+from .. import BackgroundRectangle, config
 from ..animation.composition import AnimationGroup
 from ..animation.creation import *
 from ..constants import *
@@ -849,9 +849,11 @@ class Table(VGroup):
         """
         cell = self.get_cell(pos)
         entry = self.get_entries(pos)
-        entry.add_background_rectangle(color=color, **kwargs)
-        entry.background_rectangle.stretch_to_fit_height(cell.get_height())
-        entry.background_rectangle.stretch_to_fit_width(cell.get_width())
+        bg = BackgroundRectangle(entry, color=color, **kwargs)
+        bg.stretch_to_fit_height(cell.get_height())
+        bg.stretch_to_fit_width(cell.get_width())
+        self.add_to_back(bg)
+
         return self
 
     def create(


### PR DESCRIPTION
Fixes #2078 
Before:
![image](https://user-images.githubusercontent.com/44469195/134762069-6fe208d3-c3d9-4124-9241-2a714eaaed51.png)
After:
![image](https://user-images.githubusercontent.com/44469195/134762062-6b125a3c-bd17-4ffe-be36-d0633ee37eac.png)
The problem was, that `stretch_to_fit_height(cell.get_height())` was called for each background rectangle. Now it is only called for new background rectangles.