### PR TITLE
Don't iterate over boolean in BraceBetweenPoints

### DIFF
--- a/manim/mobject/svg/brace.py
+++ b/manim/mobject/svg/brace.py
@@ -254,7 +254,7 @@ class BraceBetweenPoints(Brace):
         direction: Optional[Sequence[float]] = ORIGIN,
         **kwargs
     ):
-        if all(direction == ORIGIN):
+        if direction == ORIGIN:
             line_vector = np.array(point_2) - np.array(point_1)
             direction = np.array([line_vector[1], -line_vector[0], 0])
         super().__init__(Line(point_1, point_2), direction=direction, **kwargs)


### PR DESCRIPTION
Currently `all()` tries to iterate over a boolean. It seems like the intention is something along the lines of `all(x == y for x, y in zip(direction, ORIGIN))`, but in this case that's not needed. A simple comparison of the arrays seem to be enough and avoid exceptions.


## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
