### PR TITLE
Support groups in `TransformMatchingParts`

### DIFF
--- a/manim/animation/transform_matching_parts.py
+++ b/manim/animation/transform_matching_parts.py
@@ -247,12 +247,15 @@ class TransformMatchingTex(TransformMatchingAbstractBase):
             def construct(self):
                 variables = VGroup(MathTex("a"), MathTex("b"), MathTex("c")).arrange_submobjects().shift(UP)
 
-                eq1 = MathTex("{{x}}^2 + {{y}}^2 = {{z}}^2")
-                eq2 = MathTex("{{a}}^2 + {{b}}^2 = {{c}}^2")
+                eq1 = MathTex("{{x}}^2", "+", "{{y}}^2", "=", "{{z}}^2")
+                eq2 = MathTex("{{a}}^2", "+", "{{b}}^2", "=", "{{c}}^2")
+                eq3 = MathTex("{{a}}^2", "=", "{{c}}^2", "-", "{{b}}^2")
 
                 self.add(eq1)
                 self.wait(0.5)
                 self.play(TransformMatchingTex(Group(eq1, variables), eq2))
+                self.wait(0.5)
+                self.play(TransformMatchingTex(eq2, eq3))
                 self.wait(0.5)
 
     """

--- a/manim/animation/transform_matching_parts.py
+++ b/manim/animation/transform_matching_parts.py
@@ -263,8 +263,6 @@ class TransformMatchingTex(TransformMatchingAbstractBase):
         key_map: dict | None = None,
         **kwargs,
     ):
-        assert hasattr(mobject, "tex_string")
-        assert hasattr(target_mobject, "tex_string")
         super().__init__(
             mobject,
             target_mobject,
@@ -276,7 +274,15 @@ class TransformMatchingTex(TransformMatchingAbstractBase):
 
     @staticmethod
     def get_mobject_parts(mobject: Mobject) -> list[Mobject]:
-        return mobject.submobjects
+        if isinstance(mobject, (Group, VGroup)):
+            return [
+                p
+                for s in mobject.submobjects
+                for p in TransformMatchingTex.get_mobject_parts(s)
+            ]
+        else:
+            assert hasattr(mobject, "tex_string")
+            return mobject.submobjects
 
     @staticmethod
     def get_mobject_key(mobject: Mobject) -> str:

--- a/manim/animation/transform_matching_parts.py
+++ b/manim/animation/transform_matching_parts.py
@@ -280,7 +280,7 @@ class TransformMatchingTex(TransformMatchingAbstractBase):
 
     @staticmethod
     def get_mobject_parts(mobject: Mobject) -> list[Mobject]:
-        if isinstance(mobject, (Group, VGroup)):
+        if isinstance(mobject, (Group, VGroup, OpenGLGroup, OpenGLVGroup)):
             return [
                 p
                 for s in mobject.submobjects

--- a/manim/animation/transform_matching_parts.py
+++ b/manim/animation/transform_matching_parts.py
@@ -245,11 +245,14 @@ class TransformMatchingTex(TransformMatchingAbstractBase):
 
         class MatchingEquationParts(Scene):
             def construct(self):
-                eq1 = MathTex("{{a^2}} + {{b^2}} = {{c^2}}")
-                eq2 = MathTex("{{a^2}} = {{c^2}} - {{b^2}}")
+                variables = VGroup(MathTex("a"), MathTex("b"), MathTex("c")).arrange_submobjects().shift(UP)
+
+                eq1 = MathTex("{{x}}^2 + {{y}}^2 = {{z}}^2")
+                eq2 = MathTex("{{a}}^2 + {{b}}^2 = {{c}}^2")
+
                 self.add(eq1)
                 self.wait(0.5)
-                self.play(TransformMatchingTex(eq1, eq2))
+                self.play(TransformMatchingTex(Group(eq1, variables), eq2))
                 self.wait(0.5)
 
     """


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
I was looking for an elegant way to update an equation, letting some variables “fly in” from elsewhere.
`TransformMatchingTex` is great, but it only supported one `MathTex`-like input and one output.

This PR adds support for `Group`s (and `VGroup`s) by accessing their individual `submobject`s. 
I made it recursive, so that nested groups are supported.
Mobjects that are neither groups, nor contain a `tex_string`, will still raise an Exception.

<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
https://manimce--2602.org.readthedocs.build/en/2602/reference/manim.animation.transform_matching_parts.TransformMatchingTex.html

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
