### PR TITLE
Allowed passing vertex configuration keyword arguments to :meth:`.Graph.add_edges`

### DIFF
--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -9,6 +9,7 @@ __all__ = [
 from copy import copy
 from typing import Hashable, Iterable
 
+import itertools as it
 import networkx as nx
 import numpy as np
 
@@ -874,6 +875,7 @@ class Graph(VMobject, metaclass=ConvertToOpenGL):
         *edges: tuple[Hashable, Hashable],
         edge_type: type[Mobject] = Line,
         edge_config: dict | None = None,
+        **kwargs,
     ):
         """Add new edges to the graph.
 
@@ -892,6 +894,9 @@ class Graph(VMobject, metaclass=ConvertToOpenGL):
             whose keys are the edge tuples, and whose values are dictionaries
             containing keyword arguments to be passed for the construction
             of the corresponding edge.
+        kwargs
+            Any further keyword arguments are passed to :meth:`.add_vertices`
+            which is used to create new vertices in the passed edges.
 
         Returns
         -------
@@ -909,6 +914,10 @@ class Graph(VMobject, metaclass=ConvertToOpenGL):
             base_edge_config[e].update(edge_config.get(e, {}))
         edge_config = base_edge_config
 
+        edge_vertices = set(it.chain(*edges))
+        new_vertices = [v for v in edge_vertices if v not in self.vertices]
+        added_vertices = self.add_vertices(*new_vertices, **kwargs)
+
         added_mobjects = sum(
             (
                 self._add_edge(
@@ -918,7 +927,7 @@ class Graph(VMobject, metaclass=ConvertToOpenGL):
                 ).submobjects
                 for edge in edges
             ),
-            [],
+            added_vertices,
         )
         return self.get_group_class()(*added_mobjects)
 

--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -6,10 +6,10 @@ __all__ = [
     "Graph",
 ]
 
+import itertools as it
 from copy import copy
 from typing import Hashable, Iterable
 
-import itertools as it
 import networkx as nx
 import numpy as np
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

See title.

<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

Adding vertices and edges within the same play call causes problems. Creating edges whose vertices have not been added yet is somewhat unflexible as there is no way to influence the created vertices. With these changes, keyword arguments for vertex creation can be passed to `add_edges` as well. One example that did not work before, but does with this PR:

```py

class GraphExample(Scene):
    def construct(self):
        g = Graph([], [])
        self.play(g.animate.add_edges((1,2))  # fails because vertices for 1 and 2 are both created in the center and no edge can be constructed between them
        self.play(g.animate.add_edges((1,2), positions={1: LEFT, 2: RIGHT})  # with this PR, keyword arguments like vertex position can be passed, this renders.
```


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
