### PR TITLE
Fixed a bug with animation of removal of edges from a :class:`.Graph`

### DIFF
--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -998,7 +998,7 @@ class Graph(VMobject, metaclass=ConvertToOpenGL):
 
         mobjects = self.remove_edges(*edges)
         return AnimationGroup(
-            *(animation(mobj, **anim_args) for mobj in mobjects), group=self
+            *(animation(mobj, **anim_args) for mobj in mobjects)
         )
 
     @staticmethod

--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -997,9 +997,7 @@ class Graph(VMobject, metaclass=ConvertToOpenGL):
         animation = anim_args.pop("animation", Uncreate)
 
         mobjects = self.remove_edges(*edges)
-        return AnimationGroup(
-            *(animation(mobj, **anim_args) for mobj in mobjects)
-        )
+        return AnimationGroup(*(animation(mobj, **anim_args) for mobj in mobjects))
 
     @staticmethod
     def from_networkx(nxgraph: nx.classes.graph.Graph, **kwargs) -> Graph:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->

The `AnimationGroup` constructed in the custom override of  `Graph.remove_edges` currently uses the graph itself as the corresponding group Mobject. As the edges have already been removed from the graph mobject, this causes the edges to disappear immediately.

In this case, the `AnimationGroup` can just form its own group as its base mobject.

Fixes #2575.

<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
