### PR TITLE
Removed erroneous raw string from text tutorial

### DIFF
--- a/docs/source/tutorials/using_text.rst
+++ b/docs/source/tutorials/using_text.rst
@@ -301,7 +301,7 @@ For example,
 
 .. note::
 
-    Note that we are using a raw string (``r'...'``) instead of a regular string (``r'...'``).
+    Note that we are using a raw string (``r'...'``) instead of a regular string (``'...'``).
     This is because TeX code uses a lot of special characters - like ``\`` for example - that
     have special meaning within a regular python string. An alternative would have been to
     write ``\\`` to escape the backslash: ``Tex('\\LaTeX')``.


### PR DESCRIPTION
Removed 'r' from the regular string.



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
