### PR TITLE
Fixed opengl `set_color` with gradients

### DIFF
--- a/manim/mobject/opengl_mobject.py
+++ b/manim/mobject/opengl_mobject.py
@@ -1327,6 +1327,7 @@ class OpenGLMobject:
         # Recurse to submobjects differently from how set_rgba_array
         # in case they implement set_color differently
         if color is not None:
+
             self.color = Color(color)
         if opacity is not None:
             self.opacity = opacity

--- a/manim/mobject/types/opengl_vectorized_mobject.py
+++ b/manim/mobject/types/opengl_vectorized_mobject.py
@@ -154,7 +154,10 @@ class OpenGLVMobject(OpenGLMobject):
 
     def set_fill(self, color=None, opacity=None, recurse=True):
         if color is not None:
-            self.fill_color = Color(color)
+            if isinstance(color, str):
+                self.fill_color = Color(color)
+            else:
+                self.fill_color = color
         if opacity is not None:
             self.fill_opacity = opacity
         if recurse:
@@ -173,7 +176,10 @@ class OpenGLVMobject(OpenGLMobject):
         recurse=True,
     ):
         if color is not None:
-            self.stroke_color = Color(color)
+            if isinstance(color, str):
+                self.stroke_color = Color(color)
+            else:
+                self.stroke_color = color
         if opacity is not None:
             self.stroke_opacity = opacity
         if recurse:
@@ -259,9 +265,13 @@ class OpenGLVMobject(OpenGLMobject):
         return self
 
     def set_color(self, color, opacity=None, recurse=True):
-        self.color = Color(color)
+        if isinstance(color, str):
+            self.color = Color(color)
+        else:
+            self.color = color
         if opacity is not None:
             self.opacity = opacity
+
         self.set_fill(color, opacity=opacity, recurse=recurse)
         self.set_stroke(color, opacity=opacity, recurse=recurse)
         return self

--- a/tests/opengl/test_color_opengl.py
+++ b/tests/opengl/test_color_opengl.py
@@ -1,6 +1,7 @@
 import numpy as np
+from colour import Color
 
-from manim import BLACK, PURE_GREEN, Scene
+from manim import BLACK, BLUE, GREEN, PURE_BLUE, PURE_GREEN, PURE_RED, RED, Scene
 from manim.mobject.opengl_mobject import OpenGLMobject
 from manim.mobject.types.opengl_vectorized_mobject import OpenGLVMobject
 
@@ -93,3 +94,73 @@ def test_set_fill(using_opengl_renderer):
     assert m.color.hex == "#fff"
     m.set_color(BLACK)
     assert m.color.hex == "#000"
+
+
+def test_set_color_handles_lists_of_strs(using_opengl_renderer):
+    m = OpenGLVMobject()
+    assert m.color.hex == "#fff"
+    m.set_color([BLACK, BLUE, GREEN])
+    assert m.color[0] == BLACK
+    assert m.color[1] == BLUE
+    assert m.color[2] == GREEN
+
+    assert m.fill_color[0] == BLACK
+    assert m.fill_color[1] == BLUE
+    assert m.fill_color[2] == GREEN
+
+    assert m.stroke_color[0] == BLACK
+    assert m.stroke_color[1] == BLUE
+    assert m.stroke_color[2] == GREEN
+
+
+def test_set_color_handles_lists_of_color_objects(using_opengl_renderer):
+    m = OpenGLVMobject()
+    assert m.color.hex == "#fff"
+    m.set_color([Color(PURE_BLUE), Color(PURE_GREEN), Color(PURE_RED)])
+    assert m.color[0].hex == "#00f"
+    assert m.color[1].hex == "#0f0"
+    assert m.color[2].hex == "#f00"
+
+    assert m.fill_color[0].hex == "#00f"
+    assert m.fill_color[1].hex == "#0f0"
+    assert m.fill_color[2].hex == "#f00"
+
+    assert m.stroke_color[0].hex == "#00f"
+    assert m.stroke_color[1].hex == "#0f0"
+    assert m.stroke_color[2].hex == "#f00"
+
+
+def test_set_fill_handles_lists_of_strs(using_opengl_renderer):
+    m = OpenGLVMobject()
+    assert m.fill_color.hex == "#fff"
+    m.set_fill([BLACK, BLUE, GREEN])
+    assert m.fill_color[0] == BLACK
+    assert m.fill_color[1] == BLUE
+    assert m.fill_color[2] == GREEN
+
+
+def test_set_fill_handles_lists_of_color_objects(using_opengl_renderer):
+    m = OpenGLVMobject()
+    assert m.fill_color.hex == "#fff"
+    m.set_fill([Color(PURE_BLUE), Color(PURE_GREEN), Color(PURE_RED)])
+    assert m.fill_color[0].hex == "#00f"
+    assert m.fill_color[1].hex == "#0f0"
+    assert m.fill_color[2].hex == "#f00"
+
+
+def test_set_stroke_handles_lists_of_strs(using_opengl_renderer):
+    m = OpenGLVMobject()
+    assert m.stroke_color.hex == "#fff"
+    m.set_stroke([BLACK, BLUE, GREEN])
+    assert m.stroke_color[0] == BLACK
+    assert m.stroke_color[1] == BLUE
+    assert m.stroke_color[2] == GREEN
+
+
+def test_set_stroke_handles_lists_of_color_objects(using_opengl_renderer):
+    m = OpenGLVMobject()
+    assert m.stroke_color.hex == "#fff"
+    m.set_stroke([Color(PURE_BLUE), Color(PURE_GREEN), Color(PURE_RED)])
+    assert m.stroke_color[0].hex == "#00f"
+    assert m.stroke_color[1].hex == "#0f0"
+    assert m.stroke_color[2].hex == "#f00"


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

There is an issue when setting color or fill color with lists using the opengl renderer, it should accept lists to create a gradient, however this was broken in #2111. This fixes it to accept lists and adds tests for it. The below code is an example of what currently fails:

```py
class test(Scene):
    def construct(self):
        self.add(Circle(fill_opacity=1).set_color([BLUE, RED]))
        self.wait()
```

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
