### PR TITLE
Remove unnecessary comment in `simple_functions.py`

### DIFF
--- a/manim/utils/simple_functions.py
+++ b/manim/utils/simple_functions.py
@@ -30,13 +30,6 @@ def get_parameters(function):
     return inspect.signature(function).parameters
 
 
-# Just to have a less heavyweight name for this extremely common operation
-#
-# We may wish to have more fine-grained control over division by zero behavior
-# in the future (separate specifiable values for 0/0 and x/0 with x != 0),
-# but for now, we just allow the option to handle indeterminate 0/0.
-
-
 def clip(a, min_a, max_a):
     if a < min_a:
         return min_a


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Removed comment for a deleted function I accidentally forgot to remove in #2437.
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
