### PR TITLE
Modified :meth:`.Mobject.set_default` example to prevent leaking across the docs

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -216,7 +216,7 @@ class Mobject:
                     self.add(Text("Changing default values is easy!"))
 
                     # we revert the colour back to the default to prevent a bug in the docs.
-                    Text.set_default(color=BLACK)
+                    Text.set_default(color=WHITE)
 
         """
         if kwargs:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->
Reset the colour of `Text` at the end of the `set_default` example because `Text` had its colour set to `BLACK` across the docs, meaning that it wouldn't show up against our default black background.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
Blank `Text` example:

https://docs.manim.community/en/stable/reference/manim.mobject.svg.text_mobject.Text.html?highlight=set_color#pangorender

current `set_default` example:
https://docs.manim.community/en/stable/reference/manim.mobject.mobject.Mobject.html?highlight=set_default#changeddefaulttextcolor


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
This is a pretty band-aid solution to the problem, but it's better than doing nothing 🤷.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
