### PR TITLE
Fixed :class:`~.DecimalNumber` color when number of displayed digits changes

### DIFF
--- a/manim/mobject/numbers.py
+++ b/manim/mobject/numbers.py
@@ -250,7 +250,8 @@ class DecimalNumber(VMobject, metaclass=ConvertToOpenGL):
                 # for compatibility with updaters to not leave first number in place while updating,
                 # not needed with opengl renderer
                 mob.points[:] = 0
-
+        
+        self.init_colors()
         return self
 
     def get_value(self):

--- a/manim/mobject/numbers.py
+++ b/manim/mobject/numbers.py
@@ -250,7 +250,7 @@ class DecimalNumber(VMobject, metaclass=ConvertToOpenGL):
                 # for compatibility with updaters to not leave first number in place while updating,
                 # not needed with opengl renderer
                 mob.points[:] = 0
-        
+
         self.init_colors()
         return self
 

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -1,7 +1,7 @@
-from colour import Color
 import pytest
+from colour import Color
 
-from manim import DecimalNumber, Integer, RED
+from manim import RED, DecimalNumber, Integer
 
 
 def test_font_size():

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -1,6 +1,7 @@
+from colour import Color
 import pytest
 
-from manim.mobject.numbers import DecimalNumber
+from manim import DecimalNumber, Integer, RED
 
 
 def test_font_size():
@@ -35,3 +36,11 @@ def test_set_value_size():
 
     # round because the height is off by 1e-17
     assert round(num.height, 12) == round(test_num.height, 12)
+
+
+def test_color_when_number_of_digits_changes():
+    """Test that all digits of an Integer are colored correctly when
+    the number of digits changes."""
+    mob = Integer(color=RED)
+    mob.set_value(42)
+    assert all([submob.stroke_color == Color(RED) for submob in mob.submobjects])


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
When using `set_value` on a `DecimalNumber`, the color does not fully update if the number of digits changes. Fixed by calling `init_colors` after each call to `set_value` (there's maybe a better way to fix it).
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

Sample code:

```py
class Sample(Scene):
    def construct(self):
        d_vt = ValueTracker()
        d = Integer(color=RED)
        d.add_updater(lambda d: d.set_value(d_vt.get_value()))
        self.add(d)
        self.play(
            d_vt.animate.set_value(45)
        )
        self.wait()
```
Result:


https://user-images.githubusercontent.com/65306057/140910499-c917b724-7f5b-466a-879f-a97e85c0e97f.mp4


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
