### PR TITLE
Fix `NumberPlane` axis step 

### DIFF
--- a/manim/mobject/coordinate_systems.py
+++ b/manim/mobject/coordinate_systems.py
@@ -2109,14 +2109,14 @@ class NumberPlane(Axes):
         x_lines1, x_lines2 = self._get_lines_parallel_to_axis(
             x_axis,
             y_axis,
-            self.x_axis.x_step,
+            self.y_axis.x_step,
             self.faded_line_ratio,
         )
 
         y_lines1, y_lines2 = self._get_lines_parallel_to_axis(
             y_axis,
             x_axis,
-            self.y_axis.x_step,
+            self.x_axis.x_step,
             self.faded_line_ratio,
         )
 

--- a/tests/test_coordinate_system.py
+++ b/tests/test_coordinate_system.py
@@ -86,6 +86,10 @@ def test_NumberPlane():
         assert len(plane.y_lines) == num_y_lines
         assert len(plane.x_lines) == num_x_lines
 
+    plane = NumberPlane((-5, 5, 0.5), (-8, 8, 2))  # <- test for different step values
+    assert len(plane.x_lines) == 8
+    assert len(plane.y_lines) == 20
+
 
 def test_point_to_coords():
     ax = Axes(x_range=[0, 10, 2])


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Fixes #2082
When given different step values for the x and y axis, the line step are swapped. The frequency should follow the axis it's perpendicular to rather than parallel.
This is a direct port from #2083 . My fork went missing.
## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
