### PR TITLE
Added import lines to examples in `deprecation` docs

### DIFF
--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -103,7 +103,7 @@ def deprecated(
     Basic usage::
 
         from ..utils.deprecation import deprecated
-        
+
         @deprecated
         def foo(**kwargs):
             pass

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -283,7 +283,7 @@ def deprecated_params(
     --------
     Basic usage::
 
-        from manim.utils.deprecation import deprecated
+        from manim.utils.deprecation import deprecated_params
 
         @deprecated_params(params="a, b, c")
         def foo(**kwargs):
@@ -297,7 +297,7 @@ def deprecated_params(
 
     You can also specify additional information for a more precise warning::
 
-        from manim.utils.deprecation import deprecated
+        from manim.utils.deprecation import deprecated_params
 
         @deprecated_params(
             params="a, b, c",
@@ -313,7 +313,7 @@ def deprecated_params(
 
     Basic parameter redirection::
 
-        from manim.utils.deprecation import deprecated
+        from manim.utils.deprecation import deprecated_params
 
         @deprecated_params(redirections=[
             # Two ways to redirect one parameter to another:
@@ -329,7 +329,7 @@ def deprecated_params(
 
     Redirecting using a calculated value::
 
-        from manim.utils.deprecation import deprecated
+        from manim.utils.deprecation import deprecated_params
 
         @deprecated_params(redirections=[
             lambda runtime_in_ms: {"run_time": runtime_in_ms / 1000}
@@ -343,7 +343,7 @@ def deprecated_params(
 
     Redirecting multiple parameter values to one::
 
-        from manim.utils.deprecation import deprecated
+        from manim.utils.deprecation import deprecated_params
 
         @deprecated_params(redirections=[
             lambda buff_x=1, buff_y=1: {"buff": (buff_x, buff_y)}
@@ -357,7 +357,7 @@ def deprecated_params(
 
     Redirect one parameter to multiple::
 
-        from manim.utils.deprecation import deprecated
+        from manim.utils.deprecation import deprecated_params
 
         @deprecated_params(redirections=[
             lambda buff=1: {"buff_x": buff[0], "buff_y": buff[1]} if isinstance(buff, tuple)

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -102,7 +102,7 @@ def deprecated(
     --------
     Basic usage::
 
-        from ..utils.deprecation import deprecated
+        from manim.utils.deprecation import deprecated
 
         @deprecated
         def foo(**kwargs):

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -129,7 +129,7 @@ def deprecated(
     You can specify additional information for a more precise warning::
 
         from manim.utils.deprecation import deprecated
-        
+
         @deprecated(
             since="v0.2",
             until="v0.4",
@@ -145,7 +145,7 @@ def deprecated(
     You may also use dates instead of versions::
 
         from manim.utils.deprecation import deprecated
-        
+
         @deprecated(since="05/01/2021", until="06/01/2021")
         def foo():
             pass
@@ -284,7 +284,7 @@ def deprecated_params(
     Basic usage::
 
         from manim.utils.deprecation import deprecated
-        
+
         @deprecated_params(params="a, b, c")
         def foo(**kwargs):
             pass
@@ -298,7 +298,7 @@ def deprecated_params(
     You can also specify additional information for a more precise warning::
 
         from manim.utils.deprecation import deprecated
-        
+
         @deprecated_params(
             params="a, b, c",
             since="v0.2",
@@ -314,7 +314,7 @@ def deprecated_params(
     Basic parameter redirection::
 
         from manim.utils.deprecation import deprecated
-        
+
         @deprecated_params(redirections=[
             # Two ways to redirect one parameter to another:
             ("old_param", "new_param"),
@@ -330,7 +330,7 @@ def deprecated_params(
     Redirecting using a calculated value::
 
         from manim.utils.deprecation import deprecated
-        
+
         @deprecated_params(redirections=[
             lambda runtime_in_ms: {"run_time": runtime_in_ms / 1000}
         ])
@@ -344,7 +344,7 @@ def deprecated_params(
     Redirecting multiple parameter values to one::
 
         from manim.utils.deprecation import deprecated
-        
+
         @deprecated_params(redirections=[
             lambda buff_x=1, buff_y=1: {"buff": (buff_x, buff_y)}
         ])
@@ -358,7 +358,7 @@ def deprecated_params(
     Redirect one parameter to multiple::
 
         from manim.utils.deprecation import deprecated
-        
+
         @deprecated_params(redirections=[
             lambda buff=1: {"buff_x": buff[0], "buff_y": buff[1]} if isinstance(buff, tuple)
                     else {"buff_x": buff,    "buff_y": buff}

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -128,6 +128,8 @@ def deprecated(
 
     You can specify additional information for a more precise warning::
 
+        from manim.utils.deprecation import deprecated
+        
         @deprecated(
             since="v0.2",
             until="v0.4",
@@ -142,6 +144,8 @@ def deprecated(
 
     You may also use dates instead of versions::
 
+        from manim.utils.deprecation import deprecated
+        
         @deprecated(since="05/01/2021", until="06/01/2021")
         def foo():
             pass
@@ -279,6 +283,8 @@ def deprecated_params(
     --------
     Basic usage::
 
+        from manim.utils.deprecation import deprecated
+        
         @deprecated_params(params="a, b, c")
         def foo(**kwargs):
             pass
@@ -291,6 +297,8 @@ def deprecated_params(
 
     You can also specify additional information for a more precise warning::
 
+        from manim.utils.deprecation import deprecated
+        
         @deprecated_params(
             params="a, b, c",
             since="v0.2",
@@ -305,6 +313,8 @@ def deprecated_params(
 
     Basic parameter redirection::
 
+        from manim.utils.deprecation import deprecated
+        
         @deprecated_params(redirections=[
             # Two ways to redirect one parameter to another:
             ("old_param", "new_param"),
@@ -319,6 +329,8 @@ def deprecated_params(
 
     Redirecting using a calculated value::
 
+        from manim.utils.deprecation import deprecated
+        
         @deprecated_params(redirections=[
             lambda runtime_in_ms: {"run_time": runtime_in_ms / 1000}
         ])
@@ -331,6 +343,8 @@ def deprecated_params(
 
     Redirecting multiple parameter values to one::
 
+        from manim.utils.deprecation import deprecated
+        
         @deprecated_params(redirections=[
             lambda buff_x=1, buff_y=1: {"buff": (buff_x, buff_y)}
         ])
@@ -343,6 +357,8 @@ def deprecated_params(
 
     Redirect one parameter to multiple::
 
+        from manim.utils.deprecation import deprecated
+        
         @deprecated_params(redirections=[
             lambda buff=1: {"buff_x": buff[0], "buff_y": buff[1]} if isinstance(buff, tuple)
                     else {"buff_x": buff,    "buff_y": buff}

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -1,4 +1,9 @@
-"""Decorators for deprecating classes, functions and function parameters."""
+"""Decorators for deprecating classes, functions and function parameters.
+
+.. note::
+   To use deprecation functions, you need to import `deprecation` module. You can import it with `from ..utils.deprecation import deprecated`
+
+"""
 
 from __future__ import annotations
 

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -1,7 +1,7 @@
 """Decorators for deprecating classes, functions and function parameters.
 
 .. note::
-   To use deprecation functions, you need to import `deprecation` module. You can import it with `from ..utils.deprecation import deprecated`
+   To use deprecation functions, you need to import `deprecation` module. You can import it with "`from ..utils.deprecation import deprecated`"
 
 """
 

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -1,9 +1,4 @@
-"""Decorators for deprecating classes, functions and function parameters.
-
-.. note::
-   To use deprecation functions, you need to import `deprecation` module. You can import it with "`from ..utils.deprecation import deprecated`"
-
-"""
+"""Decorators for deprecating classes, functions and function parameters."""
 
 from __future__ import annotations
 
@@ -107,6 +102,8 @@ def deprecated(
     --------
     Basic usage::
 
+        from ..utils.deprecation import deprecated
+        
         @deprecated
         def foo(**kwargs):
             pass


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Updated an example in `deprecation` docs. Added the line `from ..utils.deprecation import deprecated` to a basic usage example.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
This is will help beginner contributors avoid confusion while using the `deprecation` module as the tip indicates that ManimCE uses its own in-house `deprecation` module and doesn't rely on external `deprecation` packages.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
https://docs.manim.community/en/stable/reference/manim.utils.deprecation.html#module-manim.utils.deprecation

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
It is just my personal opinion, as I was confused in the beginning about how to use the `deprecation` module.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
