### PR TITLE
Projection Shader compatibility with StreamLines

### DIFF
--- a/manim/renderer/vectorized_mobject_rendering.py
+++ b/manim/renderer/vectorized_mobject_rendering.py
@@ -210,11 +210,14 @@ def render_mobject_strokes_with_matrix(renderer, model_matrix, mobjects):
         end_offset = write_offset + submob.points.shape[0]
 
         points[write_offset:end_offset] = submob.points
-        colors[write_offset:end_offset] = np.repeat(
-            submob.stroke_rgba,
-            submob.points.shape[0],
-            axis=0,
-        )
+        if submob.stroke_rgba.shape[0] == points[write_offset:end_offset].shape[0]:
+            colors[write_offset:end_offset] = submob.stroke_rgba
+        else:
+            colors[write_offset:end_offset] = np.repeat(
+                submob.stroke_rgba,
+                submob.points.shape[0],
+                axis=0,
+            )
         widths[write_offset:end_offset] = np.repeat(
             submob.stroke_width,
             submob.points.shape[0],


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

Fixes #2068 

Streamlines calculate the gradients ahead of time, whereas projection shader logic is assuming that there will be a single color passed and that the numpy array must be expanded, but in the case of StreamLines the shape was already correct so when it tried expanding the array it caused an error. This PR fixes it to handle cases where the rgba .

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

Not sure if I should do the same for fill_rgba or not? I was erring on the side of caution to not change it if it is working but I guess it could have the same issue if there is a scenario for it.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
