### PR TITLE
Removed redundant ``partial_movie_files`` parameter in :meth:`.SceneFileWriter.combine_to_movie`

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -417,7 +417,7 @@ class SceneFileWriter:
             if time_diff < frame_duration:
                 sleep(frame_duration - time_diff)
 
-    def finish(self, partial_movie_files=None):
+    def finish(self):
         """
         Finishes writing to the FFMPEG buffer or writing images
         to output directory.
@@ -429,7 +429,7 @@ class SceneFileWriter:
         if write_to_movie():
             if hasattr(self, "writing_process"):
                 self.writing_process.terminate()
-            self.combine_to_movie(partial_movie_files=partial_movie_files)
+            self.combine_to_movie()
             if config.save_sections:
                 self.combine_to_section_videos()
             if config["flush_cache"]:
@@ -576,12 +576,11 @@ class SceneFileWriter:
         combine_process = subprocess.Popen(commands)
         combine_process.wait()
 
-    def combine_to_movie(self, partial_movie_files=None):
+    def combine_to_movie(self):
         """Used internally by Manim to combine the separate
         partial movie files that make up a Scene into a single
         video file for that Scene.
         """
-        # TODO: remove partial_movie_files from parameter <- gets immediately overwritten
         partial_movie_files = [el for el in self.partial_movie_files if el is not None]
         # NOTE: Here we should do a check and raise an exception if partial
         # movie file is empty.  We can't, as a lot of stuff (in particular, in

--- a/tests/test_graphical_units/testing/_test_class_makers.py
+++ b/tests/test_graphical_units/testing/_test_class_makers.py
@@ -56,8 +56,7 @@ class DummySceneFileWriter(SceneFileWriter):
     def end_animation(self, allow_write):
         pass
 
-    # TODO: remove redundant partial_movie_files parameter
-    def combine_to_movie(self, partial_movie_files):
+    def combine_to_movie(self):
         pass
 
     def combine_to_section_videos(self):


### PR DESCRIPTION
As already discussed [here](https://discord.com/channels/581738731934056449/581738732646957057/896714082227474473) the `partial_movie_files` parameter is redundant.
It gets immediately overwritten.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
