### PR TITLE
Clarified that Manim does not support Python 3.10 yet in the documentation

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -36,6 +36,8 @@ in order for Manim to work properly, some additional system
 dependencies need to be installed first. The following pages have
 operating system specific instructions for you to follow.
 
+Manim is **only** compatible with Python versions `3.7 - 3.9`, but not `3.10` as of now
+
 .. hint::
 
    Depending on your particular setup, the installation process
@@ -45,11 +47,6 @@ operating system specific instructions for you to follow.
    <https://www.manim.community/discord/>`__, or start a new
    Discussion `directly on GitHub
    <https://github.com/ManimCommunity/manim/discussions>`__.
-
-.. warning::
-
-   Manim does not support Python `3.10` yet, this will be fixed soon,
-   for now use a Python version equal or less `3.9`.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -36,7 +36,7 @@ in order for Manim to work properly, some additional system
 dependencies need to be installed first. The following pages have
 operating system specific instructions for you to follow.
 
-Manim is **only** compatible with Python versions `3.7 - 3.9`, but not `3.10` as of now
+Manim is **only** compatible with Python versions `3.7 - 3.9`, but not `3.10` for now.
 
 .. hint::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -48,8 +48,8 @@ operating system specific instructions for you to follow.
 
 .. warning::
 
-   Manim does not support Python 3.10 yet, this will be fixed soon,
-   for now use a Python version equal or less 3.9!
+   Manim does not support Python `3.10` yet, this will be fixed soon,
+   for now use a Python version equal or less `3.9`.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -36,7 +36,7 @@ in order for Manim to work properly, some additional system
 dependencies need to be installed first. The following pages have
 operating system specific instructions for you to follow.
 
-Manim is **only** compatible with Python versions `3.7 - 3.9`, but not `3.10` for now.
+Manim is **only** compatible with Python versions `3.7–3.9`, but not `3.10` for now.
 
 .. hint::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -46,6 +46,11 @@ operating system specific instructions for you to follow.
    Discussion `directly on GitHub
    <https://github.com/ManimCommunity/manim/discussions>`__.
 
+.. warning::
+
+   Manim does not support Python 3.10 yet, this will be fixed soon,
+   for now use a Python version equal or less 3.9!
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -5,7 +5,7 @@ The installation instructions depend on your particular operating
 system and package manager. If you happen to know exactly what you are doing,
 you can also simply ensure that your system has:
 
-- a reasonably recent version of Python 3 (3.7-3.9),
+- a reasonably recent version of Python 3 (3.7–3.9),
 - with working Cairo bindings in the form of
   `pycairo <https://cairographics.org/pycairo/>`__,
 - FFmpeg accessible from the command line as ``ffmpeg``,

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -5,7 +5,7 @@ The installation instructions depend on your particular operating
 system and package manager. If you happen to know exactly what you are doing,
 you can also simply ensure that your system has:
 
-- a reasonably recent version of Python 3 (3.7 or above),
+- a reasonably recent version of Python 3 (3.7-3.9),
 - with working Cairo bindings in the form of
   `pycairo <https://cairographics.org/pycairo/>`__,
 - FFmpeg accessible from the command line as ``ffmpeg``,

--- a/docs/source/installation/windows.rst
+++ b/docs/source/installation/windows.rst
@@ -19,7 +19,7 @@ to make one of them available on your system.
 Required Dependencies
 ---------------------
 
-Manim requires a recent version of Python (3.7-3.9) and ``ffmpeg``
+Manim requires a recent version of Python (3.7–3.9) and ``ffmpeg``
 in order to work.
 
 Chocolatey
@@ -58,10 +58,10 @@ Manual Installation
 *******************
 
 As mentioned above, Manim needs a reasonably recent version of
-Python 3 (3.7-3.9) and FFmpeg.
+Python 3 (3.7–3.9) and FFmpeg.
 
 **Python:** Head over to https://www.python.org, download an installer
-for Python (3.7-3.9), and follow its instructions to get Python
+for Python (3.7–3.9), and follow its instructions to get Python
 installed on your system.
 
 .. note::

--- a/docs/source/installation/windows.rst
+++ b/docs/source/installation/windows.rst
@@ -6,7 +6,7 @@ package manager like `Chocolatey <https://chocolatey.org/>`__
 or `Scoop <https://scoop.sh>`__. If you are not afraid of editing
 your System's ``PATH``, a manual installation is also possible.
 In fact, if you already have an existing Python
-installation (3.7 or newer), it might be the easiest way to get
+installation (3.7-3.9), it might be the easiest way to get
 everything up and running.
 
 If you choose to use one of the package managers, please follow
@@ -19,7 +19,7 @@ to make one of them available on your system.
 Required Dependencies
 ---------------------
 
-Manim requires a recent version of Python (3.7 or above) and ``ffmpeg``
+Manim requires a recent version of Python (3.7-3.9) and ``ffmpeg``
 in order to work.
 
 Chocolatey
@@ -58,10 +58,10 @@ Manual Installation
 *******************
 
 As mentioned above, Manim needs a reasonably recent version of
-Python 3 (3.7 or above) and FFmpeg.
+Python 3 (3.7-3.9) and FFmpeg.
 
 **Python:** Head over to https://www.python.org, download an installer
-for Python 3.7 (or newer), and follow its instructions to get Python
+for Python (3.7-3.9), and follow its instructions to get Python
 installed on your system.
 
 .. note::


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
This PR simply add a warning in the installation page saying Manim does not support Python 3.10 yet, and you should use a version that is <= 3.9
- This PR also closes issue #2308 
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
To prevent new users to install it wrong and have problems in the future
## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
https://manimce--2310.org.readthedocs.build/en/2310/

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
