### PR TITLE
Fix `NumberPlane` axis step 

### DIFF
--- a/manim/mobject/coordinate_systems.py
+++ b/manim/mobject/coordinate_systems.py
@@ -2110,14 +2110,14 @@ class NumberPlane(Axes):
         x_lines1, x_lines2 = self._get_lines_parallel_to_axis(
             x_axis,
             y_axis,
-            self.x_axis.x_step,
+            self.y_axis.x_step,
             self.faded_line_ratio,
         )
 
         y_lines1, y_lines2 = self._get_lines_parallel_to_axis(
             y_axis,
             x_axis,
-            self.y_axis.x_step,
+            self.x_axis.x_step,
             self.faded_line_ratio,
         )
 

--- a/tests/test_coordinate_system.py
+++ b/tests/test_coordinate_system.py
@@ -61,14 +61,12 @@ def test_NumberPlane():
         (pos_x_range, neg_y_range, x_vals, [-v for v in y_vals]),
         (neg_x_range, pos_y_range, [-v for v in x_vals], y_vals),
         (neg_x_range, neg_y_range, [-v for v in x_vals], [-v for v in y_vals]),
+        ((-5, 5, 0.5), (-8, 8, 2), x_vals, y_vals),  # <- test for different step values
     ]
 
     for test_data in testing_data:
 
         x_range, y_range, x_vals, y_vals = test_data
-
-        x_start, x_end = x_range
-        y_start, y_end = y_range
 
         plane = NumberPlane(
             x_range=x_range,
@@ -77,11 +75,14 @@ def test_NumberPlane():
             axis_config={"include_numbers": True},
         )
 
+        x_start, x_end, x_step = plane.x_range
+        y_start, y_end, y_step = plane.y_range
+
         # normally these values would be need to be added by one to pass since there's an
         # overlapping pair of lines at the origin, but since these planes do not cross 0,
         # this is not needed.
-        num_y_lines = math.ceil(x_end - x_start)
-        num_x_lines = math.floor(y_end - y_start)
+        num_y_lines = math.ceil(x_end - x_start) / x_step
+        num_x_lines = math.floor(y_end - y_start) / y_step
 
         assert len(plane.y_lines) == num_y_lines
         assert len(plane.x_lines) == num_x_lines

--- a/tests/test_coordinate_system.py
+++ b/tests/test_coordinate_system.py
@@ -61,12 +61,14 @@ def test_NumberPlane():
         (pos_x_range, neg_y_range, x_vals, [-v for v in y_vals]),
         (neg_x_range, pos_y_range, [-v for v in x_vals], y_vals),
         (neg_x_range, neg_y_range, [-v for v in x_vals], [-v for v in y_vals]),
-        ((-5, 5, 0.5), (-8, 8, 2), x_vals, y_vals),  # <- test for different step values
     ]
 
     for test_data in testing_data:
 
         x_range, y_range, x_vals, y_vals = test_data
+
+        x_start, x_end = x_range
+        y_start, y_end = y_range
 
         plane = NumberPlane(
             x_range=x_range,
@@ -75,17 +77,18 @@ def test_NumberPlane():
             axis_config={"include_numbers": True},
         )
 
-        x_start, x_end, x_step = plane.x_range
-        y_start, y_end, y_step = plane.y_range
-
         # normally these values would be need to be added by one to pass since there's an
         # overlapping pair of lines at the origin, but since these planes do not cross 0,
         # this is not needed.
-        num_y_lines = math.ceil(x_end - x_start) / x_step
-        num_x_lines = math.floor(y_end - y_start) / y_step
+        num_y_lines = math.ceil(x_end - x_start)
+        num_x_lines = math.floor(y_end - y_start)
 
         assert len(plane.y_lines) == num_y_lines
         assert len(plane.x_lines) == num_x_lines
+
+    plane = NumberPlane((-5, 5, 0.5), (-8, 8, 2))  # <- test for different step values
+    assert len(plane.x_lines) == 8
+    assert len(plane.y_lines) == 20
 
 
 def test_point_to_coords():


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->
## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Fixes #2082 
When given different step values for the x and y axis, the line step are swapped. The frequency should follow the axis it's perpendicular to rather than parallel.

Code used:
```py
class Test(Scene):
    def construct(self):
        plane = NumberPlane(
            [-6, 6, 1],
            [-10, 10, 2],
            config.frame_width,
            config.frame_height,
        )
        self.add(plane)
```
Before:

![Test_ManimCE_v0 10 0](https://user-images.githubusercontent.com/83535735/134813650-67ea6114-c30e-4e22-97a9-1d3865214837.png)
After:
![Test_ManimCE_v0 10 0](https://user-images.githubusercontent.com/83535735/134813629-1d54a212-29db-40dc-bbf2-0858c22d80a9.png)

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
