### PR TITLE
Replace string slice specification with tuple slice specification in `Text` mobject

### DIFF
--- a/docs/source/tutorials/using_text.rst
+++ b/docs/source/tutorials/using_text.rst
@@ -144,7 +144,7 @@ as explained in :ref:`iterating-text`.
 
     class Textt2cExample(Scene):
         def construct(self):
-            t2cindices = Text('Hello', t2c={'[1:-1]': BLUE}).move_to(LEFT)
+            t2cindices = Text('Hello', t2c={(1, -1): BLUE}).move_to(LEFT)
             t2cwords = Text('World',t2c={'rl':RED}).next_to(t2cindices, RIGHT)
             self.add(t2cindices, t2cwords)
 

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -354,9 +354,9 @@ class Text(SVGMobject):
                 def construct(self):
                     text1 = Text(
                         'Google',
-                        t2c={'[:1]': '#3174f0', '[1:2]': '#e53125',
-                             '[2:3]': '#fbb003', '[3:4]': '#3174f0',
-                             '[4:5]': '#269a43', '[5:]': '#e53125'}, font_size=58).scale(3)
+                        t2c={(0, 1): '#3174f0', (1, 2): '#e53125',
+                             (2, 3): '#fbb003', (3, 4): '#3174f0',
+                             (4, 5): '#269a43', (5, None): '#e53125'}, font_size=58).scale(3)
                     self.add(text1)
 
     As :class:`Text` uses Pango to render text, rendering non-English

--- a/manim/mobject/svg/text_mobject.py
+++ b/manim/mobject/svg/text_mobject.py
@@ -76,6 +76,9 @@ TEXT_MOB_SCALE_FACTOR = 0.05
 DEFAULT_LINE_SPACING_SCALE = 0.3
 TEXT2SVG_ADJUSTMENT_FACTOR = 4.8
 
+STYLING_DICT_TYPE = Dict[Union[str, tuple], str]
+GRADIENT_DICT_TYPE = Dict[Union[str, tuple], Sequence[Color]]
+
 
 def remove_invisible_chars(mobject):
     """Function to remove unwanted invisible characters from some mobjects.
@@ -410,11 +413,11 @@ class Text(SVGMobject):
         font: str = "",
         slant: str = NORMAL,
         weight: str = NORMAL,
-        t2c: Dict[str, str] = None,
-        t2f: Dict[str, str] = None,
-        t2g: Dict[str, tuple] = None,
-        t2s: Dict[str, str] = None,
-        t2w: Dict[str, str] = None,
+        t2c: STYLING_DICT_TYPE = None,
+        t2f: STYLING_DICT_TYPE = None,
+        t2g: GRADIENT_DICT_TYPE = None,
+        t2s: STYLING_DICT_TYPE = None,
+        t2w: STYLING_DICT_TYPE = None,
         gradient: tuple = None,
         tab_width: int = 4,
         # Mobject
@@ -451,11 +454,11 @@ class Text(SVGMobject):
         t2g = kwargs.pop("text2gradient", t2g)
         t2s = kwargs.pop("text2slant", t2s)
         t2w = kwargs.pop("text2weight", t2w)
-        self.t2c = t2c
-        self.t2f = t2f
-        self.t2g = t2g
-        self.t2s = t2s
-        self.t2w = t2w
+        self.t2c: STYLING_DICT_TYPE = t2c
+        self.t2f: STYLING_DICT_TYPE = t2f
+        self.t2g: GRADIENT_DICT_TYPE = t2g
+        self.t2s: STYLING_DICT_TYPE = t2s
+        self.t2w: STYLING_DICT_TYPE = t2w
 
         self.original_text = text
         self.disable_ligatures = disable_ligatures
@@ -653,7 +656,7 @@ class Text(SVGMobject):
         return new_setting
 
     def _get_settings_from_t2xs(
-        self, t2xs: Sequence[Tuple[Dict[str, str], str]]
+        self, t2xs: Sequence[Tuple[STYLING_DICT_TYPE, str]]
     ) -> Sequence[TextSetting]:
         settings = []
         t2xwords = set(chain(*([*t2x.keys()] for t2x, _ in t2xs)))


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
* Constructor for `Text` now receives tuple for indices in `t2x` arguments instead of string. The old way is still available but it is deprecated.
* Moved the function `find_indexes` to `_find_indexes` and deprecated the old version.
* Updated typings and relevant example
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Previously in order to color a range in a string the user provided a particular range string, e.g.
```python
Text(
    'Hello',
    t2g={
        '[1:-1]': (RED, GREEN), # <- This line
    },
)
```

This has several disadvantages:
* It is not type safe. The user may provide a dynamic range, and in case of incorrect string format it will silently fail. E.g. the user may accidentally pass floats (`'[1.0:-1]'`) and this will be processed as string literal instead of a range.
* We use our own integer parsing, that is different from Python grammar. This may lead to unexpected behavior when user passes integers in a more esoteric fashion. E.g. passing `'[01:-1]'` will be interpreted as range by the function, but it is not a valid slice in Python, because leading zeros in decimal integer literals are not permitted. On the other hand our code will silently fail interpreting `'[1_0:-1]'` as range, because the current parser does not recognize underscores as separators, but it is a valid python slice.
* The user may expect the range to be working exactly like Python's slices, thus thinking that e.g. `[::2]` is a valid range to color every other letter of a string, but the current code will silently fail interpreting it as a range.
* It does not allow spaces in ranges, so `[1:-1]` is treated differently than `[ 1:-1]`, even though in Python these are equivalent.

This PR deprecates this way of specifying ranges and provides a tuple based one. So the above example would look like this
```python
Text(
    'Hello',
    t2g={
        (1, -1): (RED, GREEN), # <- This line
    },
)
```
This solves all of the above issues:
* Tuples are processed by Python, and then passing to slice object. This ensures type safety to be the same as Python's ranges.
* Integers are interpreted by Python, so whatever they look now or in the future, we will handle them the same way.
* We can detect when the user passes a step argument and react accordingly (currently a warning is logged).
* This problem disappears because tuples are handled by Python and not our parser.

As an added bonus, we no longer need to perform regex matching, making the code slightly faster.

Disadvantages:
* Sometimes it will make the code a bit more awkward with explicit `None`s, e.g. `'[:5]'` -> `(None, 5)`, `'[5:]'` -> `(5, None)`. 
## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
https://manimce--2420.org.readthedocs.build/en/2420/tutorials/using_text.html#textt2cexample
https://manimce--2420.org.readthedocs.build/en/2420/reference/manim.mobject.svg.text_mobject.Text.html#textmorecustomization

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
The example in the second link screams SUE ME.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
