### PR TITLE
Fix usage of OpenGL SVG methods that no longer exist

### DIFF
--- a/manim/mobject/svg/opengl_tex_mobject.py
+++ b/manim/mobject/svg/opengl_tex_mobject.py
@@ -172,8 +172,8 @@ from functools import reduce
 from ... import config
 from ...constants import *
 from ...mobject.opengl_geometry import OpenGLLine
-from ...mobject.svg.opengl_svg_mobject import OpenGLSVGMobject
-from ...mobject.svg.opengl_svg_path import OpenGLSVGPathMobject
+from ...mobject.svg.svg_mobject import SVGMobject
+from ...mobject.svg.svg_path import SVGPathMobject
 from ...mobject.svg.tex_mobject import MathTex, Tex
 from ...mobject.types.opengl_vectorized_mobject import (
     OpenGLVectorizedPoint,
@@ -189,13 +189,13 @@ from .style_utils import parse_style
 TEX_MOB_SCALE_FACTOR = 0.05
 
 
-class OpenGLTexSymbol(OpenGLSVGPathMobject):
+class OpenGLTexSymbol(SVGPathMobject):
     """Purely a renaming of SVGPathMobject."""
 
     pass
 
 
-class OpenGLSingleStringMathTex(OpenGLSVGMobject):
+class OpenGLSingleStringMathTex(SVGMobject):
     """Elementary building block for rendering text with LaTeX.
 
     Tests
@@ -344,7 +344,7 @@ class OpenGLSingleStringMathTex(OpenGLSVGMobject):
         return self
 
     def init_colors(self, propagate_colors=True):
-        OpenGLSVGMobject.set_style(
+        SVGMobject.set_style(
             self,
             fill_color=self.fill_color or self.color,
             fill_opacity=self.fill_opacity,

--- a/manim/mobject/svg/opengl_text_mobject.py
+++ b/manim/mobject/svg/opengl_text_mobject.py
@@ -59,7 +59,7 @@ from manimpango import MarkupUtils, PangoUtils, TextSetting
 from ... import config, logger
 from ...constants import *
 from ...mobject.opengl_geometry import OpenGLDot
-from ...mobject.svg.opengl_svg_mobject import OpenGLSVGMobject
+from ...mobject.svg.svg_mobject import SVGMobject
 from ...mobject.types.opengl_vectorized_mobject import OpenGLVGroup
 from ...utils.color import WHITE, Colors
 
@@ -279,7 +279,7 @@ class OpenGLParagraph(OpenGLVGroup):
             )
 
 
-class OpenGLText(OpenGLSVGMobject):
+class OpenGLText(SVGMobject):
     r"""Display (non-LaTeX) text rendered using `Pango <https://pango.gnome.org/>`_.
 
     Text objects behave like a :class:`.VGroup`-like iterable of all characters
@@ -663,7 +663,7 @@ class OpenGLText(OpenGLSVGMobject):
         )
 
     def init_colors(self, propagate_colors=True):
-        OpenGLSVGMobject.set_style(
+        SVGMobject.set_style(
             self,
             fill_color=self.fill_color or self.color,
             fill_opacity=self.fill_opacity,
@@ -674,7 +674,7 @@ class OpenGLText(OpenGLSVGMobject):
         )
 
 
-class OpenGLMarkupText(OpenGLSVGMobject):
+class OpenGLMarkupText(SVGMobject):
     r"""Display (non-LaTeX) text rendered using `Pango <https://pango.gnome.org/>`_.
 
     Text objects behave like a :class:`.VGroup`-like iterable of all characters


### PR DESCRIPTION
Remove imports from the (now nonexistent)
`manim/mobject/svg/opengl_svg_mobject`
`manim/mobject/svg/opengl_svg_path`

Instead use `SVGMobject` and `SVGPathMobject`.

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
https://manimce--2400.org.readthedocs.build/en/2400/

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
