### PR TITLE
Refactored docstrings in mod:`manim.mobject.geometry`

### DIFF
--- a/manim/mobject/geometry/polygram.py
+++ b/manim/mobject/geometry/polygram.py
@@ -62,8 +62,6 @@ class Polygram(VMobject, metaclass=ConvertToOpenGL):
                 self.play(MoveAlongPath(dot, hexagram), run_time=5, rate_func=linear)
                 self.remove(dot)
                 self.wait()
-
-
     """
 
     def __init__(self, *vertex_groups: Iterable[Sequence[float]], color=BLUE, **kwargs):
@@ -143,9 +141,12 @@ class Polygram(VMobject, metaclass=ConvertToOpenGL):
         radius
             The curvature of the corners of the :class:`Polygram`.
 
+
+        .. seealso::
+            :class:`.~RoundedRectangle`
+
         Examples
         --------
-
         .. manim:: PolygramRoundCorners
             :save_last_frame:
 
@@ -159,10 +160,6 @@ class Polygram(VMobject, metaclass=ConvertToOpenGL):
 
                     shapes.arrange(RIGHT)
                     self.add(shapes)
-
-        See Also
-        --------
-        :class:`RoundedRectangle`
         """
 
         if radius == 0:
@@ -228,7 +225,6 @@ class Polygon(Polygram):
 
     Examples
     --------
-
     .. manim:: PolygonExample
         :save_last_frame:
 
@@ -354,7 +350,6 @@ class RegularPolygon(RegularPolygram):
 
     Examples
     --------
-
     .. manim:: RegularPolygonExample
         :save_last_frame:
 
@@ -488,7 +483,6 @@ class Triangle(RegularPolygon):
 
     Examples
     --------
-
     .. manim:: TriangleExample
         :save_last_frame:
 
@@ -528,7 +522,6 @@ class Rectangle(Polygon):
 
     Examples
     ----------
-
     .. manim:: RectangleExample
         :save_last_frame:
 
@@ -600,7 +593,6 @@ class Square(Rectangle):
 
     Examples
     --------
-
     .. manim:: SquareExample
         :save_last_frame:
 
@@ -629,7 +621,6 @@ class RoundedRectangle(Rectangle):
 
     Examples
     --------
-
     .. manim:: RoundedRectangleExample
         :save_last_frame:
 
@@ -651,12 +642,6 @@ class RoundedRectangle(Rectangle):
 class Cutout(VMobject, metaclass=ConvertToOpenGL):
     """A shape with smaller cutouts.
 
-    .. warning::
-
-        Technically, this class behaves similar to a symmetric difference: if
-        parts of the ``mobjects`` are not located within the ``main_shape``,
-        these parts will be added to the resulting :class:`~.VMobject`.
-
     Parameters
     ----------
     main_shape : :class:`~.VMobject`
@@ -666,6 +651,12 @@ class Cutout(VMobject, metaclass=ConvertToOpenGL):
     kwargs
         Further keyword arguments that are passed to the constructor of
         :class:`~.VMobject`.
+
+
+    .. warning::
+        Technically, this class behaves similar to a symmetric difference: if
+        parts of the ``mobjects`` are not located within the ``main_shape``,
+        these parts will be added to the resulting :class:`~.VMobject`.
 
     Examples
     --------

--- a/manim/mobject/geometry/shape_matchers.py
+++ b/manim/mobject/geometry/shape_matchers.py
@@ -18,7 +18,6 @@ class SurroundingRectangle(RoundedRectangle):
 
     Examples
     --------
-
     .. manim:: SurroundingRectExample
         :save_last_frame:
 
@@ -58,7 +57,6 @@ class BackgroundRectangle(SurroundingRectangle):
 
     Examples
     --------
-
     .. manim:: ExampleBackgroundRectangle
         :save_last_frame:
 

--- a/manim/mobject/geometry/tips.py
+++ b/manim/mobject/geometry/tips.py
@@ -23,14 +23,13 @@ from manim.utils.space_ops import angle_of_vector
 class ArrowTip(VMobject, metaclass=ConvertToOpenGL):
     r"""Base class for arrow tips.
 
-    See Also
-    --------
-    :class:`ArrowTriangleTip`
-    :class:`ArrowTriangleFilledTip`
-    :class:`ArrowCircleTip`
-    :class:`ArrowCircleFilledTip`
-    :class:`ArrowSquareTip`
-    :class:`ArrowSquareFilledTip`
+    .. seealso::
+        :class:`ArrowTriangleTip`
+        :class:`ArrowTriangleFilledTip`
+        :class:`ArrowCircleTip`
+        :class:`ArrowCircleFilledTip`
+        :class:`ArrowSquareTip`
+        :class:`ArrowSquareFilledTip`
 
     Examples
     --------


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Refactors docstrings to follow numpy format
Continuation of #2560
<!--changelog-end-->
## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
https://manimce--2569.org.readthedocs.build/en/2569/reference/manim.mobject.geometry.polygram.html
https://manimce--2569.org.readthedocs.build/en/2569/reference/manim.mobject.geometry.shape_matchers.html
https://manimce--2569.org.readthedocs.build/en/2569/reference/manim.mobject.geometry.tips.html


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
Please merge this after #2560 as the docs build might fail and the fix for it has been made in that PR.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
