### PR TITLE
Deprecated `SampleSpaceScene` and `ReconfigurableScene`

### DIFF
--- a/manim/scene/reconfigurable_scene.py
+++ b/manim/scene/reconfigurable_scene.py
@@ -4,8 +4,10 @@ from ..animation.transform import Transform
 from ..constants import *
 from ..mobject.mobject import Mobject
 from ..scene.scene import Scene
+from manim.utils.deprecation import deprecated
 
 
+@deprecated(since="0.11.0", until="0.12.0", message="Does not seem to work, and no plans to maintain it.")
 class ReconfigurableScene(Scene):
     """
     Note, this seems to no longer work as intended.

--- a/manim/scene/reconfigurable_scene.py
+++ b/manim/scene/reconfigurable_scene.py
@@ -1,13 +1,18 @@
 __all__ = ["ReconfigurableScene"]
 
+from manim.utils.deprecation import deprecated
+
 from ..animation.transform import Transform
 from ..constants import *
 from ..mobject.mobject import Mobject
 from ..scene.scene import Scene
-from manim.utils.deprecation import deprecated
 
 
-@deprecated(since="0.11.0", until="0.12.0", message="Does not seem to work, and no plans to maintain it.")
+@deprecated(
+    since="0.11.0",
+    until="0.12.0",
+    message="Does not seem to work, and no plans to maintain it.",
+)
 class ReconfigurableScene(Scene):
     """
     Note, this seems to no longer work as intended.

--- a/manim/scene/sample_space_scene.py
+++ b/manim/scene/sample_space_scene.py
@@ -10,8 +10,10 @@ from ..constants import *
 from ..mobject.probability import SampleSpace
 from ..mobject.types.vectorized_mobject import VGroup
 from ..scene.scene import Scene
+from manim.utils.deprecation import deprecated
 
 
+@deprecated(since="0.11.0", until="0.12.0", message="Out of scope of the library.")
 class SampleSpaceScene(Scene):
     def get_sample_space(self, **config):
         self.sample_space = SampleSpace(**config)

--- a/manim/scene/sample_space_scene.py
+++ b/manim/scene/sample_space_scene.py
@@ -3,6 +3,8 @@
 __all__ = ["SampleSpaceScene"]
 
 
+from manim.utils.deprecation import deprecated
+
 from ..animation.animation import Animation
 from ..animation.transform import MoveToTarget, Transform
 from ..animation.update import UpdateFromFunc
@@ -10,7 +12,6 @@ from ..constants import *
 from ..mobject.probability import SampleSpace
 from ..mobject.types.vectorized_mobject import VGroup
 from ..scene.scene import Scene
-from manim.utils.deprecation import deprecated
 
 
 @deprecated(since="0.11.0", until="0.12.0", message="Out of scope of the library.")


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Since there is [consensus](https://discord.com/channels/581738731934056449/737402086899056690/892008666037911603) to deprecated both scenes.
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
