### PR TITLE
A faster method to compute split_factors

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1506,13 +1506,16 @@ class VMobject(Mobject):
         # it's total length is target_num.  For example,
         # with curr_num = 10, target_num = 15, this would
         # be [0, 0, 1, 2, 2, 3, 4, 4, 5, 6, 6, 7, 8, 8, 9]
-        repeat_indices = (np.arange(target_num) * curr_num) // target_num
+        repeat_indices = (np.arange(target_num, dtype="i") * curr_num) // target_num
 
         # If the nth term of this list is k, it means
         # that the nth curve of our path should be split
         # into k pieces.  In the above example, this would
         # be [2, 1, 2, 1, 2, 1, 2, 1, 2, 1]
-        split_factors = [sum(repeat_indices == i) for i in range(curr_num)]
+        split_factors = np.zeros(curr_num, dtype="i")
+        for val in repeat_indices:
+            split_factors[val] += 1
+
         new_points = np.zeros((0, self.dim))
         for quad, sf in zip(bezier_quads, split_factors):
             # What was once a single cubic curve defined

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1510,8 +1510,12 @@ class VMobject(Mobject):
 
         # If the nth term of this list is k, it means
         # that the nth curve of our path should be split
-        # into k pieces.  In the above example, this would
-        # be [2, 1, 2, 1, 2, 1, 2, 1, 2, 1]
+        # into k pieces.
+        # In the above example our array had the following elements
+        # [0, 0, 1, 2, 2, 3, 4, 4, 5, 6, 6, 7, 8, 8, 9]
+        # We have two 0s, one 1, two 2s and so on.
+        # The split factors array would hence be:
+        # [2, 1, 2, 1, 2, 1, 2, 1, 2, 1]
         split_factors = np.zeros(curr_num, dtype="i")
         for val in repeat_indices:
             split_factors[val] += 1


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
The older method required 47 seconds to compute the split factors this one requires only 5.
Thanks to notkev from the discord server for suggesting this method
<!--changelog-end-->

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
