### PR TITLE
Removed unused livestream-related imports and functions from :mod:`.scene_file_writer`

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 __all__ = ["SceneFileWriter"]
 
-import datetime
 import json
 import os
 import shutil
 import subprocess
 from pathlib import Path
-from time import sleep
 from typing import Any
 
 import numpy as np
@@ -69,7 +67,6 @@ class SceneFileWriter:
 
     def __init__(self, renderer, scene_name, **kwargs):
         self.renderer = renderer
-        self.stream_lock = False
         self.init_output_directories(scene_name)
         self.init_audio()
         self.frame_count = 0
@@ -418,25 +415,6 @@ class SceneFileWriter:
         image.save(self.image_file_path)
         self.print_file_ready_message(self.image_file_path)
 
-    def idle_stream(self):
-        """
-        Doesn't write anything to the FFMPEG frame buffer.
-        """
-        while self.stream_lock:
-            a = datetime.datetime.now()
-            # self.update_frame()
-            self.renderer.update_frame()
-            n_frames = 1
-            # frame = self.get_frame()
-            frame = self.renderer.get_frame()
-            # self.add_frame(*[frame] * n_frames)
-            self.renderer.add_frame(*[frame] * n_frames)
-            b = datetime.datetime.now()
-            time_diff = (b - a).total_seconds()
-            frame_duration = 1 / config["frame_rate"]
-            if time_diff < frame_duration:
-                sleep(frame_duration - time_diff)
-
     def finish(self):
         """
         Finishes writing to the FFMPEG buffer or writing images
@@ -548,7 +526,7 @@ class SceneFileWriter:
     def combine_files(
         self,
         input_files: list[str],
-        output_file: str,
+        output_file: Path | str,
         create_gif=False,
         includes_sound=False,
     ):


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Idle stream is no longer used, was a function aiding livestreaming.
Also corrected a type hint.
<!--changelog-end-->

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
