### PR TITLE
Revert colour of background in docs to BLACK in `Mobject` page. 

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -210,7 +210,7 @@ class Mobject:
 
             class ChangedDefaultTextcolor(Scene):
                 def construct(self):
-                    self.camera.background_color
+                    self.camera.background_color = WHITE
                     Text.set_default(color=BLACK)
                     self.add(Text("Changing default values is easy!"))
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -208,10 +208,9 @@ class Mobject:
         .. manim:: ChangedDefaultTextcolor
             :save_last_frame:
 
-            config.background_color = WHITE
-
             class ChangedDefaultTextcolor(Scene):
                 def construct(self):
+                    self.camera.background_color
                     Text.set_default(color=BLACK)
                     self.add(Text("Changing default values is easy!"))
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
Calling `config.background_color` in the `set_default`  example was overwriting the background colour for all following examples. This fixes that issue.

Old:
https://docs.manim.community/en/latest/reference/manim.mobject.mobject.Mobject.html#changeddefaulttextcolor
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
Waiting...

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
