### PR TITLE
Fixed logger bug in `camera.make_background_from_func()`

### DIFF
--- a/manim/camera/camera.py
+++ b/manim/camera/camera.py
@@ -354,16 +354,10 @@ class Camera:
             The pixel array which can then be passed to set_background.
         """
 
-        logger.info(
-            "Starting set_background; for reference, the current time is ",
-            time.strftime("%H:%M:%S"),
-        )
+        logger.info("Starting set_background")
         coords = self.get_coords_of_all_pixels()
         new_background = np.apply_along_axis(coords_to_colors_func, 2, coords)
-        logger.info(
-            "Ending set_background; for reference, the current time is ",
-            time.strftime("%H:%M:%S"),
-        )
+        logger.info("Ending set_background")
 
         return self.convert_pixel_array(new_background, convert_from_floats=True)
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Fixed logger bug in `camera.make_background_from_func()` that crashed Manim.  This PR closes #2488 .
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
When calling the method `camera.make_background_from_func()` the logger would print when starting and ending the process, including a timestamp at the end.  Here is the original code:

```py
        logger.info(
            "Starting set_background; for reference, the current time is ",
            time.strftime("%H:%M:%S"),
        )
        coords = self.get_coords_of_all_pixels()
        new_background = np.apply_along_axis(coords_to_colors_func, 2, coords)
        logger.info(
            "Ending set_background; for reference, the current time is ",
            time.strftime("%H:%M:%S"),
        )
```

However, this did not work and Manim would crash when the logger was called due to the `time.strftime` call.  Additionally, it was unnecessary to print the timestamp at the end, as the log already printed the timestamp at the beginning of the message, as seen here:

```
$ manim test.py Test -ql -p
Manim Community v0.14.0

[02/17/2022 09:28:52 PM] INFO     Starting set_background
[02/17/2022 09:29:08 PM] INFO     Ending set_background
```

This PR removed the timestamp at the end and shorted the message to the above.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
N/A

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
N/A


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
