### PR TITLE
Fix `find_intersection` in `space_ops.py`

### DIFF
--- a/manim/utils/space_ops.py
+++ b/manim/utils/space_ops.py
@@ -552,10 +552,10 @@ def line_intersection(
 
 
 def find_intersection(
-    p0: Sequence[np.ndarray],
-    v0: Sequence[np.ndarray],
-    p1: Sequence[np.ndarray],
-    v1: Sequence[np.ndarray],
+    p0s: Sequence[np.ndarray],
+    v0s: Sequence[np.ndarray],
+    p1s: Sequence[np.ndarray],
+    v1s: Sequence[np.ndarray],
     threshold: float = 1e-5,
 ) -> Sequence[np.ndarray]:
     """
@@ -565,25 +565,14 @@ def find_intersection(
     For 3d values, it returns the point on the ray p0 + v0 * t closest to the
     ray p1 + v1 * t
     """
-    p0 = np.array(p0, ndmin=2)
-    v0 = np.array(v0, ndmin=2)
-    p1 = np.array(p1, ndmin=2)
-    v1 = np.array(v1, ndmin=2)
-    m, n = np.shape(p0)
-    assert n in [2, 3]
+    # algorithm from https://en.wikipedia.org/wiki/Skew_lines#Nearest_points
+    result = []
 
-    numerator = np.cross(v1, p1 - p0)
-    denominator = np.cross(v1, v0)
-    if n == 3:
-        d = len(np.shape(numerator))
-        new_numerator = np.multiply(numerator, numerator).sum(d - 1)
-        new_denominator = np.multiply(denominator, numerator).sum(d - 1)
-        numerator, denominator = new_numerator, new_denominator
-
-    denominator[abs(denominator) < threshold] = np.inf  # So that ratio goes to 0 there
-    ratio = numerator / denominator
-    ratio = np.repeat(ratio, n).reshape((m, n))
-    return p0 + ratio * v0
+    for p0, v0, p1, v1 in zip(*[p0s, v0s, p1s, v1s]):
+        normal = np.cross(v1, np.cross(v0, v1))
+        denom = max(np.dot(v0, normal), threshold)
+        result += [p0 + np.dot(p1 - p0, normal) / denom * v0]
+    return result
 
 
 def get_winding_number(points: Sequence[float]) -> float:

--- a/manim/utils/space_ops.py
+++ b/manim/utils/space_ops.py
@@ -552,10 +552,10 @@ def line_intersection(
 
 
 def find_intersection(
-    p0s: Sequence[np.ndarray],
-    v0s: Sequence[np.ndarray],
-    p1s: Sequence[np.ndarray],
-    v1s: Sequence[np.ndarray],
+    p0: Sequence[np.ndarray],
+    v0: Sequence[np.ndarray],
+    p1: Sequence[np.ndarray],
+    v1: Sequence[np.ndarray],
     threshold: float = 1e-5,
 ) -> Sequence[np.ndarray]:
     """
@@ -565,13 +565,25 @@ def find_intersection(
     For 3d values, it returns the point on the ray p0 + v0 * t closest to the
     ray p1 + v1 * t
     """
-    # algorithm from https://en.wikipedia.org/wiki/Skew_lines#Nearest_points
-    result = []
+    p0 = np.array(p0, ndmin=2)
+    v0 = np.array(v0, ndmin=2)
+    p1 = np.array(p1, ndmin=2)
+    v1 = np.array(v1, ndmin=2)
+    m, n = np.shape(p0)
+    assert n in [2, 3]
 
-    for p0, v0, p1, v1 in zip(*[p0s, v0s, p1s, v1s]):
-        normal = np.cross(v1, np.cross(v0, v1))
-        result += [p0 + np.dot(p1 - p0, normal) / np.dot(v0, normal) * v0]
-    return result
+    numerator = np.cross(v1, p1 - p0)
+    denominator = np.cross(v1, v0)
+    if n == 3:
+        d = len(np.shape(numerator))
+        new_numerator = np.multiply(numerator, numerator).sum(d - 1)
+        new_denominator = np.multiply(denominator, numerator).sum(d - 1)
+        numerator, denominator = new_numerator, new_denominator
+
+    denominator[abs(denominator) < threshold] = np.inf  # So that ratio goes to 0 there
+    ratio = numerator / denominator
+    ratio = np.repeat(ratio, n).reshape((m, n))
+    return p0 + ratio * v0
 
 
 def get_winding_number(points: Sequence[float]) -> float:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->
The new implementation of the function `find_intersection` in `space_ops.py` broke rendering of text (and tex) with the opengl renderer. This PR took account a minimum threshold to avoid division by zero.
## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
