### PR TITLE
Fixed a File logging bug and some maintenance

### DIFF
--- a/manim/_config/logger_utils.py
+++ b/manim/_config/logger_utils.py
@@ -15,7 +15,6 @@ import configparser
 import copy
 import json
 import logging
-import os
 import sys
 from typing import TYPE_CHECKING
 
@@ -26,7 +25,7 @@ from rich.logging import RichHandler
 from rich.theme import Theme
 
 if TYPE_CHECKING:
-    from manim._config.utils import ManimConfig
+    from pathlib import Path
 HIGHLIGHTED_KEYWORDS = [  # these keywords are highlighted specially
     "Played",
     "animations",
@@ -142,7 +141,7 @@ def parse_theme(parser: configparser.ConfigParser) -> Theme:
     return custom_theme
 
 
-def set_file_logger(config: ManimConfig, verbosity: str) -> None:
+def set_file_logger(scene_name: str, module_name: str, log_dir: Path) -> None:
     """Add a file handler to manim logger.
 
     The path to the file is built using ``config.log_dir``.
@@ -152,28 +151,18 @@ def set_file_logger(config: ManimConfig, verbosity: str) -> None:
     config : :class:`ManimConfig`
         The global config, used to determine the log file path.
 
-    verbosity : :class:`str`
-        The verbosity level of the logger.
-
-    Notes
-    -----
-    Calling this function changes the verbosity of all handlers assigned to
-    manim logger.
-
     """
     # Note: The log file name will be
     # <name_of_animation_file>_<name_of_scene>.log, gotten from config.  So it
     # can differ from the real name of the scene.  <name_of_scene> would only
     # appear if scene name was provided when manim was called.
-    scene_name_suffix = "".join(config["scene_names"])
-    scene_file_name = os.path.basename(config["input_file"]).split(".")[0]
+    scene_name_suffix = "".join(scene_name)
     log_file_name = (
-        f"{scene_file_name}_{scene_name_suffix}.log"
+        f"{module_name}_{scene_name_suffix}.log"
         if scene_name_suffix
-        else f"{scene_file_name}.log"
+        else f"{module_name}.log"
     )
-    log_file_path = config.get_dir("log_dir") / log_file_name
-    log_file_path.parent.mkdir(parents=True, exist_ok=True)
+    log_file_path = log_dir / log_file_name
 
     file_handler = logging.FileHandler(log_file_path, mode="w")
     file_handler.setFormatter(JSONFormatter())
@@ -181,9 +170,6 @@ def set_file_logger(config: ManimConfig, verbosity: str) -> None:
     logger = logging.getLogger("manim")
     logger.addHandler(file_handler)
     logger.info("Log file will be saved in %(logpath)s", {"logpath": log_file_path})
-
-    config.verbosity = verbosity
-    logger.setLevel(verbosity)
 
 
 class JSONFormatter(logging.Formatter):

--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -854,19 +854,24 @@ class ManimConfig(MutableMapping):
         doc="Whether to show progress bars while rendering animations.",
     )
 
-    @property
-    def log_to_file(self):
-        """Whether to save logs to a file."""
-        return self._d["log_to_file"]
+    log_to_file = property(
+        lambda self: self._d["log_to_file"],
+        lambda self, val: self._set_boolean("log_to_file", val),
+        doc="Whether to save logs to a file.",
+    )
+    # @property
+    # def log_to_file(self):
+    #    """Whether to save logs to a file."""
+    #    return self._d["log_to_file"]
 
-    @log_to_file.setter
-    def log_to_file(self, val: str) -> None:
-        self._set_boolean("log_to_file", val)
-        if val:
-            log_dir = self.get_dir("log_dir")
-            if not os.path.exists(log_dir):
-                os.makedirs(log_dir)
-            set_file_logger(self, self["verbosity"])
+    # @log_to_file.setter
+    # def log_to_file(self, val: str) -> None:
+    #    self._set_boolean("log_to_file", val)
+    #    if val:
+    #        log_dir = self.get_dir("log_dir")
+    #        if not os.path.exists(log_dir):
+    #            os.makedirs(log_dir)
+    #        set_file_logger(self, self["verbosity"])
 
     notify_outdated_version = property(
         lambda self: self._d["notify_outdated_version"],

--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -19,9 +19,9 @@ import logging
 import os
 import re
 import sys
-import typing
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
+from typing import Any, Iterable, Iterator
 
 import colour
 import numpy as np
@@ -29,7 +29,6 @@ import numpy as np
 from .. import constants
 from ..utils.tex import TexTemplate, TexTemplateFromFile
 from ..utils.tex_templates import TexTemplateLibrary
-from .logger_utils import set_file_logger
 
 
 def config_file_paths() -> list[Path]:
@@ -303,7 +302,7 @@ class ManimConfig(MutableMapping):
         self._d = {k: None for k in self._OPTS}
 
     # behave like a dict
-    def __iter__(self) -> typing.Iterator[str]:
+    def __iter__(self) -> Iterator[str]:
         return iter(self._d)
 
     def __len__(self) -> int:
@@ -316,10 +315,10 @@ class ManimConfig(MutableMapping):
         except AttributeError:
             return False
 
-    def __getitem__(self, key) -> typing.Any:
+    def __getitem__(self, key) -> Any:
         return getattr(self, key)
 
-    def __setitem__(self, key: str, val: typing.Any) -> None:
+    def __setitem__(self, key: str, val: Any) -> None:
         getattr(ManimConfig, key).fset(self, val)  # fset is the property's setter
 
     def update(self, obj: ManimConfig | dict) -> None:
@@ -394,7 +393,7 @@ class ManimConfig(MutableMapping):
         """See ManimConfig.copy()."""
         return copy.deepcopy(self)
 
-    def __deepcopy__(self, memo: dict[str, typing.Any]) -> ManimConfig:
+    def __deepcopy__(self, memo: dict[str, Any]) -> ManimConfig:
         """See ManimConfig.copy()."""
         c = ManimConfig()
         # Deepcopying the underlying dict is enough because all properties
@@ -404,14 +403,14 @@ class ManimConfig(MutableMapping):
         return c
 
     # helper type-checking methods
-    def _set_from_list(self, key: str, val: typing.Any, values: list) -> None:
+    def _set_from_list(self, key: str, val: Any, values: list) -> None:
         """Set ``key`` to ``val`` if ``val`` is contained in ``values``."""
         if val in values:
             self._d[key] = val
         else:
             raise ValueError(f"attempted to set {key} to {val}; must be in {values}")
 
-    def _set_boolean(self, key: str | int, val: typing.Any) -> None:
+    def _set_boolean(self, key: str | int, val: Any) -> None:
         """Set ``key`` to ``val`` if ``val`` is Boolean."""
         if val in [True, False]:
             self._d[key] = val
@@ -424,7 +423,7 @@ class ManimConfig(MutableMapping):
         else:
             raise ValueError(f"{key} must be tuple")
 
-    def _set_str(self, key: str, val: typing.Any) -> None:
+    def _set_str(self, key: str, val: Any) -> None:
         """Set ``key`` to ``val`` if ``val`` is a string."""
         if isinstance(val, str):
             self._d[key] = val
@@ -828,8 +827,7 @@ class ManimConfig(MutableMapping):
                 filename,
             )
 
-        if filename:
-            return self.digest_parser(make_config_parser(filename))
+        return self.digest_parser(make_config_parser(filename))
 
     # config options are properties
     preview = property(
@@ -859,19 +857,6 @@ class ManimConfig(MutableMapping):
         lambda self, val: self._set_boolean("log_to_file", val),
         doc="Whether to save logs to a file.",
     )
-    # @property
-    # def log_to_file(self):
-    #    """Whether to save logs to a file."""
-    #    return self._d["log_to_file"]
-
-    # @log_to_file.setter
-    # def log_to_file(self, val: str) -> None:
-    #    self._set_boolean("log_to_file", val)
-    #    if val:
-    #        log_dir = self.get_dir("log_dir")
-    #        if not os.path.exists(log_dir):
-    #            os.makedirs(log_dir)
-    #        set_file_logger(self, self["verbosity"])
 
     notify_outdated_version = property(
         lambda self: self._d["notify_outdated_version"],
@@ -925,12 +910,6 @@ class ManimConfig(MutableMapping):
         lambda self: self._d["force_window"],
         lambda self, val: self._set_boolean("force_window", val),
         doc="Set to force window when using the opengl renderer",
-    )
-
-    dry_run = property(
-        lambda self: self._d["dry_run"],
-        lambda self, val: self._set_boolean("dry_run", val),
-        doc="Enable dry_run so that no output files are generated and window is disabled.",
     )
 
     @property
@@ -1628,7 +1607,7 @@ class ManimFrame(Mapping):
         self.__dict__["_c"] = c
 
     # there are required by parent class Mapping to behave like a dict
-    def __getitem__(self, key: str | int) -> typing.Any:
+    def __getitem__(self, key: str | int) -> Any:
         if key in self._OPTS:
             return self._c[key]
         elif key in self._CONSTANTS:
@@ -1636,7 +1615,7 @@ class ManimFrame(Mapping):
         else:
             raise KeyError(key)
 
-    def __iter__(self) -> typing.Iterable:
+    def __iter__(self) -> Iterable:
         return iter(list(self._OPTS) + list(self._CONSTANTS))
 
     def __len__(self) -> int:

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -21,6 +21,7 @@ from pydub import AudioSegment
 from manim import __version__
 
 from .. import config, logger
+from .._config.logger_utils import set_file_logger
 from ..constants import FFMPEG_BIN, GIF_FILE_EXTENSION
 from ..utils.file_ops import (
     add_extension_if_not_present,
@@ -29,6 +30,7 @@ from ..utils.file_ops import (
     is_gif_format,
     is_png_format,
     is_webm_format,
+    log_to_file,
     modify_atime,
     write_to_movie,
 )
@@ -160,6 +162,12 @@ class SceneFileWriter:
                     module_name=module_name,
                 ),
             )
+
+            if log_to_file():
+                log_dir = guarantee_existence(config.get_dir("log_dir"))
+                set_file_logger(
+                    scene_name=scene_name, module_name=module_name, log_dir=log_dir
+                )
 
     def finish_last_section(self) -> None:
         """Delete current section if it is empty."""

--- a/manim/utils/file_ops.py
+++ b/manim/utils/file_ops.py
@@ -15,6 +15,7 @@ __all__ = [
     "is_webm_format",
     "is_mov_format",
     "write_to_movie",
+    "log_to_file",
 ]
 
 import os
@@ -117,6 +118,13 @@ def write_to_movie() -> bool:
     )
 
 
+def log_to_file() -> bool:
+    """
+    Determines if file logging is set to True.
+    """
+    return config["log_to_file"]
+
+
 def add_extension_if_not_present(file_name, extension):
     if file_name.suffix != extension:
         return file_name.with_suffix(extension)
@@ -133,14 +141,14 @@ def add_version_before_extension(file_name):
 def guarantee_existence(path):
     if not os.path.exists(path):
         os.makedirs(path)
-    return os.path.abspath(path)
+    return Path(os.path.abspath(path))
 
 
 def guarantee_empty_existence(path):
     if os.path.exists(path):
         shutil.rmtree(path)
     os.makedirs(path)
-    return os.path.abspath(path)
+    return Path(os.path.abspath(path))
 
 
 def seek_full_path_from_defaults(file_name, default_dir, extensions):

--- a/manim/utils/file_ops.py
+++ b/manim/utils/file_ops.py
@@ -25,6 +25,10 @@ import subprocess as sp
 import time
 from pathlib import Path
 from shutil import copyfile
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..scene.scene_file_writer import SceneFileWriter
 
 from manim import __version__, config, logger
 
@@ -125,33 +129,35 @@ def log_to_file() -> bool:
     return config["log_to_file"]
 
 
-def add_extension_if_not_present(file_name, extension):
+def add_extension_if_not_present(file_name: Path, extension: str) -> Path:
     if file_name.suffix != extension:
         return file_name.with_suffix(extension)
     else:
         return file_name
 
 
-def add_version_before_extension(file_name):
+def add_version_before_extension(file_name: Path) -> Path:
     file_name = Path(file_name)
     path, name, suffix = file_name.parent, file_name.stem, file_name.suffix
     return Path(path, f"{name}_ManimCE_v{__version__}{suffix}")
 
 
-def guarantee_existence(path):
+def guarantee_existence(path: Path) -> Path:
     if not os.path.exists(path):
         os.makedirs(path)
     return Path(os.path.abspath(path))
 
 
-def guarantee_empty_existence(path):
+def guarantee_empty_existence(path: Path) -> Path:
     if os.path.exists(path):
         shutil.rmtree(path)
     os.makedirs(path)
     return Path(os.path.abspath(path))
 
 
-def seek_full_path_from_defaults(file_name, default_dir, extensions):
+def seek_full_path_from_defaults(
+    file_name: Path, default_dir: str, extensions: str
+) -> Path:
     possible_paths = [file_name]
     possible_paths += [
         Path(default_dir) / f"{file_name}{extension}" for extension in ["", *extensions]
@@ -163,7 +169,7 @@ def seek_full_path_from_defaults(file_name, default_dir, extensions):
     raise OSError(error)
 
 
-def modify_atime(file_path):
+def modify_atime(file_path) -> None:
     """Will manually change the accessed time (called `atime`) of the file, as on a lot of OS the accessed time refresh is disabled by default.
 
     Parameters
@@ -196,7 +202,7 @@ def open_file(file_path, in_browser=False):
         sp.Popen(commands)
 
 
-def open_media_file(file_writer):
+def open_media_file(file_writer: SceneFileWriter) -> None:
     file_paths = []
 
     if config["save_last_frame"]:
@@ -215,7 +221,7 @@ def open_media_file(file_writer):
             logger.info(f"Previewed File at: '{file_path}'")
 
 
-def get_template_names():
+def get_template_names() -> list[str]:
     """Returns template names from the templates directory.
 
     Returns
@@ -226,7 +232,7 @@ def get_template_names():
     return [template_name.stem for template_name in template_path.glob("*.mtp")]
 
 
-def get_template_path():
+def get_template_path() -> Path:
     """Returns the Path of templates directory.
 
     Returns
@@ -250,7 +256,9 @@ def add_import_statement(file):
         f.write(import_line.rstrip("\r\n") + "\n" + content)
 
 
-def copy_template_files(project_dir=Path("."), template_name="Default"):
+def copy_template_files(
+    project_dir: Path = Path("."), template_name: str = "Default"
+) -> None:
     """Copies template files from templates dir to project_dir.
 
     Parameters

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,6 +98,7 @@ def test_custom_dirs(tmp_path):
         {
             "media_dir": tmp_path,
             "save_sections": True,
+            "log_to_file": True,
             "frame_rate": 15,
             "pixel_height": 854,
             "pixel_width": 480,
@@ -108,6 +109,7 @@ def test_custom_dirs(tmp_path):
             "images_dir": "{media_dir}/test_images",
             "text_dir": "{media_dir}/test_text",
             "tex_dir": "{media_dir}/test_tex",
+            "log_dir": "{media_dir}/test_log",
         }
     ):
         scene = MyScene()
@@ -131,7 +133,7 @@ def test_custom_dirs(tmp_path):
 
         assert_dir_filled(os.path.join(tmp_path, "test_text"))
         assert_dir_filled(os.path.join(tmp_path, "test_tex"))
-        # TODO: testing the log dir would be nice but it doesn't get generated for some reason and test crashes when setting "log_to_file" to True
+        assert_dir_filled(os.path.join(tmp_path, "test_log"))
 
 
 def test_frame_size(tmp_path):

--- a/tests/test_logging/test_logging.py
+++ b/tests/test_logging/test_logging.py
@@ -35,32 +35,6 @@ def test_logging_to_file(tmp_path, python_version):
     assert exitcode == 0, err
 
 
-@logs_comparison(
-    "BasicSceneLoggingTest.txt",
-    os.path.join("logs", "basic_scenes_square_to_circle.log"),
-)
-def test_logging_when_scene_is_not_specified(tmp_path, python_version):
-    path_basic_scene = os.path.join(
-        "tests",
-        "test_logging",
-        "basic_scenes_square_to_circle.py",
-    )
-    command = [
-        python_version,
-        "-m",
-        "manim",
-        "-ql",
-        "-v",
-        "DEBUG",
-        "--log_to_file",
-        "--media_dir",
-        str(tmp_path),
-        path_basic_scene,
-    ]
-    _, err, exitcode = capture(command)
-    assert exitcode == 0, err
-
-
 def test_error_logging(tmp_path, python_version):
     path_error_scene = Path("tests/test_logging/basic_scenes_error.py")
 


### PR DESCRIPTION
## Overview: What does this pull request change?
Closes #2285 
Removes a test
Removes the ability to change `verbosity` when calling `--log_to_file`
Adds type hints to file_ops
And does some fixes to _config.utils

I have added additional details in the commit messages

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
A bugfix is nice.

## Further Comments
This removes the ability to change verbosity through the `--log_to_file` option as it doesn't expect any input, hence that argument couldn't be set anyway.
This is same as #2541 but with a cleaner commit history and easier to review.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
