### PR TITLE
Fixed wasteful recursion in :meth:`.Mobject.get_merged_array`

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1846,7 +1846,6 @@ class Mobject:
         result = getattr(self, array_attr)
         for submob in self.submobjects:
             result = np.append(result, submob.get_merged_array(array_attr), axis=0)
-            submob.get_merged_array(array_attr)
         return result
 
     def get_all_points(self):


### PR DESCRIPTION
## Overview: What does this pull request change?
`Mobject.get_merged_array` called itself recursively twice over all submobjects and threw away the second result, which means the runtime is exponentially bigger than it needs to be.

## Motivation and Explanation: Why and how do your changes improve the library?
`Mobject.get_merged_array` is used pretty often as it's called by `get_critical_point` which is called by `move_to` and `next_to` and much else.

The speedup depends on how common nested mobjects are, and might be negligible, but still worth it.

## Further Information and Comments
There is no apparent reason for this second call, and looking at the commit history it seems like a mistake, not sure.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
