### PR TITLE
Add support for in-place modification operators for DecimalNumber

### DIFF
--- a/manim/mobject/numbers.py
+++ b/manim/mobject/numbers.py
@@ -259,6 +259,56 @@ class DecimalNumber(VMobject, metaclass=ConvertToOpenGL):
 
     def increment_value(self, delta_t=1):
         self.set_value(self.get_value() + delta_t)
+        
+    #in place modification operator overloading
+    def __iadd__(self, num): 
+        self.set_value(self.get_value() + num)
+        return self
+        
+    def __isub__(self, num): 
+        self.set_value(self.get_value() - num)
+        return self
+        
+    def __imul__(self, num): 
+        self.set_value(self.get_value() * num)
+        return self
+        
+    def __itruediv__(self, num): 
+        self.set_value(self.get_value() / num)
+        return self
+        
+    def __ifloordiv__(self, num):
+        self.set_value(self.get_value() // num)
+        return self
+        
+    def __imod__(self, num): 
+        self.set_value(self.get_value() % num)
+        return self
+        
+    def __ipow__(self, num): 
+        self.set_value(self.get_value() ** num)
+        return self
+    
+    #not sure why you'd need these but they can't hurt, right?
+    def __irshift__(self, num):
+        self.set_value(self.get_value() >> num)
+        return self
+        
+    def __ilshift__(self, num): 
+        self.set_value(self.get_value() << num)
+        return self
+    
+    def __iand__(self, num): 
+        self.set_value(self.get_value() & num)
+        return self
+
+    def __ior__(self, num): 
+        self.set_value(self.get_value() | num)
+        return self
+
+    def __ixor__(self, num): 
+        self.set_value(self.get_value() ^ num)
+        return self
 
 
 class Integer(DecimalNumber):

--- a/manim/mobject/numbers.py
+++ b/manim/mobject/numbers.py
@@ -259,54 +259,54 @@ class DecimalNumber(VMobject, metaclass=ConvertToOpenGL):
 
     def increment_value(self, delta_t=1):
         self.set_value(self.get_value() + delta_t)
-        
-    #in place modification operator overloading
-    def __iadd__(self, num): 
+
+    # in place modification operator overloading
+    def __iadd__(self, num):
         self.set_value(self.get_value() + num)
         return self
-        
-    def __isub__(self, num): 
+
+    def __isub__(self, num):
         self.set_value(self.get_value() - num)
         return self
-        
-    def __imul__(self, num): 
+
+    def __imul__(self, num):
         self.set_value(self.get_value() * num)
         return self
-        
-    def __itruediv__(self, num): 
+
+    def __itruediv__(self, num):
         self.set_value(self.get_value() / num)
         return self
-        
+
     def __ifloordiv__(self, num):
         self.set_value(self.get_value() // num)
         return self
-        
-    def __imod__(self, num): 
+
+    def __imod__(self, num):
         self.set_value(self.get_value() % num)
         return self
-        
-    def __ipow__(self, num): 
+
+    def __ipow__(self, num):
         self.set_value(self.get_value() ** num)
         return self
-    
-    #not sure why you'd need these but they can't hurt, right?
+
+    # not sure why you'd need these but they can't hurt, right?
     def __irshift__(self, num):
         self.set_value(self.get_value() >> num)
         return self
-        
-    def __ilshift__(self, num): 
+
+    def __ilshift__(self, num):
         self.set_value(self.get_value() << num)
         return self
-    
-    def __iand__(self, num): 
+
+    def __iand__(self, num):
         self.set_value(self.get_value() & num)
         return self
 
-    def __ior__(self, num): 
+    def __ior__(self, num):
         self.set_value(self.get_value() | num)
         return self
 
-    def __ixor__(self, num): 
+    def __ixor__(self, num):
         self.set_value(self.get_value() ^ num)
         return self
 

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -44,3 +44,45 @@ def test_color_when_number_of_digits_changes():
     mob = Integer(color=RED)
     mob.set_value(42)
     assert all([submob.stroke_color == Color(RED) for submob in mob.submobjects])
+
+def test_in_place_modification_operators():
+    """Test that the in-place modification operators (num += 2) work correctly."""
+    # += 
+    num = DecimalNumber(6)
+    num += 2
+    assert num.get_value() == 8
+    # -= 
+    num -= 2
+    assert num.get_value() == 6
+    # *=
+    num *= 2
+    assert num.get_value() == 12
+    # /=
+    num /= 3
+    assert num.get_value() == 4
+    # //=
+    num //= 3
+    assert num.get_value() == 1
+    # %=
+    num.set_value(5)
+    num %= 3
+    assert num.get_value() == 2
+    # **=
+    num **= 3
+    assert num.get_value() == 8
+    # >>= 
+    num >>= 1
+    assert num.get_value() == 4
+    # <<=
+    num <<= 1
+    assert num.get_value() == 8
+    # &=
+    num.set_value(7)
+    num &= 3
+    assert num.get_value() == 3
+    # |=
+    num |= 4
+    assert num.get_value() == 7
+    # ^= 
+    num ^= 2
+    assert num.get_value() == 5

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -45,13 +45,14 @@ def test_color_when_number_of_digits_changes():
     mob.set_value(42)
     assert all([submob.stroke_color == Color(RED) for submob in mob.submobjects])
 
+
 def test_in_place_modification_operators():
     """Test that the in-place modification operators (num += 2) work correctly."""
-    # += 
+    # +=
     num = DecimalNumber(6)
     num += 2
     assert num.get_value() == 8
-    # -= 
+    # -=
     num -= 2
     assert num.get_value() == 6
     # *=
@@ -70,7 +71,7 @@ def test_in_place_modification_operators():
     # **=
     num **= 3
     assert num.get_value() == 8
-    # >>= 
+    # >>=
     num >>= 1
     assert num.get_value() == 4
     # <<=
@@ -83,6 +84,6 @@ def test_in_place_modification_operators():
     # |=
     num |= 4
     assert num.get_value() == 7
-    # ^= 
+    # ^=
     num ^= 2
     assert num.get_value() == 5


### PR DESCRIPTION
This deals with issue #2275, "Operator overloading for Mobject "Integer"

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
This adds support for DecimalNumber to use in place modification operators, as a shorthand for the set_value() method. Support for the equivalent operators that do not modify in-place was NOT added. This is a response to issue #2275 
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
