### PR TITLE
Draft: Add type annotations to mobject.py

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from _typeshed import SupportsLessThan
-
 """Base classes for objects that can be displayed."""
 
 
@@ -18,7 +16,17 @@ import warnings
 from functools import partialmethod, reduce
 from math import ceil
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence, TypeVar, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Mapping,
+    Protocol,
+    Sequence,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import numpy as np
 
@@ -35,6 +43,7 @@ from ..utils.color import (
     color_gradient,
     interpolate_color,
 )
+from ..utils.deprecation import deprecated
 from ..utils.exceptions import MultiAnimationOverrideException
 from ..utils.iterables import list_update, remove_list_redundancies
 from ..utils.paths import straight_path
@@ -50,6 +59,12 @@ if TYPE_CHECKING:
     from ..animation.animation import Animation
     from ..camera.camera import Camera
     from ..utils.bezier import Interpolable
+
+    # Copy from typeshed.
+    class SupportsLessThan(Protocol):
+        def __lt__(self, __other: Any) -> bool:
+            ...
+
 
 # Generic type
 T = TypeVar("T")
@@ -445,6 +460,10 @@ class Mobject:
 
         """
         for m in mobjects:
+            # This type check is not required according to the type annotations
+            # but it was clearly useful in the past (not everyone uses
+            # types properly), so I'm leaving it. The type: ignore is to
+            # suppress warnings about it being unnecessary.
             if not isinstance(m, Mobject):  # type: ignore
                 raise TypeError("All submobjects must be of type Mobject")
             if m is self:
@@ -1373,16 +1392,31 @@ class Mobject:
             mob.points += about_point
         return self
 
+    @deprecated(
+        since="v0.11.0",
+        until="v0.12.0",
+        replacement="rotate",
+    )
     def rotate_in_place(self: MOS, angle: float, axis: np.ndarray = OUT) -> MOS:
         # redundant with default behavior of rotate now.
         return self.rotate(angle, axis=axis)
 
+    @deprecated(
+        since="v0.11.0",
+        until="v0.12.0",
+        replacement="scale",
+    )
     def scale_in_place(
         self: MOS, scale_factor: float, **kwargs: np.ndarray | None
     ) -> MOS:
         # Redundant with default behavior of scale now.
         return self.scale(scale_factor, **kwargs)
 
+    @deprecated(
+        since="v0.11.0",
+        until="v0.12.0",
+        replacement="scale",
+    )
     def scale_about_point(self: MOS, scale_factor: float, point: np.ndarray) -> MOS:
         # Redundant with default behavior of scale now.
         return self.scale(scale_factor, about_point=point)
@@ -1513,6 +1547,11 @@ class Mobject:
     ) -> MOS:
         return self.stretch(factor, dim, about_point=point)
 
+    @deprecated(
+        since="v0.11.0",
+        until="v0.12.0",
+        replacement="stretch",
+    )
     def stretch_in_place(self: MOS, factor: float, dim: int) -> MOS:
         # Now redundant with stretch
         return self.stretch(factor, dim)
@@ -1820,7 +1859,7 @@ class Mobject:
 
     def set_color(
         self: MOS,
-        color: Color | ColorStr = YELLOW_C,
+        color: ColorStr = YELLOW_C,
         family: bool = True,
     ) -> MOS:
         """Condition is function which takes in one arguments, (x, y, z).
@@ -1834,7 +1873,7 @@ class Mobject:
         self.color = Color(color)
         return self
 
-    def set_color_by_gradient(self: MOS, *colors: Color | ColorStr) -> MOS:
+    def set_color_by_gradient(self: MOS, *colors: ColorStr) -> MOS:
         self.set_submobject_colors_by_gradient(*colors)
         return self
 
@@ -1853,7 +1892,7 @@ class Mobject:
         )
         return self
 
-    def set_submobject_colors_by_gradient(self: MOS, *colors: ColorStr | Color) -> MOS:
+    def set_submobject_colors_by_gradient(self: MOS, *colors: ColorStr) -> MOS:
         if len(colors) == 0:
             raise ValueError("Need at least one color")
         elif len(colors) == 1:

--- a/manim/utils/bezier.py
+++ b/manim/utils/bezier.py
@@ -22,6 +22,7 @@ import typing
 from functools import reduce
 
 import numpy as np
+from _typeshed import SupportsLessThanT
 from scipy import linalg
 
 from ..utils.simple_functions import choose
@@ -102,14 +103,16 @@ def partial_quadratic_bezier_points(points, a, b):
 
 # Linear interpolation variants
 
+Interpolable = typing.TypeVar("Interpolable", float, np.ndarray)
 
-def interpolate(start: int, end: int, alpha: float) -> float:
+
+def interpolate(start: Interpolable, end: Interpolable, alpha: float) -> Interpolable:
     return (1 - alpha) * start + alpha * end
 
 
 def integer_interpolate(
-    start: float,
-    end: float,
+    start: int,
+    end: int,
     alpha: float,
 ) -> typing.Tuple[int, float]:
     """

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -5,11 +5,13 @@ __all__ = ["deprecated", "deprecated_params"]
 
 import inspect
 import re
-from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Iterable, List, Optional, Tuple, TypeVar, Union
 
 from decorator import decorate, decorator
 
 from .. import logger
+
+T = TypeVar("T", bound=Callable[..., Any])
 
 
 def _get_callable_info(callable: Callable) -> Tuple[str, str]:
@@ -67,12 +69,12 @@ def _deprecation_text_component(
 
 
 def deprecated(
-    func: Callable = None,
+    func: Optional[T] = None,
     since: Optional[str] = None,
     until: Optional[str] = None,
     replacement: Optional[str] = None,
     message: Optional[str] = "",
-) -> Callable:
+) -> T:
     """Decorator to mark a callable as deprecated.
 
     The decorated callable will cause a warning when used. The docstring of the

--- a/manim/utils/space_ops.py
+++ b/manim/utils/space_ops.py
@@ -341,7 +341,7 @@ def angle_of_vector(vector: Sequence[float]) -> float:
         return np.angle(complex(*vector[:2]))
 
 
-def angle_between_vectors(v1: np.ndarray, v2: np.ndarray) -> np.ndarray:
+def angle_between_vectors(v1: np.ndarray, v2: np.ndarray) -> float:
     """Returns the angle between two vectors.
     This angle will always be between 0 and pi
 


### PR DESCRIPTION
**This is a draft - it's not quite finished yet; I just put it up for discussion (and in case I never finish it and somebody wants to take over). Or in case you just want to land it unfinished.**

This adds quite a few type annotations to mobject.py (and a few to other files to help). Type checked with Pyright - MyPy basically can't handle this at all. There are quite a few type errors left but way fewer than when I started (Pyright gave up about half way through the file!)

Some misc notes:

* The code is not clear where `Sequence[float]` is allowed and where `np.ndarray` is (or either). I've mostly just put `np.ndarray`.
* Similarly for `Color` vs `str`. Not clear where either is allowed and some of the existing type annotations seem to be wrong.
* Changed `np.float64` to `float` for simplicity. They're officialy not compatible but they actually are the same.
* Removed unused `axes` parameter from `rotate_about_origin`.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
