### PR TITLE
fix: correct type of `discontinuities` parameter

### DIFF
--- a/manim/mobject/functions.py
+++ b/manim/mobject/functions.py
@@ -70,7 +70,7 @@ class ParametricFunction(VMobject, metaclass=ConvertToOpenGL):
         t_range: Optional[Sequence[float]] = None,
         scaling: _ScaleBase = LinearBase(),
         dt: float = 1e-8,
-        discontinuities: bool = None,
+        discontinuities: Optional[Iterable[float]] = None,
         use_smoothing: bool = True,
         **kwargs
     ):

--- a/manim/mobject/functions.py
+++ b/manim/mobject/functions.py
@@ -3,7 +3,7 @@
 __all__ = ["ParametricFunction", "FunctionGraph", "ImplicitFunction"]
 
 
-from typing import Callable, Optional, Sequence
+from typing import Callable, Iterable, Optional, Sequence
 
 import numpy as np
 from isosurfaces import plot_isoline


### PR DESCRIPTION
`discontinuities` was typed as a boolean but should really be
typed as an optional iterable of floats

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->

https://manimce--2305.org.readthedocs.build/en/2305/

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
