### PR TITLE
Fix color for node in graph for latex text

### DIFF
--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -414,6 +414,9 @@ class Graph(VMobject, metaclass=ConvertToOpenGL):
         }
         self.default_vertex_config = default_vertex_config
         for v, label in self._labels.items():
+            # update the color if the label is latex text
+            if type(label) == MathTex and "color" in self._vertex_config[v].keys():
+                label = label.set_color(self._vertex_config[v]["color"])
             self._vertex_config[v]["label"] = label
 
         self.vertices = {v: vertex_type(**self._vertex_config[v]) for v in vertices}


### PR DESCRIPTION
# What this pull request solve?
There was a problem when we update the color for the text of the node in the graph if this text is written in latex

# Example
Notice that for each vertix in the `vertex_config`  there's `color` key and it's `WHITE`.
```
from manim import *

config['background_color'] = WHITE


class LabeledModifiedGraph(Scene):
    def construct(self):
        vertices = ['v_0', 'v_1', 'v_2', 'v_3', 'v_4', 'v_5']
        edges = [('v_0', 'v_1'), ('v_0', 'v_2'), ('v_0', 'v_3'),
                 ('v_1', 'v_2'),
                 ('v_2', 'v_4'), ('v_2', 'v_5'),
                 ('v_4', 'v_5')]

        g = Graph(vertices,
                  edges,
                  layout="circular",
                  layout_scale=3,
                  labels=True,
                  vertex_type=LabeledDot,
                  vertex_config={'v_0': {"fill_color": BLUE_E, "color": WHITE},
                                 'v_1': {"fill_color": BLUE_E, "color": WHITE},
                                 'v_2': {"fill_color": BLUE_E, "color": WHITE},
                                 'v_3': {"fill_color": BLUE_E, "color": WHITE},
                                 'v_4': {"fill_color": BLUE_A, "color": WHITE},
                                 'v_5': {"fill_color": BLUE_A, "color": WHITE}},
                  edge_config={('v_0', 'v_1'): {"stroke_color": BLUE_E},
                               ('v_0', 'v_2'): {"stroke_color": BLUE_E},
                               ('v_0', 'v_3'): {"stroke_color": BLUE_E},
                               ('v_1', 'v_2'): {"stroke_color": BLUE_A},
                               ('v_2', 'v_4'): {"stroke_color": BLUE_A},
                               ('v_2', 'v_5'): {"stroke_color": BLUE_A},
                               ('v_4', 'v_5'): {"stroke_color": BLUE_A},
                               })

        self.play(Create(g))
        self.wait()
        self.play(g['v_1'].animate.move_to([1, 1, 0]),
                  g['v_2'].animate.move_to([-1, 1, 0]),
                  g['v_3'].animate.move_to([1, -1, 0]),
                  g['v_4'].animate.move_to([-1, -1, 0]))
        self.wait()
```

# Before the pull requst:
![LabeledModifiedGraph_ManimCE_v0 12 0](https://user-images.githubusercontent.com/31715540/141172474-8168f265-99f9-4da8-a489-01851fec2b6b.png)


# After the pull request:
![LabeledModifiedGraph_ManimCE_v0 12 0](https://user-images.githubusercontent.com/31715540/141172361-de152c98-9e79-4237-aebe-5d736bef83cd.png)