### PR TITLE
Allow custom animation parameters to be used in `added_anims`

### DIFF
--- a/manim/scene/three_d_scene.py
+++ b/manim/scene/three_d_scene.py
@@ -8,7 +8,6 @@ from typing import Iterable, Optional, Sequence, Union
 
 import numpy as np
 
-
 from .. import config
 from ..animation.animation import DEFAULT_ANIMATION_RUN_TIME, Animation
 from ..animation.transform import Transform


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->



## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

This fixes a very specific issue and I'm waiting for feedback on it.
When using `move_camera` in a `ThreeDScene`, there's the parameter `added_anims` allowing to play other animations while moving the camera. However, it is actually not possible to use custom rate functions and run times for these additional animations when they are already specified in `move_camera`.

<!--changelog-end-->

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

Code:

```py
class Sample(ThreeDScene):
    def construct(self):
        self.set_camera_orientation(
            phi=70 * DEGREES,
            theta=30 * DEGREES
        )
        d_vt = ValueTracker()
        d = DecimalNumber().to_corner(UR)
        d.add_updater(lambda d: d.set_value(d_vt.get_value()))

        self.add(ThreeDAxes(), d)
        d.add_updater(lambda d: self.add_fixed_in_frame_mobjects(d))
        self.move_camera(
            theta=120 * DEGREES,
            phi=60 * DEGREES,
            run_time=3,
            rate_func=linear,
            added_anims=[d_vt.animate(rate_func=there_and_back, run_time=2).set_value(5)]
        )
        self.wait()
```

<details><summary>Before PR:</summary>

https://user-images.githubusercontent.com/65306057/143457131-a5d77a3d-e636-4229-a534-43cf2606234f.mp4

value tracker's `rate_func` and `run_time` are not taken into account.

</details>

<details><summary>After PR:</summary>

https://user-images.githubusercontent.com/65306057/143457816-391cb6e1-77ec-405b-bb29-2ad215ab3d05.mp4

</details>

Note:
- This only happens when the `rate_func` or `run_time` parameter is specified in the `move_camera` method.
- When adding anims without any custom rate functions or run times, they will run with the default parameters (that is a run time of 1 second and a `smooth` rate function), even if those are specified in `move_camera`:
```py
self.move_camera(
    theta=120 * DEGREES,
    phi=60 * DEGREES,
    run_time=3,
    rate_func=linear,
    added_anims=[d_vt.animate.set_value(5)] # Will have a run time of 1s and a smooth rate func
)
```
and thus may be a bit counterintuitive.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
