### PR TITLE
Fixed :meth:`~DecimalNumber.string_to_mob` for opengl and added tests

### DIFF
--- a/manim/mobject/numbers.py
+++ b/manim/mobject/numbers.py
@@ -13,7 +13,8 @@ from ..mobject.types.vectorized_mobject import VMobject
 from ..mobject.value_tracker import ValueTracker
 from .opengl_compatibility import ConvertToOpenGL
 
-string_to_mob_map = {}
+string_to_mob_map_cairo = {}
+string_to_mob_map_opengl = {}
 
 
 class DecimalNumber(VMobject, metaclass=ConvertToOpenGL):
@@ -169,9 +170,18 @@ class DecimalNumber(VMobject, metaclass=ConvertToOpenGL):
         return num_string
 
     def string_to_mob(self, string, mob_class=MathTex, **kwargs):
-        if string not in string_to_mob_map:
-            string_to_mob_map[string] = mob_class(string, font_size=1.0, **kwargs)
-        mob = string_to_mob_map[string].copy()
+        is_opengl = config.renderer == "opengl"
+        if string not in string_to_mob_map_opengl and is_opengl:
+            string_to_mob_map_opengl[string] = mob_class(
+                string, font_size=1.0, **kwargs
+            )
+        elif string not in string_to_mob_map_cairo and not is_opengl:
+            string_to_mob_map_cairo[string] = mob_class(string, font_size=1.0, **kwargs)
+        mob = (
+            string_to_mob_map_opengl[string].copy()
+            if is_opengl
+            else string_to_mob_map_cairo[string].copy()
+        )
         mob.font_size = self._font_size
         return mob
 

--- a/tests/opengl/test_coordinate_system_opengl.py
+++ b/tests/opengl/test_coordinate_system_opengl.py
@@ -1,0 +1,134 @@
+import math
+
+import numpy as np
+import pytest
+
+from manim import LEFT, ORIGIN, PI, UR, Axes, Circle, ComplexPlane
+from manim import CoordinateSystem as CS
+from manim import NumberPlane, PolarPlane, ThreeDAxes, config, tempconfig
+
+
+def test_initial_config(using_opengl_renderer):
+    """Check that all attributes are defined properly from the config."""
+    cs = CS()
+    assert cs.x_range[0] == round(-config["frame_x_radius"])
+    assert cs.x_range[1] == round(config["frame_x_radius"])
+    assert cs.x_range[2] == 1.0
+    assert cs.y_range[0] == round(-config["frame_y_radius"])
+    assert cs.y_range[1] == round(config["frame_y_radius"])
+    assert cs.y_range[2] == 1.0
+
+    ax = Axes()
+    assert np.allclose(ax.get_center(), ORIGIN)
+    assert np.allclose(ax.y_axis_config["label_direction"], LEFT)
+
+    current_frame_x_radius = config.frame_x_radius
+    current_frame_y_radius = config.frame_y_radius
+    with tempconfig({"frame_x_radius": 100, "frame_y_radius": 200}):
+        cs = CS()
+        assert cs.x_range[0] == -100
+        assert cs.x_range[1] == 100
+        assert cs.y_range[0] == -200
+        assert cs.y_range[1] == 200
+
+    config.frame_x_radius = current_frame_x_radius
+    config.frame_y_radius = current_frame_y_radius
+
+
+def test_dimension(using_opengl_renderer):
+    """Check that objects have the correct dimension."""
+    assert Axes().dimension == 2
+    assert NumberPlane().dimension == 2
+    assert PolarPlane().dimension == 2
+    assert ComplexPlane().dimension == 2
+    assert ThreeDAxes().dimension == 3
+
+
+def test_abstract_base_class(using_opengl_renderer):
+    """Check that CoordinateSystem has some abstract methods."""
+    with pytest.raises(Exception):
+        CS().get_axes()
+
+
+def test_NumberPlane(using_opengl_renderer):
+    """Test that NumberPlane generates the correct number of lines when its ranges do not cross 0."""
+    pos_x_range = (0, 7)
+    neg_x_range = (-7, 0)
+
+    pos_y_range = (2, 6)
+    neg_y_range = (-6, -2)
+
+    x_vals = [0, 1.5, 2, 2.8, 4, 6.25]
+    y_vals = [2, 5, 4.25, 6, 4.5, 2.75]
+
+    testing_data = [
+        (pos_x_range, pos_y_range, x_vals, y_vals),
+        (pos_x_range, neg_y_range, x_vals, [-v for v in y_vals]),
+        (neg_x_range, pos_y_range, [-v for v in x_vals], y_vals),
+        (neg_x_range, neg_y_range, [-v for v in x_vals], [-v for v in y_vals]),
+    ]
+
+    for test_data in testing_data:
+        x_range, y_range, x_vals, y_vals = test_data
+
+        x_start, x_end = x_range
+        y_start, y_end = y_range
+
+        current_axis_config = NumberPlane().axis_config
+        plane = NumberPlane(
+            x_range=x_range,
+            y_range=y_range,
+            # x_length = 7,
+            axis_config={"include_numbers": True},
+        )
+
+        # normally these values would be need to be added by one to pass since there's an
+        # overlapping pair of lines at the origin, but since these planes do not cross 0,
+        # this is not needed.
+        num_y_lines = math.ceil(x_end - x_start)
+        num_x_lines = math.floor(y_end - y_start)
+
+        assert len(plane.y_lines) == num_y_lines
+        assert len(plane.x_lines) == num_x_lines
+
+        # As passing axis_config alters the defaults we need to reset it here to prevent other tests
+        # being affected
+        NumberPlane(
+            x_range=x_range,
+            y_range=y_range,
+            # x_length = 7,
+            axis_config=current_axis_config,
+        )
+
+
+def test_point_to_coords(using_opengl_renderer):
+    ax = Axes(x_range=[0, 10, 2])
+    circ = Circle(radius=0.5).shift(UR * 2)
+
+    # get the coordinates of the circle with respect to the axes
+    coords = np.around(ax.point_to_coords(circ.get_right()), decimals=4)
+    assert np.array_equal(coords, (7.0833, 2.6667))
+
+
+def test_coords_to_point(using_opengl_renderer):
+    ax = Axes()
+
+    # a point with respect to the axes
+    c2p_coord = np.around(ax.coords_to_point(2, 2), decimals=4)
+    assert np.array_equal(c2p_coord, (1.7143, 1.5, 0))
+
+
+def test_input_to_graph_point(using_opengl_renderer):
+    ax = Axes()
+    curve = ax.get_graph(lambda x: np.cos(x))
+    line_graph = ax.get_line_graph([1, 3, 5], [-1, 2, -2], add_vertex_dots=False)[
+        "line_graph"
+    ]
+
+    # move a square to PI on the cosine curve.
+    position = np.around(ax.input_to_graph_point(x=PI, graph=curve), decimals=4)
+    assert np.array_equal(position, (2.6928, -0.75, 0))
+
+    # test the line_graph implementation
+    position = np.around(ax.input_to_graph_point(x=PI, graph=line_graph), decimals=4)
+    assert np.array_equal(position, (2.6928, 1.2876, 0))

--- a/tests/opengl/test_number_line_opengl.py
+++ b/tests/opengl/test_number_line_opengl.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+from manim import NumberLine
+from manim.mobject.numbers import Integer
+
+
+def test_unit_vector(using_opengl_renderer):
+    """Check if the magnitude of unit vector along
+    the NumberLine is equal to its unit_size."""
+    axis1 = NumberLine(unit_size=0.4)
+    axis2 = NumberLine(x_range=[-2, 5], length=12)
+    for axis in (axis1, axis2):
+        assert np.linalg.norm(axis.get_unit_vector()) == axis.unit_size
+
+
+def test_decimal_determined_by_step(using_opengl_renderer):
+    """Checks that step size is considered when determining the number of decimal
+    places."""
+    axis = NumberLine(x_range=[-2, 2, 0.5])
+    expected_decimal_places = 1
+    actual_decimal_places = axis.decimal_number_config["num_decimal_places"]
+    assert actual_decimal_places == expected_decimal_places, (
+        "Expected 1 decimal place but got " + actual_decimal_places
+    )
+
+    axis2 = NumberLine(x_range=[-1, 1, 0.25])
+    expected_decimal_places = 2
+    actual_decimal_places = axis2.decimal_number_config["num_decimal_places"]
+    assert actual_decimal_places == expected_decimal_places, (
+        "Expected 1 decimal place but got " + actual_decimal_places
+    )
+
+
+def test_decimal_config_overrides_defaults(using_opengl_renderer):
+    """Checks that ``num_decimal_places`` is determined by step size and gets overridden by ``decimal_number_config``."""
+    axis = NumberLine(
+        x_range=[-2, 2, 0.5],
+        decimal_number_config={"num_decimal_places": 0},
+    )
+    expected_decimal_places = 0
+    actual_decimal_places = axis.decimal_number_config["num_decimal_places"]
+    assert actual_decimal_places == expected_decimal_places, (
+        "Expected 1 decimal place but got " + actual_decimal_places
+    )
+
+
+def test_whole_numbers_step_size_default_to_0_decimal_places(using_opengl_renderer):
+    """Checks that ``num_decimal_places`` defaults to 0 when a whole number step size is passed."""
+    axis = NumberLine(x_range=[-2, 2, 1])
+    expected_decimal_places = 0
+    actual_decimal_places = axis.decimal_number_config["num_decimal_places"]
+    assert actual_decimal_places == expected_decimal_places, (
+        "Expected 1 decimal place but got " + actual_decimal_places
+    )
+
+
+def test_add_labels(using_opengl_renderer):
+    expected_label_length = 6
+    num_line = NumberLine(x_range=[-4, 4])
+    num_line.add_labels(
+        dict(zip(list(range(-3, 3)), [Integer(m) for m in range(-1, 5)])),
+    )
+    actual_label_length = len(num_line.labels)
+    assert (
+        actual_label_length == expected_label_length
+    ), f"Expected a VGroup with {expected_label_length} integers but got {actual_label_length}."

--- a/tests/opengl/test_numbers_opengl.py
+++ b/tests/opengl/test_numbers_opengl.py
@@ -1,0 +1,35 @@
+from manim.mobject.numbers import DecimalNumber
+
+
+def test_font_size(using_opengl_renderer):
+    """Test that DecimalNumber returns the correct font_size value
+    after being scaled."""
+    num = DecimalNumber(0).scale(0.3)
+
+    assert round(num.font_size, 5) == 14.4
+
+
+def test_font_size_vs_scale(using_opengl_renderer):
+    """Test that scale produces the same results as .scale()"""
+    num = DecimalNumber(0, font_size=12)
+    num_scale = DecimalNumber(0).scale(1 / 4)
+
+    assert num.height == num_scale.height
+
+
+def test_changing_font_size(using_opengl_renderer):
+    """Test that the font_size property properly scales DecimalNumber."""
+    num = DecimalNumber(0, font_size=12)
+    num.font_size = 48
+
+    assert num.height == DecimalNumber(0, font_size=48).height
+
+
+def test_set_value_size(using_opengl_renderer):
+    """Test that the size of DecimalNumber after set_value is correct."""
+    num = DecimalNumber(0).scale(0.3)
+    test_num = num.copy()
+    num.set_value(0)
+
+    # round because the height is off by 1e-17
+    assert round(num.height, 12) == round(test_num.height, 12)


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

This is another batch of tests reused from cairo with the opengl renderer. These are grouped together as they were all failing due to `string_to_mob_map` holding objects from the cairo renderer that were being reused by opengl. I created a separate map for the opengl renderer to use so the tests can pass now. 

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
