### PR TITLE
CI: Remove 'Remove-Item' calls for MSYS2 Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,6 @@ jobs:
       - name: Add Windows dependencies to PATH
         if: runner.os == 'Windows'
         run: |
-          Remove-Item C:\msys64\mingw64\bin\python.exe -Force
-          Remove-Item C:\msys64\mingw64\bin\python3.exe -Force
           $env:Path += ";" + "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\win32"
           $env:Path = "$env:USERPROFILE\.poetry\bin;$($env:PATH)"
           $env:PATH = "C:\msys64\mingw64\bin;$($env:PATH)"


### PR DESCRIPTION
Now `windows-latest` defaults to `windows-2022` and it has a breaking change related to MSYS2 where there are no pre-installed packages. 
This would mean we don't need to manually remove `python.exe` installed through it.

See https://github.com/actions/virtual-environments/issues/4856

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
