### PR TITLE
Changed the default width of videos in Jupyter notebooks to 60%

### DIFF
--- a/manim/_config/default.cfg
+++ b/manim/_config/default.cfg
@@ -194,4 +194,4 @@ repr_number = green
 loglevel = ERROR
 
 [jupyter]
-media_width = 60%
+media_width = 60%%


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
According to [this poll](https://discord.com/channels/581738731934056449/737402086899056690/891468465951612939) on Discord, a default width of `60%` on Jupyter notebooks was most preferred by users.

Note that `%%` is required as otherwise the configparser will [try to do string interpolation](https://stackoverflow.com/a/58575432/15346181).
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
