### PR TITLE
Made type hint for ``line_spacing`` argument of :class:`~.Paragraph` more accurate

### DIFF
--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -120,7 +120,7 @@ class Paragraph(VGroup):
 
     Parameters
     ----------
-    line_spacing : :class:`int`, optional
+    line_spacing : :class:`float`, optional
         Represents the spacing between lines. Default to -1, which means auto.
     alignment : :class:`str`, optional
         Defines the alignment of paragraph. Default to "left". Possible values are "left", "right", "center"
@@ -411,7 +411,7 @@ class Text(SVGMobject):
         stroke_width: float = 0,
         color: Color = WHITE,
         font_size: float = DEFAULT_FONT_SIZE,
-        line_spacing: int = -1,
+        line_spacing: float = -1,
         font: str = "",
         slant: str = NORMAL,
         weight: str = NORMAL,


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
This PR adjusts the type hint on the `line_spacing` property in `Text` to be marked as a `float` instead of an `int`, closing issue #2110. For parity, adjusts the documentation to note that the `line_spacing` property in `Paragraph` is also a `float`.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
While `line_spacing` may *theoretically* want to be an int, having non-integer line spacings is a long-time established need. Moreover, no matter what the initial `line_spacing` value is, it is [*always* multiplied by `font_size`](https://github.com/ManimCommunity/manim/blob/main/manim/mobject/svg/text_mobject.py#L475-L480), which is itself a float. In Python, multiplying an int by a float results in a float, so after construction, `line_spacing` will *always* be a float. Therefore, we can safely and confidently change the type hint of `line_spacing` to be a float.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
[Text](https://manimce--2116.org.readthedocs.build/en/2116/reference/manim.mobject.svg.text_mobject.Text.html#manim.mobject.svg.text_mobject.Text)
[Paragraph](https://manimce--2116.org.readthedocs.build/en/2116/reference/manim.mobject.svg.text_mobject.Paragraph.html)

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
