### PR TITLE
Prepared new release, ``v0.11.0``

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,10 +4,10 @@ authors:
   -
     name: "The Manim Community Developers"
 cff-version: "1.1.0"
-date-released: 2021-09-01
+date-released: 2021-10-01
 license: MIT
 message: "We acknowledge the importance of good software to support research, and we note that research becomes more valuable when it is communicated effectively. To demonstrate the value of Manim, we ask that you cite Manim in your work."
 title: Manim – Mathematical Animation Framework
 url: "https://www.manim.community/"
-version: "v0.10.0"
+version: "v0.11.0"
 ...

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ authors:
   -
     name: "The Manim Community Developers"
 cff-version: "1.1.0"
-date-released: 2021-10-01
+date-released: 2021-10-02
 license: MIT
 message: "We acknowledge the importance of good software to support research, and we note that research becomes more valuable when it is communicated effectively. To demonstrate the value of Manim, we ask that you cite Manim in your work."
 title: Manim – Mathematical Animation Framework

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 .. toctree::
 
+    changelog/0.11.0-changelog
     changelog/0.10.0-changelog
     changelog/0.9.0-changelog
     changelog/0.8.0-changelog

--- a/docs/source/changelog/0.11.0-changelog.rst
+++ b/docs/source/changelog/0.11.0-changelog.rst
@@ -124,7 +124,7 @@ Fixed bugs
 * `#2039 <https://github.com/ManimCommunity/manim/pull/2039>`__: Added opengl compatibility for :meth:`~Cylinder.add_bases`.
 
 
-* `#2066 <https://github.com/ManimCommunity/manim/pull/2066>`__: Fixed issue of the logging message when cache is full 
+* `#2066 <https://github.com/ManimCommunity/manim/pull/2066>`__: Fixed issue of the logging message when cache is full
 
 
 * `#2026 <https://github.com/ManimCommunity/manim/pull/2026>`__: Fixed opengl shift animation for :class:~.Text
@@ -133,7 +133,7 @@ Fixed bugs
 * `#2028 <https://github.com/ManimCommunity/manim/pull/2028>`__: Fixed opengl overriding svg fill color
 
 
-* `#2043 <https://github.com/ManimCommunity/manim/pull/2043>`__: Fix bug where `~.NumberLine.add_labels()`  cannot accept non-mobject labels. 
+* `#2043 <https://github.com/ManimCommunity/manim/pull/2043>`__: Fix bug where `~.NumberLine.add_labels()`  cannot accept non-mobject labels.
 
 
 * `#2011 <https://github.com/ManimCommunity/manim/pull/2011>`__: Fixed `-a` flag for OpenGL.
@@ -196,7 +196,7 @@ Unclassified changes
 * `#2016 <https://github.com/ManimCommunity/manim/pull/2016>`__: Add Opengl support for Boolean Operation
 
 
-* `#2108 <https://github.com/ManimCommunity/manim/pull/2108>`__: Fix `NumberPlane` axis step 
+* `#2108 <https://github.com/ManimCommunity/manim/pull/2108>`__: Fix `NumberPlane` axis step
 
 
 * `#2001 <https://github.com/ManimCommunity/manim/pull/2001>`__: LGTM Error Fix
@@ -204,4 +204,3 @@ Unclassified changes
 
 * `#2095 <https://github.com/ManimCommunity/manim/pull/2095>`__: Use math convention in polar coordinates
    - Switched the parameter names phi and theta in `cartesian_to_spherical` and `spherical_to_cartesian`
-

--- a/docs/source/changelog/0.11.0-changelog.rst
+++ b/docs/source/changelog/0.11.0-changelog.rst
@@ -7,7 +7,7 @@ v0.11.0
 Contributors
 ============
 
-A total of 25 people contributed to this
+A total of 27 people contributed to this
 release. People with a '+' by their names authored a patch for the first
 time.
 
@@ -20,6 +20,7 @@ time.
 * Hugues Devimeux
 * Jerónimo Squartini
 * Laith Bahodi
+* Meredith Espinosa +
 * Mysaa
 * Naveen M K
 * Nicolai Weitkemper +
@@ -28,6 +29,7 @@ time.
 * icedcoffeeee
 * imadjamil +
 * leleogere +
+* Максим Заякин +
 
 
 The patches included in this release have been reviewed by
@@ -56,18 +58,24 @@ the following contributors.
 Pull requests merged
 ====================
 
-A total of 40 pull requests were merged for this release.
+A total of 45 pull requests were merged for this release.
+
+Breaking changes
+----------------
+
+* `#2095 <https://github.com/ManimCommunity/manim/pull/2095>`__: Changed angles for polar coordinates to use math convention
+   This PR switches the parameter names ``phi`` and ``theta`` in :func:`cartesian_to_spherical` and :func:`spherical_to_cartesian` to align with the `usual definition in mathematics <https://user-images.githubusercontent.com/83535735/131709630-87290522-7747-4b21-9411-dd3d35ebaf0f.png>`__.
 
 Deprecated classes and functions
 --------------------------------
 
-* `#2102 <https://github.com/ManimCommunity/manim/pull/2102>`__: Deprecated `SampleSpaceScene` and `ReconfigurableScene`
+* `#2102 <https://github.com/ManimCommunity/manim/pull/2102>`__: Deprecated :class:`~.SampleSpaceScene` and :class:`~.ReconfigurableScene`
 
 
-* `#2061 <https://github.com/ManimCommunity/manim/pull/2061>`__: Remove deprecated u-min/max and v-min/max in :class:'~.Surface'
+* `#2061 <https://github.com/ManimCommunity/manim/pull/2061>`__: Remove deprecated ``u_min``, ``u_max``, ``v_min``, ``v_max`` in :class:`~.Surface`
 
 
-* `#2024 <https://github.com/ManimCommunity/manim/pull/2024>`__: Deprecated redundant methods of Mobject
+* `#2024 <https://github.com/ManimCommunity/manim/pull/2024>`__: Deprecated redundant methods :meth:`.Mobject.rotate_in_place`, :meth:`.Mobject.scale_in_place`, :meth:`.Mobject.scale_about_point`
 
 
 * `#1991 <https://github.com/ManimCommunity/manim/pull/1991>`__: Deprecated :meth:`.VMobject.get_points`
@@ -76,14 +84,18 @@ Deprecated classes and functions
 New features
 ------------
 
+* `#2118 <https://github.com/ManimCommunity/manim/pull/2118>`__: Added 3D support for :class:`~.ArrowVectorField` and :class:`~.StreamLines` 
+
+
 * `#2075 <https://github.com/ManimCommunity/manim/pull/2075>`__: Implemented :meth:`.Mobject.set_default`, a mechanism for changing default values of keyword arguments
 
 
 * `#1998 <https://github.com/ManimCommunity/manim/pull/1998>`__: Added support for Boolean Operations on VMobjects
-   - Boolean Operations :class:`~.Union`, :class:`~.Difference`, :class:`~.Intersection`, :class:`~.Exclusion`.
+   This PR introduces boolean operations for :class:`~.VMobject`, see details and examples at
+   :class:`~.Union`, :class:`~.Difference`, :class:`~.Intersection`, :class:`~.Exclusion`.
 
-* `#1469 <https://github.com/ManimCommunity/manim/pull/1469>`__: Added proportion_from_point method to VMobject, which uses some new bezier curve utilities
-   Added new `VMobject.proportion_from_point` method and new `proportions_along_bezier_curve_for_point` and `point_lies_on_bezier_curve` bezier utility functions.
+* `#1469 <https://github.com/ManimCommunity/manim/pull/1469>`__: Added :meth:`.VMobject.proportion_from_point` to measure the proportion of points along a Bezier curve
+
 
 Enhancements
 ------------
@@ -91,16 +103,19 @@ Enhancements
 * `#2113 <https://github.com/ManimCommunity/manim/pull/2113>`__: Added OpenGL compatibility to :meth:`.ThreeDScene.begin_ambient_camera_rotation` and :meth:`.ThreeDScene.move_camera`
 
 
+* `#2016 <https://github.com/ManimCommunity/manim/pull/2016>`__: Added OpenGL support for :mod:`~.mobject.boolean_ops`
+
+
 * `#2084 <https://github.com/ManimCommunity/manim/pull/2084>`__: Added :meth:`~Table.get_highlighted_cell` and fixed :meth:`~Table.add_highlighted_cell`
-   Following the ideas of @kolibril13 and @behackl in PR #2079, this PR attempts to fix the issue in  #2078 with an additional method :meth:`~Table.get_highlighted_cell`.
-
-* `#2013 <https://github.com/ManimCommunity/manim/pull/2013>`__: Removed unnecesary check in :class:`~.TransformMatchingAbstractBase` - Fixes #1609
 
 
-* `#1971 <https://github.com/ManimCommunity/manim/pull/1971>`__: Add OpenGL support for :class:`~.StreamLines`
-   Add OpenGL support for :class:~.StreamLines
+* `#2013 <https://github.com/ManimCommunity/manim/pull/2013>`__: Removed unnecessary check in :class:`~.TransformMatchingAbstractBase`
 
-* `#2041 <https://github.com/ManimCommunity/manim/pull/2041>`__: Added config to enable opengl wireframe for debugging
+
+* `#1971 <https://github.com/ManimCommunity/manim/pull/1971>`__: Added OpenGL support for :class:`~.StreamLines`
+
+
+* `#2041 <https://github.com/ManimCommunity/manim/pull/2041>`__: Added config option to enable OpenGL wireframe for debugging
 
 
 Fixed bugs
@@ -109,67 +124,75 @@ Fixed bugs
 * `#2070 <https://github.com/ManimCommunity/manim/pull/2070>`__: Fixed :meth:`~OpenGLRenderer.get_frame` when window is created
 
 
-* `#2071 <https://github.com/ManimCommunity/manim/pull/2071>`__: Fixed :class:`~AnimationGroup` opengl compatibility
+* `#2071 <https://github.com/ManimCommunity/manim/pull/2071>`__: Fixed :class:`~AnimationGroup` OpenGL compatibility
+
+
+* `#2108 <https://github.com/ManimCommunity/manim/pull/2108>`__: Fixed swapped axis step values in :class:`~.NumberPlane`
 
 
 * `#2072 <https://github.com/ManimCommunity/manim/pull/2072>`__: Added OpenGL compatibility for :class:`~.Cube`.
 
 
-* `#2060 <https://github.com/ManimCommunity/manim/pull/2060>`__: Fixed opengl compatibility issue for meth:`~Line.set_opacity`
+* `#2060 <https://github.com/ManimCommunity/manim/pull/2060>`__: Fixed OpenGL compatibility issue for meth:`~Line.set_opacity`
 
 
-* `#2037 <https://github.com/ManimCommunity/manim/pull/2037>`__: Fixed OpenGL :meth:`~.OpenGLMobject.apply_complex_function`
+* `#2037 <https://github.com/ManimCommunity/manim/pull/2037>`__: Fixed return value of :meth:`~.OpenGLMobject.apply_complex_function`
 
 
-* `#2039 <https://github.com/ManimCommunity/manim/pull/2039>`__: Added opengl compatibility for :meth:`~Cylinder.add_bases`.
+* `#2039 <https://github.com/ManimCommunity/manim/pull/2039>`__: Added OpenGL compatibility for :meth:`~Cylinder.add_bases`.
 
 
-* `#2066 <https://github.com/ManimCommunity/manim/pull/2066>`__: Fixed issue of the logging message when cache is full
+* `#2066 <https://github.com/ManimCommunity/manim/pull/2066>`__: Fixed error raised by logging when cache is full 
 
 
-* `#2026 <https://github.com/ManimCommunity/manim/pull/2026>`__: Fixed opengl shift animation for :class:~.Text
+* `#2026 <https://github.com/ManimCommunity/manim/pull/2026>`__: Fixed OpenGL shift animation for :class:`~.Text`
 
 
-* `#2028 <https://github.com/ManimCommunity/manim/pull/2028>`__: Fixed opengl overriding svg fill color
+* `#2028 <https://github.com/ManimCommunity/manim/pull/2028>`__: Fixed OpenGL overriding SVG fill color
 
 
-* `#2043 <https://github.com/ManimCommunity/manim/pull/2043>`__: Fix bug where `~.NumberLine.add_labels()`  cannot accept non-mobject labels.
+* `#2043 <https://github.com/ManimCommunity/manim/pull/2043>`__: Fixed bug where :meth:`.NumberLine.add_labels`  cannot accept non-mobject labels
 
 
-* `#2011 <https://github.com/ManimCommunity/manim/pull/2011>`__: Fixed `-a` flag for OpenGL.
+* `#2011 <https://github.com/ManimCommunity/manim/pull/2011>`__: Fixed ``-a`` flag for OpenGL rendering
 
 
-* `#1994 <https://github.com/ManimCommunity/manim/pull/1994>`__: Fix :meth:`~.input_to_graph_point` when passing a `line_graph`
+* `#1994 <https://github.com/ManimCommunity/manim/pull/1994>`__: Fix :meth:`~.input_to_graph_point` when passing a line graph (from :meth:`.Axes.get_line_graph`)
 
 
-* `#2017 <https://github.com/ManimCommunity/manim/pull/2017>`__: Avoid using deprecated get_points and fix :class:`~.OpenGLPMPoint` color
+* `#2017 <https://github.com/ManimCommunity/manim/pull/2017>`__: Avoided using deprecated ``get_points`` method and fixed :class:`~.OpenGLPMPoint` color
 
 
 Documentation-related changes
 -----------------------------
 
+* `#2115 <https://github.com/ManimCommunity/manim/pull/2115>`__: Improved docstring of :meth:`.PMobject.add_points`
+
+
+* `#2116 <https://github.com/ManimCommunity/manim/pull/2116>`__: Made type hint for ``line_spacing`` argument of :class:`~.Paragraph` more accurate
+
 * `#2101 <https://github.com/ManimCommunity/manim/pull/2101>`__: Added note that translation process is not ready
 
 
-* `#2055 <https://github.com/ManimCommunity/manim/pull/2055>`__: Fixed :meth:`~Graph.add_edges` and :meth:`~Graph.add_vertices` parameter types
-   Updates docs for Graph.add_edges and Graph.add_vertices so that the parameters `edges` and `vertices` are the right types.
-
-* `#862 <https://github.com/ManimCommunity/manim/pull/862>`__: Prepare documentation for translation (still work in progress)
+* `#2055 <https://github.com/ManimCommunity/manim/pull/2055>`__: Fixed parameter types of :meth:`.Graph.add_edges` and :meth:`.Graph.add_vertices`
 
 
-* `#2035 <https://github.com/ManimCommunity/manim/pull/2035>`__: Fix broken link in readme
+* `#862 <https://github.com/ManimCommunity/manim/pull/862>`__: Prepared documentation for translation (still work in progress)
 
 
-* `#2020 <https://github.com/ManimCommunity/manim/pull/2020>`__:  Corrected user-wide Config Paths for *NIX
+* `#2035 <https://github.com/ManimCommunity/manim/pull/2035>`__: Fixed broken link in README
+
+
+* `#2020 <https://github.com/ManimCommunity/manim/pull/2020>`__:  Corrected paths to user-wide configuration files for MacOS and Linux
 
 
 Changes concerning the testing system
 -------------------------------------
 
-* `#2008 <https://github.com/ManimCommunity/manim/pull/2008>`__: Reuse CLI flag tests for opengl
+* `#2008 <https://github.com/ManimCommunity/manim/pull/2008>`__: Reuse CLI flag tests for OpenGL
 
 
-* `#2080 <https://github.com/ManimCommunity/manim/pull/2080>`__: Reused tests for :class:`~Mobject`. with :class:`~OpenGLMobject`
+* `#2080 <https://github.com/ManimCommunity/manim/pull/2080>`__: Reused tests for :class:`~.Mobject`. for :class:`~.OpenGLMobject`
 
 
 Changes to our development infrastructure
@@ -184,23 +207,24 @@ Code quality improvements and similar refactors
 * `#2064 <https://github.com/ManimCommunity/manim/pull/2064>`__: Removed duplicate insert shader directory
 
 
-* `#2027 <https://github.com/ManimCommunity/manim/pull/2027>`__: Added missing space in info message for :meth:`~.SceneFileWriter.clean_cache`
-   This PR should fix the missing whitespace in an info message: `… ago.You can change this …`.
+* `#2027 <https://github.com/ManimCommunity/manim/pull/2027>`__: Improved wording in info message issued by :meth:`.SceneFileWriter.clean_cache`
 
-* `#1968 <https://github.com/ManimCommunity/manim/pull/1968>`__: Flake8 Changes + Fixing Warnings
+
+* `#1968 <https://github.com/ManimCommunity/manim/pull/1968>`__: Sharpened Flake8 configuration and fixed resulting warnings
+
+
+New releases
+------------
+
+* `#2114 <https://github.com/ManimCommunity/manim/pull/2114>`__: Prepared new release, ``v0.11.0``
 
 
 Unclassified changes
 --------------------
 
-* `#2016 <https://github.com/ManimCommunity/manim/pull/2016>`__: Add Opengl support for Boolean Operation
+* `#2117 <https://github.com/ManimCommunity/manim/pull/2117>`__: Revert colour of background in docs to BLACK in `Mobject` page. 
 
 
-* `#2108 <https://github.com/ManimCommunity/manim/pull/2108>`__: Fix `NumberPlane` axis step
+* `#2001 <https://github.com/ManimCommunity/manim/pull/2001>`__: Fixed several warnings issued by LGTM
 
 
-* `#2001 <https://github.com/ManimCommunity/manim/pull/2001>`__: LGTM Error Fix
-   Fixes many LGTM issues.
-
-* `#2095 <https://github.com/ManimCommunity/manim/pull/2095>`__: Use math convention in polar coordinates
-   - Switched the parameter names phi and theta in `cartesian_to_spherical` and `spherical_to_cartesian`

--- a/docs/source/changelog/0.11.0-changelog.rst
+++ b/docs/source/changelog/0.11.0-changelog.rst
@@ -1,0 +1,207 @@
+*******
+v0.11.0
+*******
+
+:Date: October 01, 2021
+
+Contributors
+============
+
+A total of 25 people contributed to this
+release. People with a '+' by their names authored a patch for the first
+time.
+
+* Aathish Sivasubrahmanian
+* Benjamin Hackl
+* Charlie +
+* Christopher Besch +
+* Darylgolden
+* GameDungeon
+* Hugues Devimeux
+* Jerónimo Squartini
+* Laith Bahodi
+* Mysaa
+* Naveen M K
+* Nicolai Weitkemper +
+* Oliver
+* Ryan McCauley
+* icedcoffeeee
+* imadjamil +
+* leleogere +
+
+
+The patches included in this release have been reviewed by
+the following contributors.
+
+* Aathish Sivasubrahmanian
+* Benjamin Hackl
+* Charlie
+* Darylgolden
+* GameDungeon
+* Hugues Devimeux
+* Jan-Hendrik Müller
+* Laith Bahodi
+* Mark Miller
+* Mysaa
+* Naveen M K
+* Nicolai Weitkemper
+* Oliver
+* Raghav Goel
+* Ryan McCauley
+* Skaft
+* friedkeenan
+* icedcoffeeee
+* leleogere
+
+Pull requests merged
+====================
+
+A total of 40 pull requests were merged for this release.
+
+Deprecated classes and functions
+--------------------------------
+
+* `#2102 <https://github.com/ManimCommunity/manim/pull/2102>`__: Deprecated `SampleSpaceScene` and `ReconfigurableScene`
+
+
+* `#2061 <https://github.com/ManimCommunity/manim/pull/2061>`__: Remove deprecated u-min/max and v-min/max in :class:'~.Surface'
+
+
+* `#2024 <https://github.com/ManimCommunity/manim/pull/2024>`__: Deprecated redundant methods of Mobject
+
+
+* `#1991 <https://github.com/ManimCommunity/manim/pull/1991>`__: Deprecated :meth:`.VMobject.get_points`
+
+
+New features
+------------
+
+* `#2075 <https://github.com/ManimCommunity/manim/pull/2075>`__: Implemented :meth:`.Mobject.set_default`, a mechanism for changing default values of keyword arguments
+
+
+* `#1998 <https://github.com/ManimCommunity/manim/pull/1998>`__: Added support for Boolean Operations on VMobjects
+   - Boolean Operations :class:`~.Union`, :class:`~.Difference`, :class:`~.Intersection`, :class:`~.Exclusion`.
+
+* `#1469 <https://github.com/ManimCommunity/manim/pull/1469>`__: Added proportion_from_point method to VMobject, which uses some new bezier curve utilities
+   Added new `VMobject.proportion_from_point` method and new `proportions_along_bezier_curve_for_point` and `point_lies_on_bezier_curve` bezier utility functions.
+
+Enhancements
+------------
+
+* `#2113 <https://github.com/ManimCommunity/manim/pull/2113>`__: Added OpenGL compatibility to :meth:`.ThreeDScene.begin_ambient_camera_rotation` and :meth:`.ThreeDScene.move_camera`
+
+
+* `#2084 <https://github.com/ManimCommunity/manim/pull/2084>`__: Added :meth:`~Table.get_highlighted_cell` and fixed :meth:`~Table.add_highlighted_cell`
+   Following the ideas of @kolibril13 and @behackl in PR #2079, this PR attempts to fix the issue in  #2078 with an additional method :meth:`~Table.get_highlighted_cell`.
+
+* `#2013 <https://github.com/ManimCommunity/manim/pull/2013>`__: Removed unnecesary check in :class:`~.TransformMatchingAbstractBase` - Fixes #1609
+
+
+* `#1971 <https://github.com/ManimCommunity/manim/pull/1971>`__: Add OpenGL support for :class:`~.StreamLines`
+   Add OpenGL support for :class:~.StreamLines
+
+* `#2041 <https://github.com/ManimCommunity/manim/pull/2041>`__: Added config to enable opengl wireframe for debugging
+
+
+Fixed bugs
+----------
+
+* `#2070 <https://github.com/ManimCommunity/manim/pull/2070>`__: Fixed :meth:`~OpenGLRenderer.get_frame` when window is created
+
+
+* `#2071 <https://github.com/ManimCommunity/manim/pull/2071>`__: Fixed :class:`~AnimationGroup` opengl compatibility
+
+
+* `#2072 <https://github.com/ManimCommunity/manim/pull/2072>`__: Added OpenGL compatibility for :class:`~.Cube`.
+
+
+* `#2060 <https://github.com/ManimCommunity/manim/pull/2060>`__: Fixed opengl compatibility issue for meth:`~Line.set_opacity`
+
+
+* `#2037 <https://github.com/ManimCommunity/manim/pull/2037>`__: Fixed OpenGL :meth:`~.OpenGLMobject.apply_complex_function`
+
+
+* `#2039 <https://github.com/ManimCommunity/manim/pull/2039>`__: Added opengl compatibility for :meth:`~Cylinder.add_bases`.
+
+
+* `#2066 <https://github.com/ManimCommunity/manim/pull/2066>`__: Fixed issue of the logging message when cache is full 
+
+
+* `#2026 <https://github.com/ManimCommunity/manim/pull/2026>`__: Fixed opengl shift animation for :class:~.Text
+
+
+* `#2028 <https://github.com/ManimCommunity/manim/pull/2028>`__: Fixed opengl overriding svg fill color
+
+
+* `#2043 <https://github.com/ManimCommunity/manim/pull/2043>`__: Fix bug where `~.NumberLine.add_labels()`  cannot accept non-mobject labels. 
+
+
+* `#2011 <https://github.com/ManimCommunity/manim/pull/2011>`__: Fixed `-a` flag for OpenGL.
+
+
+* `#1994 <https://github.com/ManimCommunity/manim/pull/1994>`__: Fix :meth:`~.input_to_graph_point` when passing a `line_graph`
+
+
+* `#2017 <https://github.com/ManimCommunity/manim/pull/2017>`__: Avoid using deprecated get_points and fix :class:`~.OpenGLPMPoint` color
+
+
+Documentation-related changes
+-----------------------------
+
+* `#2101 <https://github.com/ManimCommunity/manim/pull/2101>`__: Added note that translation process is not ready
+
+
+* `#2055 <https://github.com/ManimCommunity/manim/pull/2055>`__: Fixed :meth:`~Graph.add_edges` and :meth:`~Graph.add_vertices` parameter types
+   Updates docs for Graph.add_edges and Graph.add_vertices so that the parameters `edges` and `vertices` are the right types.
+
+* `#862 <https://github.com/ManimCommunity/manim/pull/862>`__: Prepare documentation for translation (still work in progress)
+
+
+* `#2035 <https://github.com/ManimCommunity/manim/pull/2035>`__: Fix broken link in readme
+
+
+* `#2020 <https://github.com/ManimCommunity/manim/pull/2020>`__:  Corrected user-wide Config Paths for *NIX
+
+
+Changes concerning the testing system
+-------------------------------------
+
+* `#2008 <https://github.com/ManimCommunity/manim/pull/2008>`__: Reuse CLI flag tests for opengl
+
+
+* `#2080 <https://github.com/ManimCommunity/manim/pull/2080>`__: Reused tests for :class:`~Mobject`. with :class:`~OpenGLMobject`
+
+
+Changes to our development infrastructure
+-----------------------------------------
+
+* `#2004 <https://github.com/ManimCommunity/manim/pull/2004>`__: Cancel previous workflows in the same branch in Github Actions
+
+
+Code quality improvements and similar refactors
+-----------------------------------------------
+
+* `#2064 <https://github.com/ManimCommunity/manim/pull/2064>`__: Removed duplicate insert shader directory
+
+
+* `#2027 <https://github.com/ManimCommunity/manim/pull/2027>`__: Added missing space in info message for :meth:`~.SceneFileWriter.clean_cache`
+   This PR should fix the missing whitespace in an info message: `… ago.You can change this …`.
+
+* `#1968 <https://github.com/ManimCommunity/manim/pull/1968>`__: Flake8 Changes + Fixing Warnings
+
+
+Unclassified changes
+--------------------
+
+* `#2016 <https://github.com/ManimCommunity/manim/pull/2016>`__: Add Opengl support for Boolean Operation
+
+
+* `#2108 <https://github.com/ManimCommunity/manim/pull/2108>`__: Fix `NumberPlane` axis step 
+
+
+* `#2001 <https://github.com/ManimCommunity/manim/pull/2001>`__: LGTM Error Fix
+   Fixes many LGTM issues.
+
+* `#2095 <https://github.com/ManimCommunity/manim/pull/2095>`__: Use math convention in polar coordinates
+   - Switched the parameter names phi and theta in `cartesian_to_spherical` and `spherical_to_cartesian`
+

--- a/docs/source/changelog/0.11.0-changelog.rst
+++ b/docs/source/changelog/0.11.0-changelog.rst
@@ -84,7 +84,7 @@ Deprecated classes and functions
 New features
 ------------
 
-* `#2118 <https://github.com/ManimCommunity/manim/pull/2118>`__: Added 3D support for :class:`~.ArrowVectorField` and :class:`~.StreamLines` 
+* `#2118 <https://github.com/ManimCommunity/manim/pull/2118>`__: Added 3D support for :class:`~.ArrowVectorField` and :class:`~.StreamLines`
 
 
 * `#2075 <https://github.com/ManimCommunity/manim/pull/2075>`__: Implemented :meth:`.Mobject.set_default`, a mechanism for changing default values of keyword arguments
@@ -142,7 +142,7 @@ Fixed bugs
 * `#2039 <https://github.com/ManimCommunity/manim/pull/2039>`__: Added OpenGL compatibility for :meth:`~Cylinder.add_bases`.
 
 
-* `#2066 <https://github.com/ManimCommunity/manim/pull/2066>`__: Fixed error raised by logging when cache is full 
+* `#2066 <https://github.com/ManimCommunity/manim/pull/2066>`__: Fixed error raised by logging when cache is full
 
 
 * `#2026 <https://github.com/ManimCommunity/manim/pull/2026>`__: Fixed OpenGL shift animation for :class:`~.Text`
@@ -222,9 +222,7 @@ New releases
 Unclassified changes
 --------------------
 
-* `#2117 <https://github.com/ManimCommunity/manim/pull/2117>`__: Revert colour of background in docs to BLACK in `Mobject` page. 
+* `#2117 <https://github.com/ManimCommunity/manim/pull/2117>`__: Revert colour of background in docs to BLACK in `Mobject` page.
 
 
 * `#2001 <https://github.com/ManimCommunity/manim/pull/2001>`__: Fixed several warnings issued by LGTM
-
-

--- a/docs/source/changelog/0.11.0-changelog.rst
+++ b/docs/source/changelog/0.11.0-changelog.rst
@@ -2,12 +2,12 @@
 v0.11.0
 *******
 
-:Date: October 01, 2021
+:Date: October 02, 2021
 
 Contributors
 ============
 
-A total of 27 people contributed to this
+A total of 31 people contributed to this
 release. People with a '+' by their names authored a patch for the first
 time.
 
@@ -16,6 +16,7 @@ time.
 * Charlie +
 * Christopher Besch +
 * Darylgolden
+* Evan Boehs +
 * GameDungeon
 * Hugues Devimeux
 * Jerónimo Squartini
@@ -26,6 +27,7 @@ time.
 * Nicolai Weitkemper +
 * Oliver
 * Ryan McCauley
+* Tim +
 * icedcoffeeee
 * imadjamil +
 * leleogere +
@@ -39,9 +41,11 @@ the following contributors.
 * Benjamin Hackl
 * Charlie
 * Darylgolden
+* Evan Boehs
 * GameDungeon
 * Hugues Devimeux
 * Jan-Hendrik Müller
+* Jason Villanueva
 * Laith Bahodi
 * Mark Miller
 * Mysaa
@@ -58,16 +62,32 @@ the following contributors.
 Pull requests merged
 ====================
 
-A total of 45 pull requests were merged for this release.
+A total of 55 pull requests were merged for this release.
 
 Breaking changes
 ----------------
 
+* `#1990 <https://github.com/ManimCommunity/manim/pull/1990>`__: Changed and improved the implementation of :meth:`.CoordinateSystem.get_area` to work without Riemann rectangles
+   This changes how :meth:`.CoordinateSystem.get_area` is implemented. To mimic the old behavior (tiny Riemann rectangles), use :meth:`.CoordinateSystem.get_riemann_rectangles` with a small value for ``dx``.
+
 * `#2095 <https://github.com/ManimCommunity/manim/pull/2095>`__: Changed angles for polar coordinates to use math convention
    This PR switches the parameter names ``phi`` and ``theta`` in :func:`cartesian_to_spherical` and :func:`spherical_to_cartesian` to align with the `usual definition in mathematics <https://user-images.githubusercontent.com/83535735/131709630-87290522-7747-4b21-9411-dd3d35ebaf0f.png>`__.
 
+Highlights
+----------
+
+* `#2094 <https://github.com/ManimCommunity/manim/pull/2094>`__: Implemented :class:`~.ImplicitFunction` and :meth:`.CoordinateSystem.get_implicit_curve` for plotting implicit curves
+   An :class:`~.ImplicitFunction` allows to plot the points :math:`(x, y)` that satisfy some equation :math:`f(x,y) = 0`.
+
+* `#1998 <https://github.com/ManimCommunity/manim/pull/1998>`__: Added support for Boolean Operations on VMobjects
+   This PR introduces boolean operations for :class:`~.VMobject`, see details and examples at
+   :class:`~.Union`, :class:`~.Difference`, :class:`~.Intersection`, :class:`~.Exclusion`.
+
 Deprecated classes and functions
 --------------------------------
+
+* `#2123 <https://github.com/ManimCommunity/manim/pull/2123>`__: Renamed ``distance`` parameter of :class:`.ThreeDScene` and :class:`.ThreeDCamera` to ``focal_distance``
+
 
 * `#2102 <https://github.com/ManimCommunity/manim/pull/2102>`__: Deprecated :class:`~.SampleSpaceScene` and :class:`~.ReconfigurableScene`
 
@@ -90,15 +110,14 @@ New features
 * `#2075 <https://github.com/ManimCommunity/manim/pull/2075>`__: Implemented :meth:`.Mobject.set_default`, a mechanism for changing default values of keyword arguments
 
 
-* `#1998 <https://github.com/ManimCommunity/manim/pull/1998>`__: Added support for Boolean Operations on VMobjects
-   This PR introduces boolean operations for :class:`~.VMobject`, see details and examples at
-   :class:`~.Union`, :class:`~.Difference`, :class:`~.Intersection`, :class:`~.Exclusion`.
-
 * `#1469 <https://github.com/ManimCommunity/manim/pull/1469>`__: Added :meth:`.VMobject.proportion_from_point` to measure the proportion of points along a Bezier curve
 
 
 Enhancements
 ------------
+
+* `#2111 <https://github.com/ManimCommunity/manim/pull/2111>`__: Improved setting of OpenGL colors
+
 
 * `#2113 <https://github.com/ManimCommunity/manim/pull/2113>`__: Added OpenGL compatibility to :meth:`.ThreeDScene.begin_ambient_camera_rotation` and :meth:`.ThreeDScene.move_camera`
 
@@ -166,10 +185,23 @@ Fixed bugs
 Documentation-related changes
 -----------------------------
 
+* `#2131 <https://github.com/ManimCommunity/manim/pull/2131>`__: Copyedited the configuration tutorial in the documentation
+
+
+* `#2120 <https://github.com/ManimCommunity/manim/pull/2120>`__: Changed ``manim_directive`` to use a clean configuration via ``tempconfig``
+
+
+* `#2122 <https://github.com/ManimCommunity/manim/pull/2122>`__: Fixed broken links in inheritance graphs by moving them to ``reference.rst``
+
+
 * `#2115 <https://github.com/ManimCommunity/manim/pull/2115>`__: Improved docstring of :meth:`.PMobject.add_points`
 
 
 * `#2116 <https://github.com/ManimCommunity/manim/pull/2116>`__: Made type hint for ``line_spacing`` argument of :class:`~.Paragraph` more accurate
+
+
+* `#2117 <https://github.com/ManimCommunity/manim/pull/2117>`__: Changed the way the background color was set in a documentation example to avoid leaking the setting to other examples
+
 
 * `#2101 <https://github.com/ManimCommunity/manim/pull/2101>`__: Added note that translation process is not ready
 
@@ -204,6 +236,18 @@ Changes to our development infrastructure
 Code quality improvements and similar refactors
 -----------------------------------------------
 
+* `#2050 <https://github.com/ManimCommunity/manim/pull/2050>`__: Make colour aliases IDE-friendly
+
+
+* `#2126 <https://github.com/ManimCommunity/manim/pull/2126>`__: Fixed whitespace in info message issued by :meth:`.SceneFileWriter.clean_cache`
+
+
+* `#2124 <https://github.com/ManimCommunity/manim/pull/2124>`__: Upgraded several dependencies (in particular: ``skia-pathops``)
+
+
+* `#2001 <https://github.com/ManimCommunity/manim/pull/2001>`__: Fixed several warnings issued by LGTM
+
+
 * `#2064 <https://github.com/ManimCommunity/manim/pull/2064>`__: Removed duplicate insert shader directory
 
 
@@ -217,12 +261,3 @@ New releases
 ------------
 
 * `#2114 <https://github.com/ManimCommunity/manim/pull/2114>`__: Prepared new release, ``v0.11.0``
-
-
-Unclassified changes
---------------------
-
-* `#2117 <https://github.com/ManimCommunity/manim/pull/2117>`__: Revert colour of background in docs to BLACK in `Mobject` page.
-
-
-* `#2001 <https://github.com/ManimCommunity/manim/pull/2001>`__: Fixed several warnings issued by LGTM

--- a/docs/source/changelog/0.11.0-changelog.rst
+++ b/docs/source/changelog/0.11.0-changelog.rst
@@ -77,11 +77,14 @@ Highlights
 ----------
 
 * `#2094 <https://github.com/ManimCommunity/manim/pull/2094>`__: Implemented :class:`~.ImplicitFunction` and :meth:`.CoordinateSystem.get_implicit_curve` for plotting implicit curves
-   An :class:`~.ImplicitFunction` allows to plot the points :math:`(x, y)` that satisfy some equation :math:`f(x,y) = 0`.
+   An :class:`~.ImplicitFunction` that plots the points :math:`(x, y)` which satisfy some equation :math:`f(x,y) = 0`.
+
+* `#2075 <https://github.com/ManimCommunity/manim/pull/2075>`__: Implemented :meth:`.Mobject.set_default`, a mechanism for changing default values of keyword arguments
+
 
 * `#1998 <https://github.com/ManimCommunity/manim/pull/1998>`__: Added support for Boolean Operations on VMobjects
-   This PR introduces boolean operations for :class:`~.VMobject`, see details and examples at
-   :class:`~.Union`, :class:`~.Difference`, :class:`~.Intersection`, :class:`~.Exclusion`.
+   This PR introduces boolean operations for :class:`~.VMobject`; see details and examples at
+   :class:`~.Union`, :class:`~.Difference`, :class:`~.Intersection` and :class:`~.Exclusion`.
 
 Deprecated classes and functions
 --------------------------------
@@ -92,7 +95,7 @@ Deprecated classes and functions
 * `#2102 <https://github.com/ManimCommunity/manim/pull/2102>`__: Deprecated :class:`~.SampleSpaceScene` and :class:`~.ReconfigurableScene`
 
 
-* `#2061 <https://github.com/ManimCommunity/manim/pull/2061>`__: Remove deprecated ``u_min``, ``u_max``, ``v_min``, ``v_max`` in :class:`~.Surface`
+* `#2061 <https://github.com/ManimCommunity/manim/pull/2061>`__: Removed deprecated ``u_min``, ``u_max``, ``v_min``, ``v_max`` in :class:`~.Surface`
 
 
 * `#2024 <https://github.com/ManimCommunity/manim/pull/2024>`__: Deprecated redundant methods :meth:`.Mobject.rotate_in_place`, :meth:`.Mobject.scale_in_place`, :meth:`.Mobject.scale_about_point`
@@ -105,9 +108,6 @@ New features
 ------------
 
 * `#2118 <https://github.com/ManimCommunity/manim/pull/2118>`__: Added 3D support for :class:`~.ArrowVectorField` and :class:`~.StreamLines`
-
-
-* `#2075 <https://github.com/ManimCommunity/manim/pull/2075>`__: Implemented :meth:`.Mobject.set_default`, a mechanism for changing default values of keyword arguments
 
 
 * `#1469 <https://github.com/ManimCommunity/manim/pull/1469>`__: Added :meth:`.VMobject.proportion_from_point` to measure the proportion of points along a Bezier curve
@@ -224,7 +224,7 @@ Changes concerning the testing system
 * `#2008 <https://github.com/ManimCommunity/manim/pull/2008>`__: Reuse CLI flag tests for OpenGL
 
 
-* `#2080 <https://github.com/ManimCommunity/manim/pull/2080>`__: Reused tests for :class:`~.Mobject`. for :class:`~.OpenGLMobject`
+* `#2080 <https://github.com/ManimCommunity/manim/pull/2080>`__: Reused :class:`~.Mobject` tests for :class:`~.OpenGLMobject`
 
 
 Changes to our development infrastructure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "manim"
-version = "0.10.0"
+version = "0.11.0"
 description = "Animation engine for explanatory math videos."
 authors = ["The Manim Community Developers","3b1b <grant@3blue1brown.com>"]
 license="MIT"


### PR DESCRIPTION
New release preparations.

Some notes:

- There are still some approved PRs that can (and should) be merged (some of them from @icedcoffeeee's disappeared fork),
- we currently have a problem with the new dependency `skia-pathtools` introduced in #1998: the latest released version is incompatible with M1 macs. We need to discuss what the best strategy to handle this is: It *is* possible to build `skia-pathtools` locally (assuming a `Cython` installation is available, and by using their latest master branch, `pip install git+https://github.com/fonttools/skia-pathops.git`) -- but that doesn't seem to be a great solution for users. Alternatively, we could revert the boolean operation PR, or degrade `skia-pathtools` to an optional dependency (and include instructions in a try-except block around the corresponding imports). Further suggestions are welcome.