### PR TITLE
Fixed Documentation for Sections

### DIFF
--- a/docs/source/tutorials/a_deeper_look.rst
+++ b/docs/source/tutorials/a_deeper_look.rst
@@ -179,11 +179,11 @@ One way of fixing this is to wait a little:
        self.wait()
        self.next_section()
 
-For videos to be created for each section you have to add the ``--use_sections`` flag to the Manim call like this:
+For videos to be created for each section you have to add the ``--save_sections`` flag to the Manim call like this:
 
 .. code-block:: bash
 
-   manim --use_sections scene.py
+   manim --save_sections scene.py
 
 If you do this, the ``media`` folder will look like this:
 


### PR DESCRIPTION
Replaced `--use_sections` with the correct `--save_sections`.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
