### PR TITLE
Fixed type mismatch for height and width parameters of :class:`~.Text`

### DIFF
--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -423,8 +423,8 @@ class Text(SVGMobject):
         gradient: tuple = None,
         tab_width: int = 4,
         # Mobject
-        height: int = None,
-        width: int = None,
+        height: float = None,
+        width: float = None,
         should_center: bool = True,
         unpack_groups: bool = True,
         disable_ligatures: bool = False,


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Corrected typing mismatch for `height` and `width` parameters in `Text.__init__`.
Closes #2170

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
