### PR TITLE
Attempt at bug fix for #2202, scene_name doesn't work everywhere in config

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -85,7 +85,9 @@ class SceneFileWriter:
 
         if config["media_dir"]:
             image_dir = guarantee_existence(
-                config.get_dir("images_dir", scene_name=scene_name, module_name=module_name),
+                config.get_dir(
+                    "images_dir", scene_name=scene_name, module_name=module_name
+                ),
             )
             self.image_file_path = os.path.join(
                 image_dir,
@@ -94,7 +96,9 @@ class SceneFileWriter:
 
         if write_to_movie():
             movie_dir = guarantee_existence(
-                config.get_dir("video_dir", scene_name=scene_name, module_name=module_name),
+                config.get_dir(
+                    "video_dir", scene_name=scene_name, module_name=module_name
+                ),
             )
 
             self.movie_file_path = os.path.join(


### PR DESCRIPTION
Fixes #2202, , scene_name doesn't work for images_dir (or video_dir)

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
`{scene_name}` tag now works for `images_dir` and `videos_dir` config options
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
