### PR TITLE
Fixed bug with displaying images in Jupyter Notebooks when ``config.media_embed`` is set to ``False``

### DIFF
--- a/manim/utils/ipython_magic.py
+++ b/manim/utils/ipython_magic.py
@@ -181,7 +181,7 @@ else:
                     embed = "google.colab" in str(get_ipython())
 
                 if file_type.startswith("image"):
-                    result = Image(filename=config["output_file"], embed=embed)
+                    result = Image(filename=config["output_file"])
                 else:
                     result = Video(
                         tmpfile,


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->

This removes the specification of the `embed` parameter (which is set to `True` by default anyways) when displaying `Image`s in Jupyter Notebooks. As it turns out, specifying `embed=False` (introduced in #2442) makes the notebook include `<img src="None">`.

Fixes #2590. 

<!--changelog-start-->

<!--changelog-end-->





<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
