### PR TITLE
Fixed broken IPython magic command

### DIFF
--- a/manim/cli/render/render_options.py
+++ b/manim/cli/render/render_options.py
@@ -62,7 +62,7 @@ render_options = option_group(
         "--quality",
         default=None,
         type=click.Choice(
-            reversed([q["flag"] for q in QUALITIES.values() if q["flag"]]),
+            list(reversed([q["flag"] for q in QUALITIES.values() if q["flag"]])),
             case_sensitive=False,
         ),
         help="Render quality at the follow resolution framerates, respectively: "


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

A bug effectively breaking the `%%manim` magic command after the first execution was introduced in #2325. This PR fixes the bug.

We will need to do a bugfix release after this is merged.

<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
