### PR TITLE
Reduced the number of warnings during documentation build

### DIFF
--- a/docs/source/changelog/0.10.0-changelog.rst
+++ b/docs/source/changelog/0.10.0-changelog.rst
@@ -76,207 +76,207 @@ A total of 59 pull requests were merged for this release.
 Breaking changes
 ----------------
 
-* `#1843 <https://github.com/ManimCommunity/manim/pull/1843>`__: Dropped redundant OpenGL files and add metaclass support for :class:`~.Surface`
+* :pr:`1843`: Dropped redundant OpenGL files and add metaclass support for :class:`~.Surface`
    - ``OpenGL<x>`` classes from ``opengl_geometry.py``, ``opengl_text_mobject.py``, ``opengl_tex_mobject.py``, ``opengl_svg_path.py``, ``opengl_svg_mobject.py`` and most of ``opengl_three_dimensions.py`` have been removed.
    - ``ParametricSurface`` has been renamed to :class:`~.Surface`
 
 Deprecated classes and functions
 --------------------------------
 
-* `#1941 <https://github.com/ManimCommunity/manim/pull/1941>`__: Added examples, tests and improved documentation for :mod:`~.coordinate_systems`
+* :pr:`1941`: Added examples, tests and improved documentation for :mod:`~.coordinate_systems`
 
 
-* `#1694 <https://github.com/ManimCommunity/manim/pull/1694>`__: Added ``font_size`` parameter for :class:`~.Tex` and :class:`~.Text`, replaced ``scale`` parameters with ``font_size``
+* :pr:`1694`: Added ``font_size`` parameter for :class:`~.Tex` and :class:`~.Text`, replaced ``scale`` parameters with ``font_size``
 
 
-* `#1860 <https://github.com/ManimCommunity/manim/pull/1860>`__: Removed :class:`~.GraphScene`, :class:`~.NumberLineOld` and parameters for :class:`~.ChangingDecimal`
+* :pr:`1860`: Removed :class:`~.GraphScene`, :class:`~.NumberLineOld` and parameters for :class:`~.ChangingDecimal`
 
 
 New features
 ------------
 
-* `#1929 <https://github.com/ManimCommunity/manim/pull/1929>`__: Implementing a ``zoom`` parameter for :meth:`.ThreeDScene.move_camera`
+* :pr:`1929`: Implementing a ``zoom`` parameter for :meth:`.ThreeDScene.move_camera`
    Zooming into a :class:`~.ThreeDScene` can now be done by calling, for example, ``self.move_camera(zoom=2)`` in the ``construct`` method.
 
-* `#1980 <https://github.com/ManimCommunity/manim/pull/1980>`__: Added a ``dissipating_time`` keyword argument to :class:`~.TracedPath` to allow animating a dissipating path
+* :pr:`1980`: Added a ``dissipating_time`` keyword argument to :class:`~.TracedPath` to allow animating a dissipating path
 
 
-* `#1899 <https://github.com/ManimCommunity/manim/pull/1899>`__: Allow switching the renderer to OpenGL at runtime
+* :pr:`1899`: Allow switching the renderer to OpenGL at runtime
    Previously, the metaclass approach only changed the inheritance chain to switch between OpenGL and cairo mobjects when the class objects are initialized, i.e., at import time. This PR also triggers the changes to the inheritance chain when the value of ``config.renderer`` is changed.
 
-* `#1828 <https://github.com/ManimCommunity/manim/pull/1828>`__: Added configuration option ``zero_pad`` for zero padding PNG file names
+* :pr:`1828`: Added configuration option ``zero_pad`` for zero padding PNG file names
 
 
 Enhancements
 ------------
 
-* `#1882 <https://github.com/ManimCommunity/manim/pull/1882>`__: Added OpenGL support for :class:`~.PMobject` and its subclasses
+* :pr:`1882`: Added OpenGL support for :class:`~.PMobject` and its subclasses
 
 
-* `#1881 <https://github.com/ManimCommunity/manim/pull/1881>`__: Added methods :meth:`.Angle.get_lines` and :meth:`.Angle.get_value` to :class:`~.Angle`
+* :pr:`1881`: Added methods :meth:`.Angle.get_lines` and :meth:`.Angle.get_value` to :class:`~.Angle`
 
 
-* `#1952 <https://github.com/ManimCommunity/manim/pull/1952>`__: Added the option to save last frame for OpenGL
+* :pr:`1952`: Added the option to save last frame for OpenGL
 
 
-* `#1922 <https://github.com/ManimCommunity/manim/pull/1922>`__: Fixed IPython interface to exit cleanly when OpenGL renderer raises an error
+* :pr:`1922`: Fixed IPython interface to exit cleanly when OpenGL renderer raises an error
 
 
-* `#1923 <https://github.com/ManimCommunity/manim/pull/1923>`__: Fixed CLI help text for ``manim init`` subcommand so that it is not truncated
+* :pr:`1923`: Fixed CLI help text for ``manim init`` subcommand so that it is not truncated
 
 
-* `#1868 <https://github.com/ManimCommunity/manim/pull/1868>`__: Added OpenGL support to IPython magic
+* :pr:`1868`: Added OpenGL support to IPython magic
    The OpenGL renderer can now be used in jupyter notebooks when using the ``%%manim`` magic command.
 
-* `#1841 <https://github.com/ManimCommunity/manim/pull/1841>`__: Reduced default resolution of :class:`~.Dot3D`
+* :pr:`1841`: Reduced default resolution of :class:`~.Dot3D`
 
 
-* `#1866 <https://github.com/ManimCommunity/manim/pull/1866>`__: Allow passing keyword argument ``corner_radius`` to :class:`~.SurroundingRectangle`
+* :pr:`1866`: Allow passing keyword argument ``corner_radius`` to :class:`~.SurroundingRectangle`
 
 
-* `#1847 <https://github.com/ManimCommunity/manim/pull/1847>`__: Allow :class:`~.Cross` to be created without requiring a mobject
+* :pr:`1847`: Allow :class:`~.Cross` to be created without requiring a mobject
 
 
 Fixed bugs
 ----------
 
-* `#1985 <https://github.com/ManimCommunity/manim/pull/1985>`__: Use ``height`` to determine ``font_size`` instead of the ``_font_size`` attribute
+* :pr:`1985`: Use ``height`` to determine ``font_size`` instead of the ``_font_size`` attribute
 
 
-* `#1758 <https://github.com/ManimCommunity/manim/pull/1758>`__: Fixed scene selection being ignored when using the OpenGL renderer
+* :pr:`1758`: Fixed scene selection being ignored when using the OpenGL renderer
 
 
-* `#1871 <https://github.com/ManimCommunity/manim/pull/1871>`__: Fixed broken :meth:`.VectorScene.vector_to_coords`
+* :pr:`1871`: Fixed broken :meth:`.VectorScene.vector_to_coords`
 
 
-* `#1973 <https://github.com/ManimCommunity/manim/pull/1973>`__: Fixed indexing of :meth:`.Table.get_entries` to respect row length
+* :pr:`1973`: Fixed indexing of :meth:`.Table.get_entries` to respect row length
 
 
-* `#1950 <https://github.com/ManimCommunity/manim/pull/1950>`__: Fixed passing custom arrow shapes to :class:`~.CurvedArrow`
+* :pr:`1950`: Fixed passing custom arrow shapes to :class:`~.CurvedArrow`
 
 
-* `#1967 <https://github.com/ManimCommunity/manim/pull/1967>`__: Fixed :attr:`.Axes.coordinate_labels` referring to the entire axis, not just its labels
+* :pr:`1967`: Fixed :attr:`.Axes.coordinate_labels` referring to the entire axis, not just its labels
 
 
-* `#1951 <https://github.com/ManimCommunity/manim/pull/1951>`__: Fixed :meth:`.Axes.get_line_graph` returning a graph rendered below the axes
+* :pr:`1951`: Fixed :meth:`.Axes.get_line_graph` returning a graph rendered below the axes
 
 
-* `#1943 <https://github.com/ManimCommunity/manim/pull/1943>`__: Added ``buff`` keyword argument to :class:`~.BraceLabel`
+* :pr:`1943`: Added ``buff`` keyword argument to :class:`~.BraceLabel`
 
 
-* `#1938 <https://github.com/ManimCommunity/manim/pull/1938>`__: Fixed :class:`~.Rotate` for angles that are multiples of :math:`2\pi`
+* :pr:`1938`: Fixed :class:`~.Rotate` for angles that are multiples of :math:`2\pi`
 
 
-* `#1924 <https://github.com/ManimCommunity/manim/pull/1924>`__: Made arrow tips rotate ``IN`` and ``OUT`` properly
+* :pr:`1924`: Made arrow tips rotate ``IN`` and ``OUT`` properly
 
 
-* `#1931 <https://github.com/ManimCommunity/manim/pull/1931>`__: Fixed ``row_heights`` in :meth:`.Mobject.arrange_in_grid`
+* :pr:`1931`: Fixed ``row_heights`` in :meth:`.Mobject.arrange_in_grid`
 
 
-* `#1893 <https://github.com/ManimCommunity/manim/pull/1893>`__: Fixed CLI error when rendering a file containing a single scene without specifying the scene name
+* :pr:`1893`: Fixed CLI error when rendering a file containing a single scene without specifying the scene name
 
 
-* `#1744 <https://github.com/ManimCommunity/manim/pull/1744>`__: Fixed bug in :class:`~.NumberPlane` with strictly positive or strictly negative values for ``x_range`` and ``y_range``
+* :pr:`1744`: Fixed bug in :class:`~.NumberPlane` with strictly positive or strictly negative values for ``x_range`` and ``y_range``
 
 
-* `#1887 <https://github.com/ManimCommunity/manim/pull/1887>`__: Fixed ``custom_config`` not working in ``frames_comparison``
+* :pr:`1887`: Fixed ``custom_config`` not working in ``frames_comparison``
 
 
-* `#1879 <https://github.com/ManimCommunity/manim/pull/1879>`__: Fixed how the installed version is determined by Poetry
+* :pr:`1879`: Fixed how the installed version is determined by Poetry
 
 
 Documentation-related changes
 -----------------------------
 
-* `#1979 <https://github.com/ManimCommunity/manim/pull/1979>`__: Corrected Japanese phrases in documentation
+* :pr:`1979`: Corrected Japanese phrases in documentation
 
 
-* `#1976 <https://github.com/ManimCommunity/manim/pull/1976>`__: Fixed labelling of languages in documentation example
+* :pr:`1976`: Fixed labelling of languages in documentation example
 
 
-* `#1949 <https://github.com/ManimCommunity/manim/pull/1949>`__: Rewrite installation instructions from scratch
+* :pr:`1949`: Rewrite installation instructions from scratch
 
 
-* `#1963 <https://github.com/ManimCommunity/manim/pull/1963>`__: Added sitemap to ``robots.txt``
+* :pr:`1963`: Added sitemap to ``robots.txt``
 
 
-* `#1939 <https://github.com/ManimCommunity/manim/pull/1939>`__: Fixed formatting of parameter description of :class:`~.NumberPlane`
+* :pr:`1939`: Fixed formatting of parameter description of :class:`~.NumberPlane`
 
 
-* `#1918 <https://github.com/ManimCommunity/manim/pull/1918>`__: Fixed a typo in the text tutorial
+* :pr:`1918`: Fixed a typo in the text tutorial
 
 
-* `#1915 <https://github.com/ManimCommunity/manim/pull/1915>`__: Improved the wording of the installation instructions for Google Colab
+* :pr:`1915`: Improved the wording of the installation instructions for Google Colab
 
 
-* `#1906 <https://github.com/ManimCommunity/manim/pull/1906>`__: Improved language and overall consistency in ``README``
+* :pr:`1906`: Improved language and overall consistency in ``README``
 
 
-* `#1880 <https://github.com/ManimCommunity/manim/pull/1880>`__: Updated tutorials to use ``.animate`` instead of :class:`~.ApplyMethod`
+* :pr:`1880`: Updated tutorials to use ``.animate`` instead of :class:`~.ApplyMethod`
 
 
-* `#1877 <https://github.com/ManimCommunity/manim/pull/1877>`__: Remove duplicated imports in some documentation examples
+* :pr:`1877`: Remove duplicated imports in some documentation examples
 
 
-* `#1869 <https://github.com/ManimCommunity/manim/pull/1869>`__: Fixed duplicated Parameters section in  :meth:`.Mobject.arrange_in_grid`
+* :pr:`1869`: Fixed duplicated Parameters section in  :meth:`.Mobject.arrange_in_grid`
 
 
 Changes concerning the testing system
 -------------------------------------
 
-* `#1894 <https://github.com/ManimCommunity/manim/pull/1894>`__: Fixed an OpenGL test
+* :pr:`1894`: Fixed an OpenGL test
 
 
 Changes to our development infrastructure
 -----------------------------------------
 
-* `#1987 <https://github.com/ManimCommunity/manim/pull/1987>`__: Added support for using OpenGL in subprocess in Windows pipeline
+* :pr:`1987`: Added support for using OpenGL in subprocess in Windows pipeline
 
 
-* `#1964 <https://github.com/ManimCommunity/manim/pull/1964>`__: Added ``CITATION.cff`` and a method to automatically update this citation with new releases
+* :pr:`1964`: Added ``CITATION.cff`` and a method to automatically update this citation with new releases
 
 
-* `#1856 <https://github.com/ManimCommunity/manim/pull/1856>`__: Modified Dockerfile to support multi-platform builds via ``docker buildx``
+* :pr:`1856`: Modified Dockerfile to support multi-platform builds via ``docker buildx``
 
 
-* `#1955 <https://github.com/ManimCommunity/manim/pull/1955>`__: Partially support OpenGL rendering with Docker
+* :pr:`1955`: Partially support OpenGL rendering with Docker
 
 
-* `#1896 <https://github.com/ManimCommunity/manim/pull/1896>`__: Made RTD apt install FFMPEG instead of installing a Python binding
+* :pr:`1896`: Made RTD apt install FFMPEG instead of installing a Python binding
 
 
-* `#1864 <https://github.com/ManimCommunity/manim/pull/1864>`__: Shortened and simplified PR template
+* :pr:`1864`: Shortened and simplified PR template
 
 
-* `#1853 <https://github.com/ManimCommunity/manim/pull/1853>`__: Updated Sphinx to 4.1.2
+* :pr:`1853`: Updated Sphinx to 4.1.2
 
 
 Code quality improvements and similar refactors
 -----------------------------------------------
 
-* `#1960 <https://github.com/ManimCommunity/manim/pull/1960>`__: Ignore fewer flake8 errors
+* :pr:`1960`: Ignore fewer flake8 errors
 
 
-* `#1947 <https://github.com/ManimCommunity/manim/pull/1947>`__: Set flake8 not to ignore undefined names in Python code
+* :pr:`1947`: Set flake8 not to ignore undefined names in Python code
 
 
-* `#1948 <https://github.com/ManimCommunity/manim/pull/1948>`__: flake8: Set max-line-length instead of ignoring long lines
+* :pr:`1948`: flake8: Set max-line-length instead of ignoring long lines
 
 
-* `#1956 <https://github.com/ManimCommunity/manim/pull/1956>`__:  Upgrade to modern Python syntax
+* :pr:`1956`:  Upgrade to modern Python syntax
    - This pull request was created `with the command <https://github.com/asottile/pyupgrade#readme>`__ ``pyupgrade --py36-plus **/*.py``
    - Python f-strings simplify the code and `should speed up execution <https://www.scivision.dev/python-f-string-speed>`__.
 
-* `#1898 <https://github.com/ManimCommunity/manim/pull/1898>`__: Replaced ``self.data["attr"]`` and ``self.uniforms["attr"]`` with ``self.attr``
+* :pr:`1898`: Replaced ``self.data["attr"]`` and ``self.uniforms["attr"]`` with ``self.attr``
    In particular, ``OpenGLVMobject.points`` can now be accessed directly.
 
-* `#1934 <https://github.com/ManimCommunity/manim/pull/1934>`__: Improved code quality by implementing suggestions from LGTM
+* :pr:`1934`: Improved code quality by implementing suggestions from LGTM
 
 
-* `#1861 <https://github.com/ManimCommunity/manim/pull/1861>`__: Updated ``dearpygui`` version to 0.8.x
+* :pr:`1861`: Updated ``dearpygui`` version to 0.8.x
 
 
 New releases
 ------------
 
-* `#1989 <https://github.com/ManimCommunity/manim/pull/1989>`__: Prepare new release v0.10.0
+* :pr:`1989`: Prepare new release v0.10.0

--- a/docs/source/changelog/0.11.0-changelog.rst
+++ b/docs/source/changelog/0.11.0-changelog.rst
@@ -67,197 +67,197 @@ A total of 55 pull requests were merged for this release.
 Breaking changes
 ----------------
 
-* `#1990 <https://github.com/ManimCommunity/manim/pull/1990>`__: Changed and improved the implementation of :meth:`.CoordinateSystem.get_area` to work without Riemann rectangles
+* :pr:`1990`: Changed and improved the implementation of :meth:`.CoordinateSystem.get_area` to work without Riemann rectangles
    This changes how :meth:`.CoordinateSystem.get_area` is implemented. To mimic the old behavior (tiny Riemann rectangles), use :meth:`.CoordinateSystem.get_riemann_rectangles` with a small value for ``dx``.
 
-* `#2095 <https://github.com/ManimCommunity/manim/pull/2095>`__: Changed angles for polar coordinates to use math convention
+* :pr:`2095`: Changed angles for polar coordinates to use math convention
    This PR switches the parameter names ``phi`` and ``theta`` in :func:`cartesian_to_spherical` and :func:`spherical_to_cartesian` to align with the `usual definition in mathematics <https://user-images.githubusercontent.com/83535735/131709630-87290522-7747-4b21-9411-dd3d35ebaf0f.png>`__.
 
 Highlights
 ----------
 
-* `#2094 <https://github.com/ManimCommunity/manim/pull/2094>`__: Implemented :class:`~.ImplicitFunction` and :meth:`.CoordinateSystem.get_implicit_curve` for plotting implicit curves
+* :pr:`2094`: Implemented :class:`~.ImplicitFunction` and :meth:`.CoordinateSystem.get_implicit_curve` for plotting implicit curves
    An :class:`~.ImplicitFunction` that plots the points :math:`(x, y)` which satisfy some equation :math:`f(x,y) = 0`.
 
-* `#2075 <https://github.com/ManimCommunity/manim/pull/2075>`__: Implemented :meth:`.Mobject.set_default`, a mechanism for changing default values of keyword arguments
+* :pr:`2075`: Implemented :meth:`.Mobject.set_default`, a mechanism for changing default values of keyword arguments
 
 
-* `#1998 <https://github.com/ManimCommunity/manim/pull/1998>`__: Added support for Boolean Operations on VMobjects
+* :pr:`1998`: Added support for Boolean Operations on VMobjects
    This PR introduces boolean operations for :class:`~.VMobject`; see details and examples at
    :class:`~.Union`, :class:`~.Difference`, :class:`~.Intersection` and :class:`~.Exclusion`.
 
 Deprecated classes and functions
 --------------------------------
 
-* `#2123 <https://github.com/ManimCommunity/manim/pull/2123>`__: Renamed ``distance`` parameter of :class:`.ThreeDScene` and :class:`.ThreeDCamera` to ``focal_distance``
+* :pr:`2123`: Renamed ``distance`` parameter of :class:`.ThreeDScene` and :class:`.ThreeDCamera` to ``focal_distance``
 
 
-* `#2102 <https://github.com/ManimCommunity/manim/pull/2102>`__: Deprecated :class:`~.SampleSpaceScene` and :class:`~.ReconfigurableScene`
+* :pr:`2102`: Deprecated :class:`~.SampleSpaceScene` and :class:`~.ReconfigurableScene`
 
 
-* `#2061 <https://github.com/ManimCommunity/manim/pull/2061>`__: Removed deprecated ``u_min``, ``u_max``, ``v_min``, ``v_max`` in :class:`~.Surface`
+* :pr:`2061`: Removed deprecated ``u_min``, ``u_max``, ``v_min``, ``v_max`` in :class:`~.Surface`
 
 
-* `#2024 <https://github.com/ManimCommunity/manim/pull/2024>`__: Deprecated redundant methods :meth:`.Mobject.rotate_in_place`, :meth:`.Mobject.scale_in_place`, :meth:`.Mobject.scale_about_point`
+* :pr:`2024`: Deprecated redundant methods :meth:`.Mobject.rotate_in_place`, :meth:`.Mobject.scale_in_place`, :meth:`.Mobject.scale_about_point`
 
 
-* `#1991 <https://github.com/ManimCommunity/manim/pull/1991>`__: Deprecated :meth:`.VMobject.get_points`
+* :pr:`1991`: Deprecated :meth:`.VMobject.get_points`
 
 
 New features
 ------------
 
-* `#2118 <https://github.com/ManimCommunity/manim/pull/2118>`__: Added 3D support for :class:`~.ArrowVectorField` and :class:`~.StreamLines`
+* :pr:`2118`: Added 3D support for :class:`~.ArrowVectorField` and :class:`~.StreamLines`
 
 
-* `#1469 <https://github.com/ManimCommunity/manim/pull/1469>`__: Added :meth:`.VMobject.proportion_from_point` to measure the proportion of points along a Bezier curve
+* :pr:`1469`: Added :meth:`.VMobject.proportion_from_point` to measure the proportion of points along a Bezier curve
 
 
 Enhancements
 ------------
 
-* `#2111 <https://github.com/ManimCommunity/manim/pull/2111>`__: Improved setting of OpenGL colors
+* :pr:`2111`: Improved setting of OpenGL colors
 
 
-* `#2113 <https://github.com/ManimCommunity/manim/pull/2113>`__: Added OpenGL compatibility to :meth:`.ThreeDScene.begin_ambient_camera_rotation` and :meth:`.ThreeDScene.move_camera`
+* :pr:`2113`: Added OpenGL compatibility to :meth:`.ThreeDScene.begin_ambient_camera_rotation` and :meth:`.ThreeDScene.move_camera`
 
 
-* `#2016 <https://github.com/ManimCommunity/manim/pull/2016>`__: Added OpenGL support for :mod:`~.mobject.boolean_ops`
+* :pr:`2016`: Added OpenGL support for :mod:`~.mobject.boolean_ops`
 
 
-* `#2084 <https://github.com/ManimCommunity/manim/pull/2084>`__: Added :meth:`~Table.get_highlighted_cell` and fixed :meth:`~Table.add_highlighted_cell`
+* :pr:`2084`: Added :meth:`~Table.get_highlighted_cell` and fixed :meth:`~Table.add_highlighted_cell`
 
 
-* `#2013 <https://github.com/ManimCommunity/manim/pull/2013>`__: Removed unnecessary check in :class:`~.TransformMatchingAbstractBase`
+* :pr:`2013`: Removed unnecessary check in :class:`~.TransformMatchingAbstractBase`
 
 
-* `#1971 <https://github.com/ManimCommunity/manim/pull/1971>`__: Added OpenGL support for :class:`~.StreamLines`
+* :pr:`1971`: Added OpenGL support for :class:`~.StreamLines`
 
 
-* `#2041 <https://github.com/ManimCommunity/manim/pull/2041>`__: Added config option to enable OpenGL wireframe for debugging
+* :pr:`2041`: Added config option to enable OpenGL wireframe for debugging
 
 
 Fixed bugs
 ----------
 
-* `#2070 <https://github.com/ManimCommunity/manim/pull/2070>`__: Fixed :meth:`~OpenGLRenderer.get_frame` when window is created
+* :pr:`2070`: Fixed :meth:`~OpenGLRenderer.get_frame` when window is created
 
 
-* `#2071 <https://github.com/ManimCommunity/manim/pull/2071>`__: Fixed :class:`~AnimationGroup` OpenGL compatibility
+* :pr:`2071`: Fixed :class:`~AnimationGroup` OpenGL compatibility
 
 
-* `#2108 <https://github.com/ManimCommunity/manim/pull/2108>`__: Fixed swapped axis step values in :class:`~.NumberPlane`
+* :pr:`2108`: Fixed swapped axis step values in :class:`~.NumberPlane`
 
 
-* `#2072 <https://github.com/ManimCommunity/manim/pull/2072>`__: Added OpenGL compatibility for :class:`~.Cube`.
+* :pr:`2072`: Added OpenGL compatibility for :class:`~.Cube`.
 
 
-* `#2060 <https://github.com/ManimCommunity/manim/pull/2060>`__: Fixed OpenGL compatibility issue for meth:`~Line.set_opacity`
+* :pr:`2060`: Fixed OpenGL compatibility issue for meth:`~Line.set_opacity`
 
 
-* `#2037 <https://github.com/ManimCommunity/manim/pull/2037>`__: Fixed return value of :meth:`~.OpenGLMobject.apply_complex_function`
+* :pr:`2037`: Fixed return value of :meth:`~.OpenGLMobject.apply_complex_function`
 
 
-* `#2039 <https://github.com/ManimCommunity/manim/pull/2039>`__: Added OpenGL compatibility for :meth:`~Cylinder.add_bases`.
+* :pr:`2039`: Added OpenGL compatibility for :meth:`~Cylinder.add_bases`.
 
 
-* `#2066 <https://github.com/ManimCommunity/manim/pull/2066>`__: Fixed error raised by logging when cache is full
+* :pr:`2066`: Fixed error raised by logging when cache is full
 
 
-* `#2026 <https://github.com/ManimCommunity/manim/pull/2026>`__: Fixed OpenGL shift animation for :class:`~.Text`
+* :pr:`2026`: Fixed OpenGL shift animation for :class:`~.Text`
 
 
-* `#2028 <https://github.com/ManimCommunity/manim/pull/2028>`__: Fixed OpenGL overriding SVG fill color
+* :pr:`2028`: Fixed OpenGL overriding SVG fill color
 
 
-* `#2043 <https://github.com/ManimCommunity/manim/pull/2043>`__: Fixed bug where :meth:`.NumberLine.add_labels`  cannot accept non-mobject labels
+* :pr:`2043`: Fixed bug where :meth:`.NumberLine.add_labels`  cannot accept non-mobject labels
 
 
-* `#2011 <https://github.com/ManimCommunity/manim/pull/2011>`__: Fixed ``-a`` flag for OpenGL rendering
+* :pr:`2011`: Fixed ``-a`` flag for OpenGL rendering
 
 
-* `#1994 <https://github.com/ManimCommunity/manim/pull/1994>`__: Fix :meth:`~.input_to_graph_point` when passing a line graph (from :meth:`.Axes.get_line_graph`)
+* :pr:`1994`: Fix :meth:`~.input_to_graph_point` when passing a line graph (from :meth:`.Axes.get_line_graph`)
 
 
-* `#2017 <https://github.com/ManimCommunity/manim/pull/2017>`__: Avoided using deprecated ``get_points`` method and fixed :class:`~.OpenGLPMPoint` color
+* :pr:`2017`: Avoided using deprecated ``get_points`` method and fixed :class:`~.OpenGLPMPoint` color
 
 
 Documentation-related changes
 -----------------------------
 
-* `#2131 <https://github.com/ManimCommunity/manim/pull/2131>`__: Copyedited the configuration tutorial in the documentation
+* :pr:`2131`: Copyedited the configuration tutorial in the documentation
 
 
-* `#2120 <https://github.com/ManimCommunity/manim/pull/2120>`__: Changed ``manim_directive`` to use a clean configuration via ``tempconfig``
+* :pr:`2120`: Changed ``manim_directive`` to use a clean configuration via ``tempconfig``
 
 
-* `#2122 <https://github.com/ManimCommunity/manim/pull/2122>`__: Fixed broken links in inheritance graphs by moving them to ``reference.rst``
+* :pr:`2122`: Fixed broken links in inheritance graphs by moving them to ``reference.rst``
 
 
-* `#2115 <https://github.com/ManimCommunity/manim/pull/2115>`__: Improved docstring of :meth:`.PMobject.add_points`
+* :pr:`2115`: Improved docstring of :meth:`.PMobject.add_points`
 
 
-* `#2116 <https://github.com/ManimCommunity/manim/pull/2116>`__: Made type hint for ``line_spacing`` argument of :class:`~.Paragraph` more accurate
+* :pr:`2116`: Made type hint for ``line_spacing`` argument of :class:`~.Paragraph` more accurate
 
 
-* `#2117 <https://github.com/ManimCommunity/manim/pull/2117>`__: Changed the way the background color was set in a documentation example to avoid leaking the setting to other examples
+* :pr:`2117`: Changed the way the background color was set in a documentation example to avoid leaking the setting to other examples
 
 
-* `#2101 <https://github.com/ManimCommunity/manim/pull/2101>`__: Added note that translation process is not ready
+* :pr:`2101`: Added note that translation process is not ready
 
 
-* `#2055 <https://github.com/ManimCommunity/manim/pull/2055>`__: Fixed parameter types of :meth:`.Graph.add_edges` and :meth:`.Graph.add_vertices`
+* :pr:`2055`: Fixed parameter types of :meth:`.Graph.add_edges` and :meth:`.Graph.add_vertices`
 
 
-* `#862 <https://github.com/ManimCommunity/manim/pull/862>`__: Prepared documentation for translation (still work in progress)
+* :pr:`862`: Prepared documentation for translation (still work in progress)
 
 
-* `#2035 <https://github.com/ManimCommunity/manim/pull/2035>`__: Fixed broken link in README
+* :pr:`2035`: Fixed broken link in README
 
 
-* `#2020 <https://github.com/ManimCommunity/manim/pull/2020>`__:  Corrected paths to user-wide configuration files for MacOS and Linux
+* :pr:`2020`:  Corrected paths to user-wide configuration files for MacOS and Linux
 
 
 Changes concerning the testing system
 -------------------------------------
 
-* `#2008 <https://github.com/ManimCommunity/manim/pull/2008>`__: Reuse CLI flag tests for OpenGL
+* :pr:`2008`: Reuse CLI flag tests for OpenGL
 
 
-* `#2080 <https://github.com/ManimCommunity/manim/pull/2080>`__: Reused :class:`~.Mobject` tests for :class:`~.OpenGLMobject`
+* :pr:`2080`: Reused :class:`~.Mobject` tests for :class:`~.OpenGLMobject`
 
 
 Changes to our development infrastructure
 -----------------------------------------
 
-* `#2004 <https://github.com/ManimCommunity/manim/pull/2004>`__: Cancel previous workflows in the same branch in Github Actions
+* :pr:`2004`: Cancel previous workflows in the same branch in Github Actions
 
 
 Code quality improvements and similar refactors
 -----------------------------------------------
 
-* `#2050 <https://github.com/ManimCommunity/manim/pull/2050>`__: Make colour aliases IDE-friendly
+* :pr:`2050`: Make colour aliases IDE-friendly
 
 
-* `#2126 <https://github.com/ManimCommunity/manim/pull/2126>`__: Fixed whitespace in info message issued by :meth:`.SceneFileWriter.clean_cache`
+* :pr:`2126`: Fixed whitespace in info message issued by :meth:`.SceneFileWriter.clean_cache`
 
 
-* `#2124 <https://github.com/ManimCommunity/manim/pull/2124>`__: Upgraded several dependencies (in particular: ``skia-pathops``)
+* :pr:`2124`: Upgraded several dependencies (in particular: ``skia-pathops``)
 
 
-* `#2001 <https://github.com/ManimCommunity/manim/pull/2001>`__: Fixed several warnings issued by LGTM
+* :pr:`2001`: Fixed several warnings issued by LGTM
 
 
-* `#2064 <https://github.com/ManimCommunity/manim/pull/2064>`__: Removed duplicate insert shader directory
+* :pr:`2064`: Removed duplicate insert shader directory
 
 
-* `#2027 <https://github.com/ManimCommunity/manim/pull/2027>`__: Improved wording in info message issued by :meth:`.SceneFileWriter.clean_cache`
+* :pr:`2027`: Improved wording in info message issued by :meth:`.SceneFileWriter.clean_cache`
 
 
-* `#1968 <https://github.com/ManimCommunity/manim/pull/1968>`__: Sharpened Flake8 configuration and fixed resulting warnings
+* :pr:`1968`: Sharpened Flake8 configuration and fixed resulting warnings
 
 
 New releases
 ------------
 
-* `#2114 <https://github.com/ManimCommunity/manim/pull/2114>`__: Prepared new release, ``v0.11.0``
+* :pr:`2114`: Prepared new release, ``v0.11.0``

--- a/docs/source/changelog/0.12.0-changelog.rst
+++ b/docs/source/changelog/0.12.0-changelog.rst
@@ -73,12 +73,12 @@ A total of 52 pull requests were merged for this release.
 Highlights
 ----------
 
-* `#1812 <https://github.com/ManimCommunity/manim/pull/1812>`__: Implemented logarithmic scaling for :class:`~.NumberLine` / :class:`~.Axes`
+* :pr:`1812`: Implemented logarithmic scaling for :class:`~.NumberLine` / :class:`~.Axes`
    This implements scaling bases that can be passed to the ``scaling`` keyword
    argument of :class:`.NumberLine`. See :class:`.LogBase` (for a logarithmic scale) and
    :class:`.LinearBase` (for the default scale) for more details and examples.
 
-* `#2152 <https://github.com/ManimCommunity/manim/pull/2152>`__: Introduced API for scene sections via :meth:`.Scene.next_section`
+* :pr:`2152`: Introduced API for scene sections via :meth:`.Scene.next_section`
    Sections divide a scene into multiple parts, resulting in multiple output videos (when using the ``--save_sections`` flag).
    The cuts between two sections are defined by the user in the :meth:`~.Scene.construct` method.
    Each section has an optional name and type, which can be used by a plugin (`see an example <https://github.com/ManimEditorProject/manim_editor>`__).
@@ -87,179 +87,179 @@ Highlights
 Deprecated classes and functions
 --------------------------------
 
-* `#1926 <https://github.com/ManimCommunity/manim/pull/1926>`__: OpenGL: changed ``submobjects`` to be a property
+* :pr:`1926`: OpenGL: changed ``submobjects`` to be a property
 
 
-* `#2245 <https://github.com/ManimCommunity/manim/pull/2245>`__: Removed deprecated method ``get_center_point`` and parameters ``azimuth_label_scale``, ``number_scale_value``, ``label_scale``, ``scale_factor``, ``size``, ``x_min``, ``x_max``, ``delta_x``, ``y_min``, ``y_max``, ``delta_y``
+* :pr:`2245`: Removed deprecated method ``get_center_point`` and parameters ``azimuth_label_scale``, ``number_scale_value``, ``label_scale``, ``scale_factor``, ``size``, ``x_min``, ``x_max``, ``delta_x``, ``y_min``, ``y_max``, ``delta_y``
 
 
-* `#2187 <https://github.com/ManimCommunity/manim/pull/2187>`__: Renamed ``get_graph`` and its variants to :meth:`~.CoordinateSystem.plot`
+* :pr:`2187`: Renamed ``get_graph`` and its variants to :meth:`~.CoordinateSystem.plot`
 
 
-* `#2065 <https://github.com/ManimCommunity/manim/pull/2065>`__: Deprecated :class:`~.FullScreenFadeRectangle` and :class:`~.PictureInPictureFrame`
+* :pr:`2065`: Deprecated :class:`~.FullScreenFadeRectangle` and :class:`~.PictureInPictureFrame`
 
 
 New features
 ------------
 
-* `#2025 <https://github.com/ManimCommunity/manim/pull/2025>`__: Implemented :meth:`.CoordinateSystem.input_to_graph_coords` and fixed :meth:`.CoordinateSystem.angle_of_tangent`
+* :pr:`2025`: Implemented :meth:`.CoordinateSystem.input_to_graph_coords` and fixed :meth:`.CoordinateSystem.angle_of_tangent`
 
 
-* `#2151 <https://github.com/ManimCommunity/manim/pull/2151>`__: Added option to set the input file from a config file
+* :pr:`2151`: Added option to set the input file from a config file
 
 
-* `#2128 <https://github.com/ManimCommunity/manim/pull/2128>`__: Added keyword arguments ``match_center``, ``match_width`` etc. to :meth:`.Mobject.become`
+* :pr:`2128`: Added keyword arguments ``match_center``, ``match_width`` etc. to :meth:`.Mobject.become`
 
 
-* `#2162 <https://github.com/ManimCommunity/manim/pull/2162>`__: Implemented :meth:`.MovingCamera.auto_zoom` for automatically zooming onto specified mobjects
+* :pr:`2162`: Implemented :meth:`.MovingCamera.auto_zoom` for automatically zooming onto specified mobjects
 
 
-* `#2236 <https://github.com/ManimCommunity/manim/pull/2236>`__: Added ``skip_animations`` argument to :meth:`.Scene.next_section`
+* :pr:`2236`: Added ``skip_animations`` argument to :meth:`.Scene.next_section`
 
 
-* `#2196 <https://github.com/ManimCommunity/manim/pull/2196>`__: Implemented :meth:`.Line3D.parallel_to` and :meth:`.Line3D.perpendicular_to`
+* :pr:`2196`: Implemented :meth:`.Line3D.parallel_to` and :meth:`.Line3D.perpendicular_to`
 
 
 Enhancements
 ------------
 
-* `#2138 <https://github.com/ManimCommunity/manim/pull/2138>`__: Fixed example for :meth:`~.Vector.coordinate_label` and added more customization for :class:`~.Matrix`
+* :pr:`2138`: Fixed example for :meth:`~.Vector.coordinate_label` and added more customization for :class:`~.Matrix`
    - Additional keyword arguments for :meth:`~.Vector.coordinate_label` are passed to the constructed matrix.
    - :class:`~.Matrix` now accepts a ``bracket_config`` keyword argument.
 
-* `#2139 <https://github.com/ManimCommunity/manim/pull/2139>`__: Changed the color of :class:`~.NumberLine` from ``LIGHT_GREY`` to ``WHITE``
+* :pr:`2139`: Changed the color of :class:`~.NumberLine` from ``LIGHT_GREY`` to ``WHITE``
 
 
-* `#2157 <https://github.com/ManimCommunity/manim/pull/2157>`__: Added :meth:`.CoordinateSystem.plot_polar_graph`
+* :pr:`2157`: Added :meth:`.CoordinateSystem.plot_polar_graph`
 
 
-* `#2243 <https://github.com/ManimCommunity/manim/pull/2243>`__: Fixed wasteful recursion in :meth:`.Mobject.get_merged_array`
+* :pr:`2243`: Fixed wasteful recursion in :meth:`.Mobject.get_merged_array`
 
 
-* `#2205 <https://github.com/ManimCommunity/manim/pull/2205>`__: Improved last frame output handling for the OpenGL renderer
+* :pr:`2205`: Improved last frame output handling for the OpenGL renderer
 
 
-* `#2172 <https://github.com/ManimCommunity/manim/pull/2172>`__: Added ``should_render`` attribute to disable rendering mobjects
+* :pr:`2172`: Added ``should_render`` attribute to disable rendering mobjects
 
 
-* `#2182 <https://github.com/ManimCommunity/manim/pull/2182>`__: Changed the default width of videos in Jupyter notebooks to 60%
+* :pr:`2182`: Changed the default width of videos in Jupyter notebooks to 60%
 
 
 Fixed bugs
 ----------
 
-* `#2244 <https://github.com/ManimCommunity/manim/pull/2244>`__: Fixed :meth:`.CoordinateSystem.get_area` when using few plot points and a boundary graph
+* :pr:`2244`: Fixed :meth:`.CoordinateSystem.get_area` when using few plot points and a boundary graph
 
 
-* `#2232 <https://github.com/ManimCommunity/manim/pull/2232>`__: Fixed :class:`.Graph` stopping to update after animating additions/deletions of vertices or edges
+* :pr:`2232`: Fixed :class:`.Graph` stopping to update after animating additions/deletions of vertices or edges
 
 
-* `#2142 <https://github.com/ManimCommunity/manim/pull/2142>`__: Fixed issue with duplicates in OpenGL family and added tests
+* :pr:`2142`: Fixed issue with duplicates in OpenGL family and added tests
 
 
-* `#2168 <https://github.com/ManimCommunity/manim/pull/2168>`__: Fixed order of return values of :func:`.space_ops.cartesian_to_spherical`
+* :pr:`2168`: Fixed order of return values of :func:`.space_ops.cartesian_to_spherical`
 
 
-* `#2160 <https://github.com/ManimCommunity/manim/pull/2160>`__: Made projection shaders compatible with :class:`.StreamLines`
+* :pr:`2160`: Made projection shaders compatible with :class:`.StreamLines`
 
 
-* `#2140 <https://github.com/ManimCommunity/manim/pull/2140>`__: Fixed passing color lists to :meth:`.Mobject.set_color` for the OpenGL renderer
+* :pr:`2140`: Fixed passing color lists to :meth:`.Mobject.set_color` for the OpenGL renderer
 
 
-* `#2211 <https://github.com/ManimCommunity/manim/pull/2211>`__: Fixed animations not respecting the specified rate function
+* :pr:`2211`: Fixed animations not respecting the specified rate function
 
 
-* `#2161 <https://github.com/ManimCommunity/manim/pull/2161>`__: Fixed ``IndexOutOfBoundsError`` in TeX logging
+* :pr:`2161`: Fixed ``IndexOutOfBoundsError`` in TeX logging
 
 
-* `#2148 <https://github.com/ManimCommunity/manim/pull/2148>`__: Fixed :class:`~.Arrow` tip disorientation with :meth:`.Line.put_start_and_end_on`
+* :pr:`2148`: Fixed :class:`~.Arrow` tip disorientation with :meth:`.Line.put_start_and_end_on`
 
 
-* `#2192 <https://github.com/ManimCommunity/manim/pull/2192>`__: Fixed :func:`.svg_path.string_to_numbers` sometimes returning strings
+* :pr:`2192`: Fixed :func:`.svg_path.string_to_numbers` sometimes returning strings
 
 
-* `#2185 <https://github.com/ManimCommunity/manim/pull/2185>`__: Fixed type mismatch for height and width parameters of :class:`~.Text`
+* :pr:`2185`: Fixed type mismatch for height and width parameters of :class:`~.Text`
 
 
 Documentation-related changes
 -----------------------------
 
-* `#2228 <https://github.com/ManimCommunity/manim/pull/2228>`__: Added a new boolean operation example to the gallery
+* :pr:`2228`: Added a new boolean operation example to the gallery
 
 
-* `#2239 <https://github.com/ManimCommunity/manim/pull/2239>`__: Removed erroneous raw string from text tutorial
+* :pr:`2239`: Removed erroneous raw string from text tutorial
 
 
-* `#2184 <https://github.com/ManimCommunity/manim/pull/2184>`__: Moved comments in :class:`~.VMobject` to documentation
+* :pr:`2184`: Moved comments in :class:`~.VMobject` to documentation
 
 
-* `#2217 <https://github.com/ManimCommunity/manim/pull/2217>`__: Removed superfluous dots in documentation of :class:`.Section`
+* :pr:`2217`: Removed superfluous dots in documentation of :class:`.Section`
 
 
-* `#2215 <https://github.com/ManimCommunity/manim/pull/2215>`__: Fixed typo in docstring of :meth:`.ThreeDAxes.get_z_axis_label`
+* :pr:`2215`: Fixed typo in docstring of :meth:`.ThreeDAxes.get_z_axis_label`
 
 
-* `#2212 <https://github.com/ManimCommunity/manim/pull/2212>`__: Fixed Documentation for Sections
+* :pr:`2212`: Fixed Documentation for Sections
 
 
-* `#2201 <https://github.com/ManimCommunity/manim/pull/2201>`__: Fixed a typo in the documentation
+* :pr:`2201`: Fixed a typo in the documentation
 
 
-* `#2165 <https://github.com/ManimCommunity/manim/pull/2165>`__: Added Crowdin configuration and changed source files to ``.pot`` format
+* :pr:`2165`: Added Crowdin configuration and changed source files to ``.pot`` format
 
 
-* `#2130 <https://github.com/ManimCommunity/manim/pull/2130>`__:  Transferred troubleshooting installation related snippets from Discord to the documentation
+* :pr:`2130`:  Transferred troubleshooting installation related snippets from Discord to the documentation
 
 
-* `#2176 <https://github.com/ManimCommunity/manim/pull/2176>`__: Modified :meth:`.Mobject.set_default` example to prevent leaking across the docs
+* :pr:`2176`: Modified :meth:`.Mobject.set_default` example to prevent leaking across the docs
 
 
 Changes concerning the testing system
 -------------------------------------
 
-* `#2197 <https://github.com/ManimCommunity/manim/pull/2197>`__: Added tests for resolution flag
+* :pr:`2197`: Added tests for resolution flag
 
 
-* `#2146 <https://github.com/ManimCommunity/manim/pull/2146>`__: Increased test coverage for OpenGL renderer
+* :pr:`2146`: Increased test coverage for OpenGL renderer
 
 
 Changes to our development infrastructure
 -----------------------------------------
 
-* `#2191 <https://github.com/ManimCommunity/manim/pull/2191>`__: Removed ``add-trailing-comma`` pre-commit hook
+* :pr:`2191`: Removed ``add-trailing-comma`` pre-commit hook
 
 
 Code quality improvements and similar refactors
 -----------------------------------------------
 
-* `#2136 <https://github.com/ManimCommunity/manim/pull/2136>`__: Added type hints to all colors
+* :pr:`2136`: Added type hints to all colors
 
 
-* `#2220 <https://github.com/ManimCommunity/manim/pull/2220>`__: Cleanup: let ``Scene.renderer.time`` return something that makes sense
+* :pr:`2220`: Cleanup: let ``Scene.renderer.time`` return something that makes sense
 
 
-* `#2222 <https://github.com/ManimCommunity/manim/pull/2222>`__: Updated Classifiers in ``pyproject.toml``: removed Python 3.6, added Python 3.9
+* :pr:`2222`: Updated Classifiers in ``pyproject.toml``: removed Python 3.6, added Python 3.9
 
 
-* `#2213 <https://github.com/ManimCommunity/manim/pull/2213>`__: Removed redundant ``partial_movie_files`` parameter in :meth:`.SceneFileWriter.combine_to_movie`
+* :pr:`2213`: Removed redundant ``partial_movie_files`` parameter in :meth:`.SceneFileWriter.combine_to_movie`
 
 
-* `#2200 <https://github.com/ManimCommunity/manim/pull/2200>`__: Addressed some maintenance TODOs
+* :pr:`2200`: Addressed some maintenance TODOs
    - Changed an `Exception` to `ValueError`
    - Fixed :meth:`.MappingCamera.points_to_pixel_coords` by adding the ``mobject`` argument of the parent
    - Rounded up width in :class:`.SplitScreenCamera`
    - Added docstring to :meth:`.Camera.capture_mobject`
 
-* `#2194 <https://github.com/ManimCommunity/manim/pull/2194>`__: Added type hints to :mod:`.utils.images`
+* :pr:`2194`: Added type hints to :mod:`.utils.images`
 
 
-* `#2171 <https://github.com/ManimCommunity/manim/pull/2171>`__: Added type hints to :mod:`.utils.ipython_magic`
+* :pr:`2171`: Added type hints to :mod:`.utils.ipython_magic`
 
 
-* `#2164 <https://github.com/ManimCommunity/manim/pull/2164>`__: Improved readability of regular expression
+* :pr:`2164`: Improved readability of regular expression
 
 
 New releases
 ------------
 
-* `#2247 <https://github.com/ManimCommunity/manim/pull/2247>`__: Prepared new release ``v0.12.0``
+* :pr:`2247`: Prepared new release ``v0.12.0``

--- a/docs/source/changelog/0.13.0-changelog.rst
+++ b/docs/source/changelog/0.13.0-changelog.rst
@@ -60,13 +60,13 @@ A total of 39 pull requests were merged for this release.
 Highlights
 ----------
 
-* `#2313 <https://github.com/ManimCommunity/manim/pull/2313>`__: Finalized translation process and documentation
+* :pr:`2313`: Finalized translation process and documentation
 
 
 Deprecated classes and functions
 --------------------------------
 
-* `#2331 <https://github.com/ManimCommunity/manim/pull/2331>`__: Removed deprecations up to ``v0.12.0``
+* :pr:`2331`: Removed deprecations up to ``v0.12.0``
    - Removed ``distance`` parameters from :class:`~.ThreeDCamera` (replacement: ``focal_distance``)
    - Removed ``min_distance_to_new_point`` parameter from :class:`~.TracedPath`
    - Removed ``positive_space_ratio`` and ``dash_spacing`` parameters from :class:`~.DashedVMobject`
@@ -74,137 +74,137 @@ Deprecated classes and functions
    - Removed ``ReconfigurableScene``
    - Removed ``SampleSpaceScene``
 
-* `#2312 <https://github.com/ManimCommunity/manim/pull/2312>`__: Replaced all occurrences of ``set_submobjects``
+* :pr:`2312`: Replaced all occurrences of ``set_submobjects``
 
 
 New features
 ------------
 
-* `#2314 <https://github.com/ManimCommunity/manim/pull/2314>`__: Added basic support for adding subcaptions via :meth:`.Scene.add_subcaption`
+* :pr:`2314`: Added basic support for adding subcaptions via :meth:`.Scene.add_subcaption`
    - New method :meth:`.Scene.add_subcaption`
    - New keyword arguments ``subcaption``, ``subcaption_duration``, ``subcaption_offset`` for :meth:`.Scene.play`
 
-* `#2267 <https://github.com/ManimCommunity/manim/pull/2267>`__: Implemented :meth:`.CoordinateSystem.plot_antiderivative_graph`
+* :pr:`2267`: Implemented :meth:`.CoordinateSystem.plot_antiderivative_graph`
 
 
 Enhancements
 ------------
 
-* `#2347 <https://github.com/ManimCommunity/manim/pull/2347>`__: Moved ``manim_directive.py`` to ``manim.utils.docbuild``
+* :pr:`2347`: Moved ``manim_directive.py`` to ``manim.utils.docbuild``
 
 
-* `#2340 <https://github.com/ManimCommunity/manim/pull/2340>`__: Added documentation for :mod:`.animation.growing` and improved :class:`.SpinInFromNothing`
+* :pr:`2340`: Added documentation for :mod:`.animation.growing` and improved :class:`.SpinInFromNothing`
 
 
-* `#2343 <https://github.com/ManimCommunity/manim/pull/2343>`__: Replaced current tree layout algorithm with SageMath's for improved layout of large trees
+* :pr:`2343`: Replaced current tree layout algorithm with SageMath's for improved layout of large trees
 
 
-* `#2351 <https://github.com/ManimCommunity/manim/pull/2351>`__: Added missing ``**kwargs`` parameter to :meth:`.Table.add_highlighted_cell`
+* :pr:`2351`: Added missing ``**kwargs`` parameter to :meth:`.Table.add_highlighted_cell`
 
 
-* `#2344 <https://github.com/ManimCommunity/manim/pull/2344>`__: Resized SVG logos, fit content to canvas
+* :pr:`2344`: Resized SVG logos, fit content to canvas
 
 
 Fixed bugs
 ----------
 
-* `#2359 <https://github.com/ManimCommunity/manim/pull/2359>`__: Resolved ``ValueError`` when calling ``manim cfg write``
+* :pr:`2359`: Resolved ``ValueError`` when calling ``manim cfg write``
 
 
-* `#2276 <https://github.com/ManimCommunity/manim/pull/2276>`__: Fixed bug with alignment of z-axis in :class:`~.ThreeDAxes`
+* :pr:`2276`: Fixed bug with alignment of z-axis in :class:`~.ThreeDAxes`
 
 
-* `#2325 <https://github.com/ManimCommunity/manim/pull/2325>`__: Several improvements to handling of ``quality`` argument
+* :pr:`2325`: Several improvements to handling of ``quality`` argument
 
 
-* `#2335 <https://github.com/ManimCommunity/manim/pull/2335>`__: Fixed bug with zooming camera and :class:`~.PointCloud`
+* :pr:`2335`: Fixed bug with zooming camera and :class:`~.PointCloud`
 
 
-* `#2328 <https://github.com/ManimCommunity/manim/pull/2328>`__: Fixed bug causing incorrect RGBA values to be passed to cairo
+* :pr:`2328`: Fixed bug causing incorrect RGBA values to be passed to cairo
 
 
-* `#2292 <https://github.com/ManimCommunity/manim/pull/2292>`__: Fixed positioning of :class:`~.Flash`
+* :pr:`2292`: Fixed positioning of :class:`~.Flash`
 
 
-* `#2262 <https://github.com/ManimCommunity/manim/pull/2262>`__: Fixed wrong cell coordinates with :meth:`.Table.get_cell` after scaling
+* :pr:`2262`: Fixed wrong cell coordinates with :meth:`.Table.get_cell` after scaling
 
 
-* `#2280 <https://github.com/ManimCommunity/manim/pull/2280>`__: Fixed :class:`~.DecimalNumber` color when number of displayed digits changes
+* :pr:`2280`: Fixed :class:`~.DecimalNumber` color when number of displayed digits changes
 
 
 Documentation-related changes
 -----------------------------
 
-* `#2354 <https://github.com/ManimCommunity/manim/pull/2354>`__: Port over docs and typings from ``mobject.py`` and ``vectorized_mobject.py`` to their OpenGL counterparts
+* :pr:`2354`: Port over docs and typings from ``mobject.py`` and ``vectorized_mobject.py`` to their OpenGL counterparts
 
 
-* `#2350 <https://github.com/ManimCommunity/manim/pull/2350>`__: Added mention of Manim sideview extension for VS Code
+* :pr:`2350`: Added mention of Manim sideview extension for VS Code
 
 
-* `#2342 <https://github.com/ManimCommunity/manim/pull/2342>`__: Removed :meth:`~.CoordinateSystem.get_graph` usage from :class:`~.Axes` example
+* :pr:`2342`: Removed :meth:`~.CoordinateSystem.get_graph` usage from :class:`~.Axes` example
 
 
-* `#2216 <https://github.com/ManimCommunity/manim/pull/2216>`__: Edited and added new sections to the quickstart tutorial
+* :pr:`2216`: Edited and added new sections to the quickstart tutorial
 
 
-* `#2279 <https://github.com/ManimCommunity/manim/pull/2279>`__: Added documentation for discontinuous functions
+* :pr:`2279`: Added documentation for discontinuous functions
 
 
-* `#2319 <https://github.com/ManimCommunity/manim/pull/2319>`__: Swapped ``dotL`` and ``dotR`` in :meth:`.Mobject.interpolate` example
+* :pr:`2319`: Swapped ``dotL`` and ``dotR`` in :meth:`.Mobject.interpolate` example
 
 
-* `#2230 <https://github.com/ManimCommunity/manim/pull/2230>`__: Copyedited building blocks tutorial
+* :pr:`2230`: Copyedited building blocks tutorial
 
 
-* `#2310 <https://github.com/ManimCommunity/manim/pull/2310>`__: Clarified that Manim does not support Python 3.10 yet in the documentation
+* :pr:`2310`: Clarified that Manim does not support Python 3.10 yet in the documentation
 
 
-* `#2294 <https://github.com/ManimCommunity/manim/pull/2294>`__: Made documentation front page more concise and rearranged order of tutorials
+* :pr:`2294`: Made documentation front page more concise and rearranged order of tutorials
 
 
-* `#2287 <https://github.com/ManimCommunity/manim/pull/2287>`__: Replace link to old interactive notebook
+* :pr:`2287`: Replace link to old interactive notebook
 
 
 Changes concerning the testing system
 -------------------------------------
 
-* `#2346 <https://github.com/ManimCommunity/manim/pull/2346>`__: Made ``frames_comparsion`` decorator for frame testing a proper module of the library
+* :pr:`2346`: Made ``frames_comparsion`` decorator for frame testing a proper module of the library
 
 
-* `#2318 <https://github.com/ManimCommunity/manim/pull/2318>`__: Added tests for ``remover`` keyword argument of :class:`~.AnimationGroup`
+* :pr:`2318`: Added tests for ``remover`` keyword argument of :class:`~.AnimationGroup`
 
 
-* `#2301 <https://github.com/ManimCommunity/manim/pull/2301>`__: Added a test for :meth:`.ThreeDScene.add_fixed_in_frame_mobjects`
+* :pr:`2301`: Added a test for :meth:`.ThreeDScene.add_fixed_in_frame_mobjects`
 
 
-* `#2274 <https://github.com/ManimCommunity/manim/pull/2274>`__: Optimized some tests to reduce duration
+* :pr:`2274`: Optimized some tests to reduce duration
 
 
-* `#2272 <https://github.com/ManimCommunity/manim/pull/2272>`__: Added test for :class:`~.Broadcast`
+* :pr:`2272`: Added test for :class:`~.Broadcast`
 
 
 Code quality improvements and similar refactors
 -----------------------------------------------
 
-* `#2327 <https://github.com/ManimCommunity/manim/pull/2327>`__: Corrected type hint for ``labels`` keyword argument of :class:`~.Graph`
+* :pr:`2327`: Corrected type hint for ``labels`` keyword argument of :class:`~.Graph`
 
 
-* `#2329 <https://github.com/ManimCommunity/manim/pull/2329>`__: Remove unintended line break in README
+* :pr:`2329`: Remove unintended line break in README
 
 
-* `#2305 <https://github.com/ManimCommunity/manim/pull/2305>`__: Corrected type hint ``discontinuities`` argument for :class:`~.ParametricFunction`
+* :pr:`2305`: Corrected type hint ``discontinuities`` argument for :class:`~.ParametricFunction`
 
 
-* `#2300 <https://github.com/ManimCommunity/manim/pull/2300>`__: Add contact email for PyPi
+* :pr:`2300`: Add contact email for PyPi
 
 
 New releases
 ------------
 
-* `#2353 <https://github.com/ManimCommunity/manim/pull/2353>`__: Prepare new release: ``v0.13.0``
+* :pr:`2353`: Prepare new release: ``v0.13.0``
 
 
 Unclassified changes
 --------------------
 
-* `#2348 <https://github.com/ManimCommunity/manim/pull/2348>`__: Updated translation source files
+* :pr:`2348`: Updated translation source files

--- a/docs/source/changelog/0.13.1-changelog.rst
+++ b/docs/source/changelog/0.13.1-changelog.rst
@@ -27,10 +27,10 @@ A total of 2 pull requests were merged for this release.
 Fixed bugs
 ----------
 
-* `#2363 <https://github.com/ManimCommunity/manim/pull/2363>`__: Fixed broken IPython magic command
+* :pr:`2363`: Fixed broken IPython magic command
 
 
 New releases
 ------------
 
-* `#2364 <https://github.com/ManimCommunity/manim/pull/2364>`__: Prepared bugfix release ``v0.13.1``
+* :pr:`2364`: Prepared bugfix release ``v0.13.1``

--- a/docs/source/changelog/0.14.0-changelog.rst
+++ b/docs/source/changelog/0.14.0-changelog.rst
@@ -62,7 +62,7 @@ A total of 29 pull requests were merged for this release.
 Deprecated classes and functions
 --------------------------------
 
-* `#2390 <https://github.com/ManimCommunity/manim/pull/2390>`__: Removed deprecations up to `v0.13.0`
+* :pr:`2390`: Removed deprecations up to `v0.13.0`
    - Removed ``get_graph``, ``get_implicit_curve``, ``get_derivative_graph``, ``get_line_graph`` and ``get_parametric_curve`` in favour of their ``plot`` variants
    - Removed ``FullScreenFadeRectangle`` and ``PictureInPictureFrame``
    - Removed ``path_arc`` parameter from :class:`~.SpinInFromNothing`
@@ -71,101 +71,101 @@ Deprecated classes and functions
 New features
 ------------
 
-* `#2341 <https://github.com/ManimCommunity/manim/pull/2341>`__: Update :class:`~.Text` to use new ``ManimPango`` color setting
+* :pr:`2341`: Update :class:`~.Text` to use new ``ManimPango`` color setting
    * :class:`~.Text` class now uses color setting introduced in ``ManimPango 0.4.0`` for color and gradient.
 
-* `#2397 <https://github.com/ManimCommunity/manim/pull/2397>`__: Added ``label_constructor`` parameter for :class:`~.NumberLine`
+* :pr:`2397`: Added ``label_constructor`` parameter for :class:`~.NumberLine`
    Allows changing the class that will be used to construct :class:`~.Axes` and :class:`~.NumberLine` labels by default. Makes it possible to easily use :class:`~.Text` for labels if needed.
 
 Enhancements
 ------------
 
-* `#2383 <https://github.com/ManimCommunity/manim/pull/2383>`__: Made :meth:`.Surface.set_fill_by_value` support gradients along different axes
+* :pr:`2383`: Made :meth:`.Surface.set_fill_by_value` support gradients along different axes
 
 
-* `#2388 <https://github.com/ManimCommunity/manim/pull/2388>`__: Added ``about_point`` keyword argument to :class:`~.ApplyMatrix`
+* :pr:`2388`: Added ``about_point`` keyword argument to :class:`~.ApplyMatrix`
 
 
-* `#2395 <https://github.com/ManimCommunity/manim/pull/2395>`__: Add documentation for paths functions
+* :pr:`2395`: Add documentation for paths functions
 
 
-* `#2372 <https://github.com/ManimCommunity/manim/pull/2372>`__: Improved :class:`~.DashedVMobject`
+* :pr:`2372`: Improved :class:`~.DashedVMobject`
    :class:`~.DashedVMobject` used to create stretched and uneven dashes on most plotted curves. Now the dash lengths are equalized. An option is reserved to use the old method.
    New keyword argument: ``dash_offset``. This parameter shifts the starting point.
 
 Fixed bugs
 ----------
 
-* `#2409 <https://github.com/ManimCommunity/manim/pull/2409>`__: Fixed performance degradation by trimming empty curves from paths when calling :meth:`.VMobject.align_points`
+* :pr:`2409`: Fixed performance degradation by trimming empty curves from paths when calling :meth:`.VMobject.align_points`
 
 
-* `#2392 <https://github.com/ManimCommunity/manim/pull/2392>`__: Fixed ``ZeroDivisionError`` in :mod:`~.mobject.three_dimensions`
+* :pr:`2392`: Fixed ``ZeroDivisionError`` in :mod:`~.mobject.three_dimensions`
 
 
-* `#2362 <https://github.com/ManimCommunity/manim/pull/2362>`__: Fixed phi updater in :meth:`.ThreeDScene.begin_3dillusion_camera_rotation`
+* :pr:`2362`: Fixed phi updater in :meth:`.ThreeDScene.begin_3dillusion_camera_rotation`
 
 
 Documentation-related changes
 -----------------------------
 
-* `#2415 <https://github.com/ManimCommunity/manim/pull/2415>`__: Removed instructions on using and installing Docker in README
+* :pr:`2415`: Removed instructions on using and installing Docker in README
 
 
-* `#2414 <https://github.com/ManimCommunity/manim/pull/2414>`__: Made improvements to the :doc:`configuration` tutorial
+* :pr:`2414`: Made improvements to the :doc:`configuration` tutorial
 
 
-* `#2423 <https://github.com/ManimCommunity/manim/pull/2423>`__: Changed recommendation to ``mactex-no-gui`` from ``mactex`` for macOS install
+* :pr:`2423`: Changed recommendation to ``mactex-no-gui`` from ``mactex`` for macOS install
 
 
-* `#2407 <https://github.com/ManimCommunity/manim/pull/2407>`__: Clarified docstrings of :meth:`.Mobject.animate`, :meth:`.Mobject.set` and :class:`~.Variable`
+* :pr:`2407`: Clarified docstrings of :meth:`.Mobject.animate`, :meth:`.Mobject.set` and :class:`~.Variable`
 
 
-* `#2352 <https://github.com/ManimCommunity/manim/pull/2352>`__: Added Crowdin badge
+* :pr:`2352`: Added Crowdin badge
 
 
-* `#2371 <https://github.com/ManimCommunity/manim/pull/2371>`__: Added ``dvips`` to list of required LaTeX packages on Linux
+* :pr:`2371`: Added ``dvips`` to list of required LaTeX packages on Linux
 
 
-* `#2403 <https://github.com/ManimCommunity/manim/pull/2403>`__: Improved docstring of :class:`~.ApplyMethod` and removed propagated ``__init__`` docstring
+* :pr:`2403`: Improved docstring of :class:`~.ApplyMethod` and removed propagated ``__init__`` docstring
 
 
-* `#2391 <https://github.com/ManimCommunity/manim/pull/2391>`__: Fixed typo in parameter name in documentation of :class:`~.NumberLine`
+* :pr:`2391`: Fixed typo in parameter name in documentation of :class:`~.NumberLine`
 
 
-* `#2368 <https://github.com/ManimCommunity/manim/pull/2368>`__: Added note in Internationalization
+* :pr:`2368`: Added note in Internationalization
 
 
 Code quality improvements and similar refactors
 -----------------------------------------------
 
-* `#2408 <https://github.com/ManimCommunity/manim/pull/2408>`__: Removed various return annotations that were stifling type inference
+* :pr:`2408`: Removed various return annotations that were stifling type inference
 
 
-* `#2424 <https://github.com/ManimCommunity/manim/pull/2424>`__: Removed ``strings.py``
+* :pr:`2424`: Removed ``strings.py``
 
 
-* `#1972 <https://github.com/ManimCommunity/manim/pull/1972>`__: Added support for MyPy
+* :pr:`1972`: Added support for MyPy
 
 
-* `#2410 <https://github.com/ManimCommunity/manim/pull/2410>`__: Fixed Flake8
+* :pr:`2410`: Fixed Flake8
 
 
-* `#2401 <https://github.com/ManimCommunity/manim/pull/2401>`__: Fixed type annotations in :mod:`.mobject.three_dimensions`
+* :pr:`2401`: Fixed type annotations in :mod:`.mobject.three_dimensions`
 
 
-* `#2405 <https://github.com/ManimCommunity/manim/pull/2405>`__: Removed some unused OpenGL files
+* :pr:`2405`: Removed some unused OpenGL files
 
 
-* `#2399 <https://github.com/ManimCommunity/manim/pull/2399>`__: Fixed type annotations in :mod:`~.mobject.table`
+* :pr:`2399`: Fixed type annotations in :mod:`~.mobject.table`
 
 
-* `#2385 <https://github.com/ManimCommunity/manim/pull/2385>`__: Made comments in quickstart tutorial more precise
+* :pr:`2385`: Made comments in quickstart tutorial more precise
 
 
-* `#2377 <https://github.com/ManimCommunity/manim/pull/2377>`__: Fixed type hint for an argument of :class:`~.MoveAlongPath`
+* :pr:`2377`: Fixed type hint for an argument of :class:`~.MoveAlongPath`
 
 
 New releases
 ------------
 
-* `#2411 <https://github.com/ManimCommunity/manim/pull/2411>`__: Prepare new release, ``v0.14.0``
+* :pr:`2411`: Prepare new release, ``v0.14.0``

--- a/docs/source/changelog/0.15.0-changelog.rst
+++ b/docs/source/changelog/0.15.0-changelog.rst
@@ -67,29 +67,29 @@ A total of 71 pull requests were merged for this release.
 Breaking changes
 ----------------
 
-* `#2476 <https://github.com/ManimCommunity/manim/pull/2476>`__: Improved structure of the :mod:`.mobject` module
+* :pr:`2476`: Improved structure of the :mod:`.mobject` module
    Arrow tips now have to be imported from ``manim.mobject.geometry.tips`` instead of ``manim.mobject.geometry``.
 
-* `#2387 <https://github.com/ManimCommunity/manim/pull/2387>`__: Refactored :class:`~.BarChart` and made it inherit from :class:`~.Axes`
+* :pr:`2387`: Refactored :class:`~.BarChart` and made it inherit from :class:`~.Axes`
    - :class:`~.BarChart` now inherits from :class:`~.Axes`, allowing it to use :class:`~.Axes`' methods. Also improves :class:`~.BarChart`'s configuration and ease of use.
    - Added :meth:`~.BarChart.get_bar_labels` to annotate the value of each bar of a :class:`~.BarChart`.
 
 Deprecated classes and functions
 --------------------------------
 
-* `#2568 <https://github.com/ManimCommunity/manim/pull/2568>`__: Removed Deprecated Methods
+* :pr:`2568`: Removed Deprecated Methods
    Removed methods and classes that were deprecated since v0.10.0 and v0.11.0
 
-* `#2457 <https://github.com/ManimCommunity/manim/pull/2457>`__: Deprecated :class:`.ShowCreationThenFadeOut`
+* :pr:`2457`: Deprecated :class:`.ShowCreationThenFadeOut`
 
 
 New features
 ------------
 
-* `#2442 <https://github.com/ManimCommunity/manim/pull/2442>`__: Added ``media_embed`` config option to control whether media in Jupyter notebooks is embedded
+* :pr:`2442`: Added ``media_embed`` config option to control whether media in Jupyter notebooks is embedded
 
 
-* `#2504 <https://github.com/ManimCommunity/manim/pull/2504>`__: Added finer control over :meth:`.Scene.wait` being static (i.e., no updaters) or not
+* :pr:`2504`: Added finer control over :meth:`.Scene.wait` being static (i.e., no updaters) or not
    - Added keyword argument ``frozen_frame`` to :class:`.Wait` and :meth:`.Scene.wait`
    - New convenience method: :meth:`.Scene.pause` (alias for ``Scene.wait(frozen_frame=True)``)
    - Changed default behavior for OpenGL updaters: updater functions are now not called by default when they are added
@@ -98,34 +98,34 @@ New features
 Enhancements
 ------------
 
-* `#2478 <https://github.com/ManimCommunity/manim/pull/2478>`__: Alternative scaling for tree graph layout
+* :pr:`2478`: Alternative scaling for tree graph layout
 
 
-* `#2565 <https://github.com/ManimCommunity/manim/pull/2565>`__: Allowed passing vertex configuration keyword arguments to :meth:`.Graph.add_edges`
+* :pr:`2565`: Allowed passing vertex configuration keyword arguments to :meth:`.Graph.add_edges`
 
 
-* `#2467 <https://github.com/ManimCommunity/manim/pull/2467>`__: :class:`~.MathTex`, :class:`~.Tex`, :class:`~.Text` and :class:`~.MarkupText` inherit color from their parent mobjects
+* :pr:`2467`: :class:`~.MathTex`, :class:`~.Tex`, :class:`~.Text` and :class:`~.MarkupText` inherit color from their parent mobjects
 
 
-* `#2537 <https://github.com/ManimCommunity/manim/pull/2537>`__: Added support for PySide coordinate system
+* :pr:`2537`: Added support for PySide coordinate system
 
 
-* `#2158 <https://github.com/ManimCommunity/manim/pull/2158>`__: Added OpenGL compatibility to :meth:`.ThreeDScene.add_fixed_orientation_mobjects` and  :meth:`.ThreeDScene.add_fixed_in_frame_mobjects`
+* :pr:`2158`: Added OpenGL compatibility to :meth:`.ThreeDScene.add_fixed_orientation_mobjects` and  :meth:`.ThreeDScene.add_fixed_in_frame_mobjects`
 
 
-* `#2535 <https://github.com/ManimCommunity/manim/pull/2535>`__: Implemented performance enhancement for :meth:`.VMobject.insert_n_curves_to_point_list`
+* :pr:`2535`: Implemented performance enhancement for :meth:`.VMobject.insert_n_curves_to_point_list`
 
 
-* `#2516 <https://github.com/ManimCommunity/manim/pull/2516>`__: Cached view matrix for :class:`~.OpenGLCamera`
+* :pr:`2516`: Cached view matrix for :class:`~.OpenGLCamera`
 
 
-* `#2508 <https://github.com/ManimCommunity/manim/pull/2508>`__: Improve performance for :meth:`.Mobject.become`
+* :pr:`2508`: Improve performance for :meth:`.Mobject.become`
 
 
-* `#2332 <https://github.com/ManimCommunity/manim/pull/2332>`__: Changed ``color``, ``stroke_color`` and ``fill_color`` attributes to properties
+* :pr:`2332`: Changed ``color``, ``stroke_color`` and ``fill_color`` attributes to properties
 
 
-* `#2396 <https://github.com/ManimCommunity/manim/pull/2396>`__: Fixed animations introducing or removing objects
+* :pr:`2396`: Fixed animations introducing or removing objects
    * :class:`.ShowPassingFlash` now removes objects when the animation is finished
    * Added ``introducer`` keyword argument to :class:`.Animation` analogous to ``remover``
    * Updated :class:`.Graph` vertex addition handling
@@ -133,181 +133,181 @@ Enhancements
 Fixed bugs
 ----------
 
-* `#2574 <https://github.com/ManimCommunity/manim/pull/2574>`__: Improved Error in :mod:`.utils.tex_file_writing`
+* :pr:`2574`: Improved Error in :mod:`.utils.tex_file_writing`
 
 
-* `#2580 <https://github.com/ManimCommunity/manim/pull/2580>`__: Fixed :func:`.find_intersection` in :mod:`.space_ops`
+* :pr:`2580`: Fixed :func:`.find_intersection` in :mod:`.space_ops`
 
 
-* `#2576 <https://github.com/ManimCommunity/manim/pull/2576>`__: Fixed a bug with animation of removal of edges from a :class:`.Graph`
+* :pr:`2576`: Fixed a bug with animation of removal of edges from a :class:`.Graph`
 
 
-* `#2556 <https://github.com/ManimCommunity/manim/pull/2556>`__: Fixed showing highlighted cells when creating :class:`.Table`
+* :pr:`2556`: Fixed showing highlighted cells when creating :class:`.Table`
 
 
-* `#2559 <https://github.com/ManimCommunity/manim/pull/2559>`__: Fix setting line numbers in :class:`.Text` when using ManimPango settings
+* :pr:`2559`: Fix setting line numbers in :class:`.Text` when using ManimPango settings
 
 
-* `#2557 <https://github.com/ManimCommunity/manim/pull/2557>`__: Fixed logger bug in :meth:`.Camera.make_background_from_func`
+* :pr:`2557`: Fixed logger bug in :meth:`.Camera.make_background_from_func`
 
 
-* `#2548 <https://github.com/ManimCommunity/manim/pull/2548>`__: Fixed :class:`.Axes` plotting bug with logarithmic x-axis
+* :pr:`2548`: Fixed :class:`.Axes` plotting bug with logarithmic x-axis
 
 
-* `#1547 <https://github.com/ManimCommunity/manim/pull/1547>`__: Fixed certain unicode characters in users' paths causing issues on Windows
+* :pr:`1547`: Fixed certain unicode characters in users' paths causing issues on Windows
 
 
-* `#2526 <https://github.com/ManimCommunity/manim/pull/2526>`__: Fixed segfault when using ``--enable_gui``
+* :pr:`2526`: Fixed segfault when using ``--enable_gui``
 
 
-* `#2538 <https://github.com/ManimCommunity/manim/pull/2538>`__: Fixed flickering OpenGL preview when using ``frozen_frame``
+* :pr:`2538`: Fixed flickering OpenGL preview when using ``frozen_frame``
 
 
-* `#2528 <https://github.com/ManimCommunity/manim/pull/2528>`__: Fixed custom naming of gifs and added some tests
+* :pr:`2528`: Fixed custom naming of gifs and added some tests
 
 
-* `#2487 <https://github.com/ManimCommunity/manim/pull/2487>`__: Fixed :meth:`.ThreeDCamera.remove_fixed_orientation_mobjects`
+* :pr:`2487`: Fixed :meth:`.ThreeDCamera.remove_fixed_orientation_mobjects`
 
 
-* `#2530 <https://github.com/ManimCommunity/manim/pull/2530>`__: Use single source of truth for default text values
+* :pr:`2530`: Use single source of truth for default text values
 
 
-* `#2494 <https://github.com/ManimCommunity/manim/pull/2494>`__: Fixed an issue related to previewing gifs
+* :pr:`2494`: Fixed an issue related to previewing gifs
 
 
-* `#2490 <https://github.com/ManimCommunity/manim/pull/2490>`__: Fixed order of transformation application in :class:`~.SVGMobject`
+* :pr:`2490`: Fixed order of transformation application in :class:`~.SVGMobject`
 
 
-* `#2357 <https://github.com/ManimCommunity/manim/pull/2357>`__: Fixed ``screeninfo.get_monitors`` for MacOS
+* :pr:`2357`: Fixed ``screeninfo.get_monitors`` for MacOS
 
 
-* `#2444 <https://github.com/ManimCommunity/manim/pull/2444>`__: Fixed :meth:`.VectorScene.add_axes`
+* :pr:`2444`: Fixed :meth:`.VectorScene.add_axes`
 
 
 Documentation-related changes
 -----------------------------
 
-* `#2560 <https://github.com/ManimCommunity/manim/pull/2560>`__: Refactored more docstrings in :mod:`.geometry`
+* :pr:`2560`: Refactored more docstrings in :mod:`.geometry`
 
 
-* `#2571 <https://github.com/ManimCommunity/manim/pull/2571>`__: Refactored docstrings in :mod:`.graphing`
+* :pr:`2571`: Refactored docstrings in :mod:`.graphing`
 
 
-* `#2569 <https://github.com/ManimCommunity/manim/pull/2569>`__: Refactored docstrings in :mod:`.geometry`
+* :pr:`2569`: Refactored docstrings in :mod:`.geometry`
 
-* `#2549 <https://github.com/ManimCommunity/manim/pull/2549>`__: Added a page for internals which links to our GitHub wiki
-
-
-* `#2458 <https://github.com/ManimCommunity/manim/pull/2458>`__: Improved documentation for :class:`.Rotate`
+* :pr:`2549`: Added a page for internals which links to our GitHub wiki
 
 
-* `#2459 <https://github.com/ManimCommunity/manim/pull/2459>`__: Added examples to some transform animations
+* :pr:`2458`: Improved documentation for :class:`.Rotate`
 
 
-* `#2517 <https://github.com/ManimCommunity/manim/pull/2517>`__: Added guide on profiling and improving performance
+* :pr:`2459`: Added examples to some transform animations
 
 
-* `#2518 <https://github.com/ManimCommunity/manim/pull/2518>`__: Added imports to examples for ``deprecation`` decorator
+* :pr:`2517`: Added guide on profiling and improving performance
 
 
-* `#2499 <https://github.com/ManimCommunity/manim/pull/2499>`__: Improved help text for ``--write_to_movie``
+* :pr:`2518`: Added imports to examples for ``deprecation`` decorator
 
 
-* `#2465 <https://github.com/ManimCommunity/manim/pull/2465>`__: Added documentation for :func:`.index_labels`
+* :pr:`2499`: Improved help text for ``--write_to_movie``
 
 
-* `#2495 <https://github.com/ManimCommunity/manim/pull/2495>`__: Updated minimal LaTeX installation instructions
+* :pr:`2465`: Added documentation for :func:`.index_labels`
 
 
-* `#2500 <https://github.com/ManimCommunity/manim/pull/2500>`__: Added note about contributions during refactor period
+* :pr:`2495`: Updated minimal LaTeX installation instructions
 
 
-* `#2431 <https://github.com/ManimCommunity/manim/pull/2431>`__: Changed example in :meth:`.Surface.set_fill_by_value`
+* :pr:`2500`: Added note about contributions during refactor period
 
 
-* `#2485 <https://github.com/ManimCommunity/manim/pull/2485>`__: Fixed some typos in documentation
+* :pr:`2431`: Changed example in :meth:`.Surface.set_fill_by_value`
 
 
-* `#2493 <https://github.com/ManimCommunity/manim/pull/2493>`__: Fixed typo in documentation for parameters of :class:`.Square`
+* :pr:`2485`: Fixed some typos in documentation
 
 
-* `#2482 <https://github.com/ManimCommunity/manim/pull/2482>`__: Updated Python version requirement in installation guide
+* :pr:`2493`: Fixed typo in documentation for parameters of :class:`.Square`
 
 
-* `#2438 <https://github.com/ManimCommunity/manim/pull/2438>`__: Removed unnecessary rotation from example
+* :pr:`2482`: Updated Python version requirement in installation guide
 
 
-* `#2468 <https://github.com/ManimCommunity/manim/pull/2468>`__: Hid more private methods from the docs
+* :pr:`2438`: Removed unnecessary rotation from example
 
 
-* `#2466 <https://github.com/ManimCommunity/manim/pull/2466>`__: Fixed a typo in the documentation for plugins
+* :pr:`2468`: Hid more private methods from the docs
 
 
-* `#2448 <https://github.com/ManimCommunity/manim/pull/2448>`__: Improvements to the ``.pot`` files cleaning system
+* :pr:`2466`: Fixed a typo in the documentation for plugins
 
 
-* `#2436 <https://github.com/ManimCommunity/manim/pull/2436>`__: Fixed typo and improved example in building blocks tutorial
+* :pr:`2448`: Improvements to the ``.pot`` files cleaning system
+
+
+* :pr:`2436`: Fixed typo and improved example in building blocks tutorial
 
 
 Changes to our development infrastructure
 -----------------------------------------
 
-* `#2554 <https://github.com/ManimCommunity/manim/pull/2554>`__: Removed ``Remove-Item`` calls for MSYS2 Python
+* :pr:`2554`: Removed ``Remove-Item`` calls for MSYS2 Python
 
 
-* `#2531 <https://github.com/ManimCommunity/manim/pull/2531>`__: Added a GitHub Action for automatic validation of citation metadata
+* :pr:`2531`: Added a GitHub Action for automatic validation of citation metadata
 
 
-* `#2536 <https://github.com/ManimCommunity/manim/pull/2536>`__: Upgraded version of setup-ffmpeg CI action
+* :pr:`2536`: Upgraded version of setup-ffmpeg CI action
 
 
-* `#2484 <https://github.com/ManimCommunity/manim/pull/2484>`__: Updated tinytex download URL
+* :pr:`2484`: Updated tinytex download URL
 
 
 Code quality improvements and similar refactors
 -----------------------------------------------
 
-* `#2573 <https://github.com/ManimCommunity/manim/pull/2573>`__: Moved :mod:`.value_tracker` back inside :mod:`.mobject`
+* :pr:`2573`: Moved :mod:`.value_tracker` back inside :mod:`.mobject`
 
 
-* `#2566 <https://github.com/ManimCommunity/manim/pull/2566>`__: Removed unused livestream-related imports and functions from :mod:`.scene_file_writer`
+* :pr:`2566`: Removed unused livestream-related imports and functions from :mod:`.scene_file_writer`
 
 
-* `#2524 <https://github.com/ManimCommunity/manim/pull/2524>`__: Reworked :mod:`.space_ops`
+* :pr:`2524`: Reworked :mod:`.space_ops`
 
 
-* `#2519 <https://github.com/ManimCommunity/manim/pull/2519>`__: Removed outdated comment
+* :pr:`2519`: Removed outdated comment
 
 
-* `#2503 <https://github.com/ManimCommunity/manim/pull/2503>`__: Removed unused imports
+* :pr:`2503`: Removed unused imports
 
 
-* `#2475 <https://github.com/ManimCommunity/manim/pull/2475>`__: Removed setuptools dependency
+* :pr:`2475`: Removed setuptools dependency
 
 
-* `#2472 <https://github.com/ManimCommunity/manim/pull/2472>`__: Removed unnecessary comment in :mod:`.simple_functions`
+* :pr:`2472`: Removed unnecessary comment in :mod:`.simple_functions`
 
 
-* `#2429 <https://github.com/ManimCommunity/manim/pull/2429>`__: Upgraded to future-style type annotations
+* :pr:`2429`: Upgraded to future-style type annotations
 
 
-* `#2464 <https://github.com/ManimCommunity/manim/pull/2464>`__: Bump pillow from 8.4.0 to 9.0.0
+* :pr:`2464`: Bump pillow from 8.4.0 to 9.0.0
 
 
-* `#2376 <https://github.com/ManimCommunity/manim/pull/2376>`__: Updated dependencies for Python 3.10
+* :pr:`2376`: Updated dependencies for Python 3.10
 
 
-* `#2437 <https://github.com/ManimCommunity/manim/pull/2437>`__: Cleaned up :mod:`.simple_functions`
+* :pr:`2437`: Cleaned up :mod:`.simple_functions`
    - Removed ``fdiv`` as in all cases where it was used, it was just doing the same thing as numpy array division.
    - Replaced old implementation of the choose function with scipy's implementation
    - Use ``lru_cache`` (least recently used cache) for caching the choose function. Since it's only used for beziers, only 2 choose k and 3 choose k will be used, hence a size of 10 should be enough.
    - Removed ``clip_in_place`` in favor of ``np.clip``
    - Removed one use of ``clip_in_place`` that wasn't actually doing anything
 
-* `#2439 <https://github.com/ManimCommunity/manim/pull/2439>`__: Removed twitter template from scripts
+* :pr:`2439`: Removed twitter template from scripts
 
 
 New releases
 ------------
 
-* `#2547 <https://github.com/ManimCommunity/manim/pull/2547>`__: Prepared new release, ``v0.15.0``
+* :pr:`2547`: Prepared new release, ``v0.15.0``

--- a/docs/source/changelog/0.5.0-changelog.rst
+++ b/docs/source/changelog/0.5.0-changelog.rst
@@ -69,233 +69,233 @@ A total of 64 pull requests were merged for this release.
 Highlights
 ----------
 
-* `#1075 <https://github.com/ManimCommunity/manim/pull/1075>`__: Add OpenGL Renderer
+* :pr:`1075`: Add OpenGL Renderer
    Adds an OpenGLRenderer, OpenGLCamera, OpenGL-enabled Mobjects, and a ``--use_opengl_renderer`` flag. When this flag is passed, you can pass the ``-p`` flag to preview animations, the ``-w`` flag to generate video, and the ``-q`` flag to specify render quality. If you don't pass either the ``-p`` or the ``-w`` flag, nothing will happen. Scenes rendered with the OpenGL renderer must *only* use OpenGL-enabled Mobjects.
 
 Deprecated classes and functions
 --------------------------------
 
-* `#1124 <https://github.com/ManimCommunity/manim/pull/1124>`__: Deprecated :class:`ShowCreation` in favor of :class:`Create`
+* :pr:`1124`: Deprecated :class:`ShowCreation` in favor of :class:`Create`
    1. Deprecated :class:`ShowCreation` in favor of :class:`Create` across the library with the exception of the `show_creation` boolean variable `vector_space_scene.py`
    2. Added a deprecation warning in the original :class:`ShowCreation` class.
 
-* `#1110 <https://github.com/ManimCommunity/manim/pull/1110>`__: Deprecated SmallDot + OpenGLSmallDot
+* :pr:`1110`: Deprecated SmallDot + OpenGLSmallDot
    `SmallDot` isn't necessary and a deprecation warning will be raised. This will be removed in a future release.
 
 New features
 ------------
 
-* `#1037 <https://github.com/ManimCommunity/manim/pull/1037>`__: Added new fade and transform animations (:class:`~.TransformMatchingShapes`, :class:`~.TransformMatchingTex`, :class:`~.FadeTransform`) from 3b1b/manim
+* :pr:`1037`: Added new fade and transform animations (:class:`~.TransformMatchingShapes`, :class:`~.TransformMatchingTex`, :class:`~.FadeTransform`) from 3b1b/manim
    Added new Fade animation: :class:`~FadeOutToPoint`
    Added :class:`~FadeTransform` and :class:`~FadeTransformPieces` for transforming mobjects and submobjects with a fade
    Added :class:`~TransformMatchingShapes` and :class:`~TransformMatchingTex` for transforming mobjects and tex that have matching parts
 
-* `#1097 <https://github.com/ManimCommunity/manim/pull/1097>`__: Added 3D Mobject :class:`~.Dot3D`
+* :pr:`1097`: Added 3D Mobject :class:`~.Dot3D`
 
 
-* `#1074 <https://github.com/ManimCommunity/manim/pull/1074>`__: Added jupyter media_width option to the config
+* :pr:`1074`: Added jupyter media_width option to the config
 
 
-* `#1107 <https://github.com/ManimCommunity/manim/pull/1107>`__: Added :class:`~.Unwrite` animation class to complement :class:`~.Write`
+* :pr:`1107`: Added :class:`~.Unwrite` animation class to complement :class:`~.Write`
    Added :class:`Unwrite` which inherits from :class:`~.Write`. It automatically reverses the animation of :class:`~.Write` by passing the reversed rate function, but it also takes an additional boolean parameter `reverse` which, if `False`, renders the animation from left to right (assuming text oriented in the usual way), but if `True`, it renders right to left.
 
-* `#1085 <https://github.com/ManimCommunity/manim/pull/1085>`__: Added :class:`~.Angle` and :class:`~.RightAngle` for intersecting lines
+* :pr:`1085`: Added :class:`~.Angle` and :class:`~.RightAngle` for intersecting lines
    :class:`~.Angle` and :class:`~.RightAngle` both take two lines as input. If they intersect, or share a common vertex, an angle is drawn between them. Users can customize the look of the angle and also use a dotted right angle.
 
 Enhancements
 ------------
 
-* `#1144 <https://github.com/ManimCommunity/manim/pull/1144>`__: Improved quality of GIFs
+* :pr:`1144`: Improved quality of GIFs
 
 
-* `#1157 <https://github.com/ManimCommunity/manim/pull/1157>`__: Refresh triangulation on call to :meth:`~.OpenGLVMobject.apply_points_function`
+* :pr:`1157`: Refresh triangulation on call to :meth:`~.OpenGLVMobject.apply_points_function`
    Rotate called apply_points_function, which was previous not subclassed by OpenGLMobject - now it is. Then, the vertex normals can be updated too.
 
    Additionally, the old_points matrix would change after rotating, making the old points / new points test irrelevant. This is addressed with a .copy call.
 
-* `#1151 <https://github.com/ManimCommunity/manim/pull/1151>`__: Added parametric function support to :class:`OpenGLSurface`
+* :pr:`1151`: Added parametric function support to :class:`OpenGLSurface`
 
 
-* `#1139 <https://github.com/ManimCommunity/manim/pull/1139>`__: In-Code `config["preview"]` Support
+* :pr:`1139`: In-Code `config["preview"]` Support
 
 
-* `#1123 <https://github.com/ManimCommunity/manim/pull/1123>`__: Added caching, skipping, and user-specified background colors to the OpenGL renderer
+* :pr:`1123`: Added caching, skipping, and user-specified background colors to the OpenGL renderer
    OpenGL play logic has been improved to support caching and skipping with `-n` argument ( it is now similar to Cairo play logic). A random bug was fixed in OpenGLSurface and OpenGL background color can now be changed via `background_color` argument.
 
-* `#1118 <https://github.com/ManimCommunity/manim/pull/1118>`__: Allow passing animation arguments with .animate syntax
+* :pr:`1118`: Allow passing animation arguments with .animate syntax
    Users will now be able to do things like `obj.animate(run_time=2).method(arg)` if they want to specify animation arguments for an individual `.animate` call, and can still not specify any arguments like `obj.animate.method(arg)`.
 
    Passing animation arguments is only allowed directly after `.animate` is accessed, if passed elsewhere then a `ValueError` is raised.
 
-* `#718 <https://github.com/ManimCommunity/manim/pull/718>`__: Rotating the numbers in y axis
+* :pr:`718`: Rotating the numbers in y axis
    In Axes, the y axis will be rotated 90deg but the numbers are
    also rotated and shouldn't be. Fixes this issue.
 
-* `#1070 <https://github.com/ManimCommunity/manim/pull/1070>`__: Raise FileNotFoundError when unable to locate the .cfg file specified via ``--config_file``
+* :pr:`1070`: Raise FileNotFoundError when unable to locate the .cfg file specified via ``--config_file``
    Raising the error will stop script execution and let the user know that there are problems with the `--config_file` location instead of reverting back to the default configuration.
 
 Fixed bugs
 ----------
 
-* `#1224 <https://github.com/ManimCommunity/manim/pull/1224>`__: Fixed :class:`~.ShowIncreasingSubsets`, :class:`~.ShowSubmobjectsOneByOne`, and :class:`~.AddTextLetterByLetter`
+* :pr:`1224`: Fixed :class:`~.ShowIncreasingSubsets`, :class:`~.ShowSubmobjectsOneByOne`, and :class:`~.AddTextLetterByLetter`
 
 
-* `#1201 <https://github.com/ManimCommunity/manim/pull/1201>`__: Prevent crash on :meth:`~.Scene.embed` for empty scenes
+* :pr:`1201`: Prevent crash on :meth:`~.Scene.embed` for empty scenes
 
 
-* `#1192 <https://github.com/ManimCommunity/manim/pull/1192>`__: Fixed issue when an animation is cached, manim can't merge the partial movie files.
+* :pr:`1192`: Fixed issue when an animation is cached, manim can't merge the partial movie files.
 
 
-* `#1193 <https://github.com/ManimCommunity/manim/pull/1193>`__: Fixed using :class:`~.Animation` without a child :class:`~.Mobject` in :class:`~.AnimationGroup`
+* :pr:`1193`: Fixed using :class:`~.Animation` without a child :class:`~.Mobject` in :class:`~.AnimationGroup`
    `AnimationGroup` may now take `Animation` objects which do not have a child `Mobject`, such as `Wait`.
 
-* `#1170 <https://github.com/ManimCommunity/manim/pull/1170>`__: Fixed minor SVG parsing bugs
+* :pr:`1170`: Fixed minor SVG parsing bugs
 
 
-* `#1159 <https://github.com/ManimCommunity/manim/pull/1159>`__: Added support for multiple transforms in the same SVG element
+* :pr:`1159`: Added support for multiple transforms in the same SVG element
 
 
-* `#1156 <https://github.com/ManimCommunity/manim/pull/1156>`__: Fixed :class:`~.DrawBorderThenFill` to support OpenGL and improved type hints for some functions
+* :pr:`1156`: Fixed :class:`~.DrawBorderThenFill` to support OpenGL and improved type hints for some functions
    Fixed a bug in :class:`~.DrawBorderThenFill` that prevented :class:`~.Write` animations from working with :class:`~.OpenGLVMobjects` and slightly improved type hints for some animation functions to include :class:`~.OpenGLVMobject`.
 
-* `#1134 <https://github.com/ManimCommunity/manim/pull/1134>`__: Fixed the `-a` flag.
+* :pr:`1134`: Fixed the `-a` flag.
    The ``-a`` / ``--write-all`` flag was broken. When used, it would cause Manim to crash just after beginning to render the second scene.
 
-* `#1115 <https://github.com/ManimCommunity/manim/pull/1115>`__: Fixed bugs in :class:`~.OpenGLMobject` and added :class:`ApplyMethod` support
+* :pr:`1115`: Fixed bugs in :class:`~.OpenGLMobject` and added :class:`ApplyMethod` support
    Fixed undefined variables and converted :class:`Mobject` to :class:`OpenGLMobject`. Also, fixed assert statement in :class:`ApplyMethod`.
 
-* `#1092 <https://github.com/ManimCommunity/manim/pull/1092>`__: Refactored coordinate_systems.py, fixed bugs, added :class:`~.NumberPlane` test
+* :pr:`1092`: Refactored coordinate_systems.py, fixed bugs, added :class:`~.NumberPlane` test
    The default behavior of :meth:`~.Mobject.rotate` is to rotate about the center of :class:`~.Mobject`. :class:`~.NumberLine` is symmetric about the point at the number 0 only when ``|x_min|`` == ``|x_max|``. Ideally, the rotation should coincide with
    the point at number 0 on the line.
 
    Added a regression test and additionally fixed some bugs introduced in :pr:`718`.
 
-* `#1078 <https://github.com/ManimCommunity/manim/pull/1078>`__: Removed stray print statements from `__main__.py`
+* :pr:`1078`: Removed stray print statements from `__main__.py`
    Uses rich's print traceback instead and fixes an issue in printing the version twice when `manim --version` is called.
 
-* `#1086 <https://github.com/ManimCommunity/manim/pull/1086>`__: Fixed broken line spacing in :class:`~.Text`
+* :pr:`1086`: Fixed broken line spacing in :class:`~.Text`
    The `line_spacing` kwarg was missing when creating :class:`Text` Mobjects; this adds it.
 
-* `#1083 <https://github.com/ManimCommunity/manim/pull/1083>`__: Corrected the shape of :class:`~.Torus`
+* :pr:`1083`: Corrected the shape of :class:`~.Torus`
    :class:`Torus` draws a surface with an elliptical cross-section when `minor_radius` is different from 1. This PR ensures the cross-section is always a circle.
 
 Documentation-related changes
 -----------------------------
 
-* `#1217 <https://github.com/ManimCommunity/manim/pull/1217>`__: Copyedited the document on testing in our documentation
+* :pr:`1217`: Copyedited the document on testing in our documentation
 
 
-* `#1206 <https://github.com/ManimCommunity/manim/pull/1206>`__: Added Docstrings to :class:`~.Mobject`
+* :pr:`1206`: Added Docstrings to :class:`~.Mobject`
 
 
-* `#1218 <https://github.com/ManimCommunity/manim/pull/1218>`__: Removed BezierSpline from the example gallery
+* :pr:`1218`: Removed BezierSpline from the example gallery
 
 
-* `#1219 <https://github.com/ManimCommunity/manim/pull/1219>`__: Updated Dockerfile (include dependencies for building documentation), moved documentation to main README
+* :pr:`1219`: Updated Dockerfile (include dependencies for building documentation), moved documentation to main README
 
 
-* `#1209 <https://github.com/ManimCommunity/manim/pull/1209>`__: Added :ref_methods: to the manim directive
+* :pr:`1209`: Added :ref_methods: to the manim directive
    This allows class methods to be linked in the documentation. Checkout the `example references <https://docs.manim.community/en/latest/examples.html#movingaround>`_ below the code to see how this is used!
 
-* `#1204 <https://github.com/ManimCommunity/manim/pull/1204>`__: Added rotation example to example gallery
+* :pr:`1204`: Added rotation example to example gallery
 
 
-* `#1137 <https://github.com/ManimCommunity/manim/pull/1137>`__: Added GitHub Wiki pages on adding testing/documentation to Sphinx Docs
+* :pr:`1137`: Added GitHub Wiki pages on adding testing/documentation to Sphinx Docs
 
 
-* `#1114 <https://github.com/ManimCommunity/manim/pull/1114>`__: Added examples for :class:`~.Ellipse`, :class:`~.Polygon`, :class:`~.RegularPolygon`, :class:`~.Triangle` and :class:`~.RoundedRectangle`
+* :pr:`1114`: Added examples for :class:`~.Ellipse`, :class:`~.Polygon`, :class:`~.RegularPolygon`, :class:`~.Triangle` and :class:`~.RoundedRectangle`
 
 
-* `#1195 <https://github.com/ManimCommunity/manim/pull/1195>`__: Removed SmallDot from example
+* :pr:`1195`: Removed SmallDot from example
 
 
-* `#1130 <https://github.com/ManimCommunity/manim/pull/1130>`__: Added pre-commit to run black and flake8, updated contributing documentation accordingly
+* :pr:`1130`: Added pre-commit to run black and flake8, updated contributing documentation accordingly
 
 
-* `#1138 <https://github.com/ManimCommunity/manim/pull/1138>`__: Moved previous version changelogs to separate files; Added a Script to generate future changelogs
+* :pr:`1138`: Moved previous version changelogs to separate files; Added a Script to generate future changelogs
    This script quickly generates a changelog for whoever is making the release.
 
-* `#1190 <https://github.com/ManimCommunity/manim/pull/1190>`__: Added note in contributing guide to read the latest version of the documentation
+* :pr:`1190`: Added note in contributing guide to read the latest version of the documentation
 
 
-* `#1188 <https://github.com/ManimCommunity/manim/pull/1188>`__: Added sounds example to docs
+* :pr:`1188`: Added sounds example to docs
 
 
-* `#1165 <https://github.com/ManimCommunity/manim/pull/1165>`__: Added documentation for installing Manim on Colab
+* :pr:`1165`: Added documentation for installing Manim on Colab
 
 
-* `#1128 <https://github.com/ManimCommunity/manim/pull/1128>`__: Added examples for :class:`~.DashedLine`, :class:`~.TangentLine`, :class:`~.Elbow`, :class:`~.Arrow`, :class:`~.Vector`, :class:`~.DoubleArrow`
+* :pr:`1128`: Added examples for :class:`~.DashedLine`, :class:`~.TangentLine`, :class:`~.Elbow`, :class:`~.Arrow`, :class:`~.Vector`, :class:`~.DoubleArrow`
 
 
-* `#1177 <https://github.com/ManimCommunity/manim/pull/1177>`__: Replace links to the latest version of the documentation to the stable version
+* :pr:`1177`: Replace links to the latest version of the documentation to the stable version
 
 
-* `#1077 <https://github.com/ManimCommunity/manim/pull/1077>`__: Added details to :func:`~.Mobject.get_critical_point`
+* :pr:`1077`: Added details to :func:`~.Mobject.get_critical_point`
 
 
-* `#1154 <https://github.com/ManimCommunity/manim/pull/1154>`__: Fixed some typing hints. (ints to floats)
+* :pr:`1154`: Fixed some typing hints. (ints to floats)
 
 
-* `#1036 <https://github.com/ManimCommunity/manim/pull/1036>`__: Added :class:`~.SurroundingRectangle` to the example gallery
+* :pr:`1036`: Added :class:`~.SurroundingRectangle` to the example gallery
 
 
-* `#1103 <https://github.com/ManimCommunity/manim/pull/1103>`__: Added documentation and examples for Square, Dot, Circle and Rectangle
+* :pr:`1103`: Added documentation and examples for Square, Dot, Circle and Rectangle
 
 
-* `#1101 <https://github.com/ManimCommunity/manim/pull/1101>`__: Added documentation to :class:`~.Mobject`
+* :pr:`1101`: Added documentation to :class:`~.Mobject`
 
 
-* `#1088 <https://github.com/ManimCommunity/manim/pull/1088>`__: Added new svg files to documentation and imports
+* :pr:`1088`: Added new svg files to documentation and imports
    In particular, SVGPathMobject, VMobjectFromPathstring, and the style_utils functions to manim's namespace.
 
-* `#1076 <https://github.com/ManimCommunity/manim/pull/1076>`__: Improve documentation for GraphScene
+* :pr:`1076`: Improve documentation for GraphScene
    Updated `coords_to_point` and `point_to_coords` under `manim/scene/graph_scene.py` as the dosctring of each function confusingly described the opposite of what it is supposed to do.
 
 Changes concerning the testing system
 -------------------------------------
 
-* `#1160 <https://github.com/ManimCommunity/manim/pull/1160>`__: Enable CI testing for OpenGL
+* :pr:`1160`: Enable CI testing for OpenGL
 
 
-* `#1100 <https://github.com/ManimCommunity/manim/pull/1100>`__: Rewrote test cases to use sys.executable in the command instead of "python"
+* :pr:`1100`: Rewrote test cases to use sys.executable in the command instead of "python"
    Tests would fail due to `capture()` not spawning a subshell in the correct environment, so when python was called, the test would be unable to find necessary packages.
 
-* `#1079 <https://github.com/ManimCommunity/manim/pull/1079>`__: Removed the hardcoded value, `manim`, in `test_version.py`
+* :pr:`1079`: Removed the hardcoded value, `manim`, in `test_version.py`
 
 
 Changes to our development infrastructure
 -----------------------------------------
 
-* `#1213 <https://github.com/ManimCommunity/manim/pull/1213>`__: Updated TinyTex dependencies
+* :pr:`1213`: Updated TinyTex dependencies
 
 
-* `#1187 <https://github.com/ManimCommunity/manim/pull/1187>`__: Add CodeCov to Github Workflow
+* :pr:`1187`: Add CodeCov to Github Workflow
 
 
-* `#1166 <https://github.com/ManimCommunity/manim/pull/1166>`__: CI: Use poetry's cache dir rather than pip
+* :pr:`1166`: CI: Use poetry's cache dir rather than pip
 
 
-* `#1071 <https://github.com/ManimCommunity/manim/pull/1071>`__: Enable pytest-cov based code coverage
+* :pr:`1071`: Enable pytest-cov based code coverage
    - Include pytest-cov as a python module as part of developer dependencies
    - In updating poetry to include pytest-cov, manimpango moved from version 0.2.3 to 0.2.4, and libpango1.0-dev needed to be installed in Ubuntu.
    - Add to the CI workflow (`ci.yml`) to create and upload test coverage.
 
-* `#1073 <https://github.com/ManimCommunity/manim/pull/1073>`__: Removed "one line summary" from PULL_REQUEST_TEMPLATE.md
+* :pr:`1073`: Removed "one line summary" from PULL_REQUEST_TEMPLATE.md
 
 
 Code quality improvements and similar refactors
 -----------------------------------------------
 
-* `#1167 <https://github.com/ManimCommunity/manim/pull/1167>`__: Merge :class:`~.OpenGLMobject` and :class:`~.Mobject`
+* :pr:`1167`: Merge :class:`~.OpenGLMobject` and :class:`~.Mobject`
 
 
-* `#1164 <https://github.com/ManimCommunity/manim/pull/1164>`__: Fixed single PEP8 style in `cairo_renderer.py`
+* :pr:`1164`: Fixed single PEP8 style in `cairo_renderer.py`
 
 
-* `#1140 <https://github.com/ManimCommunity/manim/pull/1140>`__: Flake8 Compat & Code Cleanup
+* :pr:`1140`: Flake8 Compat & Code Cleanup
 
 
-* `#1019 <https://github.com/ManimCommunity/manim/pull/1019>`__: Refactored :meth:`~.Scene.play`
+* :pr:`1019`: Refactored :meth:`~.Scene.play`
    - Removed the _**three**_ decorators of :meth:`~.Scene.play`, in particular: caching logic and file writer logic are now included within :meth:`~.Scene.play` (it wasn't possible before, because `scene.wait` and `scene.play` were two different things).
    - Added `is_static_wait` attributes to Wait. (<=> if wait is a frozen frame).
    - Renamed and moved `scene.add_static_frame` to `renderer.freeze_current_frame`.

--- a/docs/source/changelog/0.6.0-changelog.rst
+++ b/docs/source/changelog/0.6.0-changelog.rst
@@ -81,16 +81,16 @@ A total of 112 pull requests were merged for this release.
 Breaking changes
 ----------------
 
-* `#1347 <https://github.com/ManimCommunity/manim/pull/1347>`__: Restructure vector_field module and add documentation
+* :pr:`1347`: Restructure vector_field module and add documentation
    :class`~.VectorField` is renamed to :class:`~.ArrowVectorField` and a new class :class:`~.VectorField` is added as a superclass for :class:`~.ArrowVectorField` and :class:`~.StreamLines`. :class:`~.AnimatedStreamLines` is removed. It's functionality is moved to :class:`~.StreamLines`. Added a lot of new options when working with vector fields. :class:`~.ShowPassingFlashWithThinningStrokeWidth` was moved to the indication module.
 
-* `#1161 <https://github.com/ManimCommunity/manim/pull/1161>`__: Upgrades to CoordinateSystem and graphing.
+* :pr:`1161`: Upgrades to CoordinateSystem and graphing.
    Breaking changes were introduced to :class:`~.Axes`, :class:`~.ThreeDAxes`, :class:`~.NumberPlane` and :class:`~.NumberLine`
    All the above now use lists to construct their ranges as opposed to explicitly defining these values. `x_range` has replaced `x_min`, `x_max` and defining the step is much easier with `x_step` --> ``x_range``  :  ``[x_min, x_max, x_step]``. There were also many upgrades to these classes which improve their functionality and appearance.
 
    ``NumberLineOld`` was introduced to continue support for :class:`~.GraphScene`, although we are moving away from GraphScene and intend to deprecate it in a future release.
 
-* `#1013 <https://github.com/ManimCommunity/manim/pull/1013>`__: Refactored the Command Line Interface to use Click instead of Argparse
+* :pr:`1013`: Refactored the Command Line Interface to use Click instead of Argparse
    This change breaks the CLI API to organize the structure of Manim Community's commands, options, and arguments.
 
    To be more in line with POSIX compliant CLI conventions, options for commands are given *BEFORE* their arguments.
@@ -109,36 +109,36 @@ Breaking changes
 Deprecated classes and functions
 --------------------------------
 
-* `#1431 <https://github.com/ManimCommunity/manim/pull/1431>`__: Fix CLI bugs
+* :pr:`1431`: Fix CLI bugs
    - Fixed conflict with ``-f`` which was previously assigned to both ``--show_in_file_browser`` and ``--format`` by removing ``-f`` from ``--format``. A warning is issued that ``-f`` will soon move to ``--format``.
    - Added back in flags to render the files as gif/last frame. Deprecated them in favor of ``--format``.
    - Fixed the broken ``--output_file``/``-o`` option.
    - Fixed an issue where the ``-qh`` quality option was interpreted as ``-q`` ``-h``, prompting the help page.
 
-* `#1354 <https://github.com/ManimCommunity/manim/pull/1354>`__: Refactored a few functions in space_ops.py, deprecated :func:`~.angle_between`
+* :pr:`1354`: Refactored a few functions in space_ops.py, deprecated :func:`~.angle_between`
 
 
-* `#1370 <https://github.com/ManimCommunity/manim/pull/1370>`__: Remove TexMobject and TextMobject
+* :pr:`1370`: Remove TexMobject and TextMobject
    TexMobject and TextMobject have been deprecated for a while, they are now fully removed. Use Tex or MathTex instead.
 
-* `#1349 <https://github.com/ManimCommunity/manim/pull/1349>`__: Removed the deprecated ``SmallDot`` mobject
+* :pr:`1349`: Removed the deprecated ``SmallDot`` mobject
 
 
-* `#1259 <https://github.com/ManimCommunity/manim/pull/1259>`__: Removed deprecated CairoText class
+* :pr:`1259`: Removed deprecated CairoText class
 
 New features
 ------------
 
-* `#1386 <https://github.com/ManimCommunity/manim/pull/1386>`__: Implement utility methods for adding/removing vertices and edges of graphs; allow custom mobjects as vertices
+* :pr:`1386`: Implement utility methods for adding/removing vertices and edges of graphs; allow custom mobjects as vertices
 
 
-* `#1385 <https://github.com/ManimCommunity/manim/pull/1385>`__: Added :meth:`~.Axes.get_line_graph` for plotting a line graph
+* :pr:`1385`: Added :meth:`~.Axes.get_line_graph` for plotting a line graph
    Added :meth:`~.Axes.get_line_graph` that returns a line graph from lists of points along x, y and z (optional) axes.
 
-* `#1381 <https://github.com/ManimCommunity/manim/pull/1381>`__: Hot reloading for the OpenGL renderer
+* :pr:`1381`: Hot reloading for the OpenGL renderer
    Rerun scene when the input file is modified
 
-* `#1383 <https://github.com/ManimCommunity/manim/pull/1383>`__: Overhaul of the :mod:`~.animation.indication` module interfaces
+* :pr:`1383`: Overhaul of the :mod:`~.animation.indication` module interfaces
    - Added class `Circumscribe` combining functionality of `CircleIndicate`, `AnimationOnSurroundingRectangle`, `ShowPassingFlashAround`, `ShowCreationThenDestructionAround`, `ShowCreationThenFadeAround`, which have all been deprecated.
    - Changes to `Flash`: `flash_radius` parameter now defines inner radius of the animation. Added new parameter `time_width`.
    - `ShowCreationThenDestruction` has been deprecated in favor of `ShowPassingFlash`
@@ -147,329 +147,329 @@ New features
    - Added documentation and examples to all the above
    - Other minor enhancements and bug-fixes
 
-* `#1348 <https://github.com/ManimCommunity/manim/pull/1348>`__: Added :class:`~.Polyhedron`, and platonic solids :class:`~.Tetrahedron`, :class:`~.Octahedron`, :class:`~.Icosahedron` and :class:`~.Dodecahedron`
+* :pr:`1348`: Added :class:`~.Polyhedron`, and platonic solids :class:`~.Tetrahedron`, :class:`~.Octahedron`, :class:`~.Icosahedron` and :class:`~.Dodecahedron`
 
 
-* `#1285 <https://github.com/ManimCommunity/manim/pull/1285>`__: Add :meth:`~.Scene.interactive_embed` for OpenGL rendering
+* :pr:`1285`: Add :meth:`~.Scene.interactive_embed` for OpenGL rendering
    :meth:`~.Scene.interactive_embed` allows interaction with Scene via mouse and keyboard as well as dynamic commands via an iPython terminal.
 
-* `#1261 <https://github.com/ManimCommunity/manim/pull/1261>`__: Render image automatically if no animation is played in a scene
+* :pr:`1261`: Render image automatically if no animation is played in a scene
    - If no animations in scene and asked to preview/render a video, preview/render an image instead of raising a confusing error.
 
-* `#1200 <https://github.com/ManimCommunity/manim/pull/1200>`__: Add text and SVG mobjects to OpenGL
+* :pr:`1200`: Add text and SVG mobjects to OpenGL
    Added OpenGL-compatible text and SVG mobjects
 
 Enhancements
 ------------
 
-* `#1398 <https://github.com/ManimCommunity/manim/pull/1398>`__: Fix and enhance `Mobject.arrange_in_grid`
+* :pr:`1398`: Fix and enhance `Mobject.arrange_in_grid`
    `arrange_in_grid` now actually arranges submobjects in a grid. Added new parameters `buff`, `cell_alignment`, `row_alignments`, `col_alignments`, `row_heights`, `col_widths`, `flow_order`.
 
-* `#1407 <https://github.com/ManimCommunity/manim/pull/1407>`__: Fix bug and rename :meth:`vector_coordinate_label` to :meth:`~.Vector.coordinate_label` and move it to :class:`geometry.py`
+* :pr:`1407`: Fix bug and rename :meth:`vector_coordinate_label` to :meth:`~.Vector.coordinate_label` and move it to :class:`geometry.py`
 
 
-* `#1380 <https://github.com/ManimCommunity/manim/pull/1380>`__: Allow image objects as background images
+* :pr:`1380`: Allow image objects as background images
 
 
-* `#1391 <https://github.com/ManimCommunity/manim/pull/1391>`__: Add `path_arc` support to `.animate` syntax
+* :pr:`1391`: Add `path_arc` support to `.animate` syntax
    The parameter `path_arc` of :class:`~.Transform` now works with the `.animate` syntax
 
-* `#1364 <https://github.com/ManimCommunity/manim/pull/1364>`__: Added :meth:`~.Mobject.match_points`
+* :pr:`1364`: Added :meth:`~.Mobject.match_points`
    - Added :func:`~.Mobject.match_points`, which transforms the points, positions and submobjects of a Mobject to match that of the other while keeping style unchanged.
 
-* `#1363 <https://github.com/ManimCommunity/manim/pull/1363>`__: Change of TeX compiler and output file format
+* :pr:`1363`: Change of TeX compiler and output file format
 
 
-* `#1359 <https://github.com/ManimCommunity/manim/pull/1359>`__: Make FILE a required argument
+* :pr:`1359`: Make FILE a required argument
    * Make `FILE` a required argument, `manim/cli/render/commands.py`:L30
 
-* `#1304 <https://github.com/ManimCommunity/manim/pull/1304>`__: Improve Tex string splitting at double braces: only split for double brace groups
+* :pr:`1304`: Improve Tex string splitting at double braces: only split for double brace groups
 
 
-* `#1340 <https://github.com/ManimCommunity/manim/pull/1340>`__: Add OpenGL support to the new transform animations
+* :pr:`1340`: Add OpenGL support to the new transform animations
    Made `FadeTransform`, `FadeTransformPieces`, `TransformMatchingShapes` and `TransformMatchingTex` compatible with OpenGL rendering.
 
-* `#1343 <https://github.com/ManimCommunity/manim/pull/1343>`__: Make TexTemplate() simple, but keep Tex()'s default template
+* :pr:`1343`: Make TexTemplate() simple, but keep Tex()'s default template
    TexTemplate() now returns a simple tex template.
 
-* `#1321 <https://github.com/ManimCommunity/manim/pull/1321>`__: Add OpenGL support to :class:`~.AnimationGroup`
+* :pr:`1321`: Add OpenGL support to :class:`~.AnimationGroup`
 
 
-* `#1302 <https://github.com/ManimCommunity/manim/pull/1302>`__: Raise appropriate errors in :meth:`~.VMobject.point_from_proportion`
+* :pr:`1302`: Raise appropriate errors in :meth:`~.VMobject.point_from_proportion`
    - Raise an error if the ``alpha`` argument is not between 0 and 1.
    - Raise an error if the :class:`~.VMobject` has no points.
 
-* `#1315 <https://github.com/ManimCommunity/manim/pull/1315>`__: Fix performance issues with :meth:`~.VMobject.get_arc_length`, stemming from :pr:`1274`
+* :pr:`1315`: Fix performance issues with :meth:`~.VMobject.get_arc_length`, stemming from :pr:`1274`
 
 
-* `#1320 <https://github.com/ManimCommunity/manim/pull/1320>`__: Add `jpeg` extension to the default image extensions
+* :pr:`1320`: Add `jpeg` extension to the default image extensions
 
 
-* `#1234 <https://github.com/ManimCommunity/manim/pull/1234>`__: Added new method :meth:`~.Mobject.get_midpoint`
+* :pr:`1234`: Added new method :meth:`~.Mobject.get_midpoint`
    Implemented :meth:`~.Mobject.get_midpoint` to return the point that is the middle of the stroke line of an mobject.
 
-* `#1237 <https://github.com/ManimCommunity/manim/pull/1237>`__: Notify user if they are using an outdated version of Manim
+* :pr:`1237`: Notify user if they are using an outdated version of Manim
 
 
-* `#1308 <https://github.com/ManimCommunity/manim/pull/1308>`__: Improved :class:`~.ManimBanner` animations
+* :pr:`1308`: Improved :class:`~.ManimBanner` animations
 
 
-* `#1275 <https://github.com/ManimCommunity/manim/pull/1275>`__: Add SVG <line> element support to :class:`~.SVGMobject`
+* :pr:`1275`: Add SVG <line> element support to :class:`~.SVGMobject`
 
 
-* `#1238 <https://github.com/ManimCommunity/manim/pull/1238>`__: Add parameter ``about_point`` for :meth:`~.Mobject.rotate`
+* :pr:`1238`: Add parameter ``about_point`` for :meth:`~.Mobject.rotate`
 
 
-* `#1260 <https://github.com/ManimCommunity/manim/pull/1260>`__: Change Brace from Tex to SVG (#1258)
+* :pr:`1260`: Change Brace from Tex to SVG (#1258)
 
 
-* `#1122 <https://github.com/ManimCommunity/manim/pull/1122>`__: Support for specifying the interpolation algorithms for individual ImageMobjects
+* :pr:`1122`: Support for specifying the interpolation algorithms for individual ImageMobjects
 
 
-* `#1283 <https://github.com/ManimCommunity/manim/pull/1283>`__: Set default value of keyword ``random_seed`` in :class:`~.Scene` to ``None`` (was 0 and fixed before)
+* :pr:`1283`: Set default value of keyword ``random_seed`` in :class:`~.Scene` to ``None`` (was 0 and fixed before)
 
 
-* `#1220 <https://github.com/ManimCommunity/manim/pull/1220>`__: Added sanity checks to :meth:`~.Mobject.add_to_back` for Mobjects
+* :pr:`1220`: Added sanity checks to :meth:`~.Mobject.add_to_back` for Mobjects
    Add Mobject `add_to_back` sanity checks:
    - Raises ValueError when Mobject tries to add itself
    - Raises TypeError when a non-Mobject is added
    - Filters out incoming duplicate submobjects if at least one instance of that submobject exists in the list
 
-* `#1249 <https://github.com/ManimCommunity/manim/pull/1249>`__: Set corners of :class:`~.Rectangle` in counterclockwise direction
+* :pr:`1249`: Set corners of :class:`~.Rectangle` in counterclockwise direction
    This improves the look of transformations between rectangles and other simple mobjects.
 
-* `#1248 <https://github.com/ManimCommunity/manim/pull/1248>`__: Add Copy function to TexTemplate
+* :pr:`1248`: Add Copy function to TexTemplate
 
 
 Fixed bugs
 ----------
 
-* `#1368 <https://github.com/ManimCommunity/manim/pull/1368>`__: Added a check to ensure checking for the latest version was successful
+* :pr:`1368`: Added a check to ensure checking for the latest version was successful
 
 
-* `#1413 <https://github.com/ManimCommunity/manim/pull/1413>`__: Prevent duplication of the same mobject when adding to submobjects via :meth:`~.Mobject.add_to_back`
+* :pr:`1413`: Prevent duplication of the same mobject when adding to submobjects via :meth:`~.Mobject.add_to_back`
    Fixes #1412
 
-* `#1395 <https://github.com/ManimCommunity/manim/pull/1395>`__: SVG transforms now handle exponent notation (6.02e23)
+* :pr:`1395`: SVG transforms now handle exponent notation (6.02e23)
 
 
-* `#1355 <https://github.com/ManimCommunity/manim/pull/1355>`__: Rewrite `put_start_and_end_on` to work in 3D
+* :pr:`1355`: Rewrite `put_start_and_end_on` to work in 3D
 
 
-* `#1346 <https://github.com/ManimCommunity/manim/pull/1346>`__: Fixed errors introduced by stray print in :class:`~.MathTex`
+* :pr:`1346`: Fixed errors introduced by stray print in :class:`~.MathTex`
 
 
-* `#1305 <https://github.com/ManimCommunity/manim/pull/1305>`__: Automatically remove long tick marks not within the range of the :class:`~NumberLine`
+* :pr:`1305`: Automatically remove long tick marks not within the range of the :class:`~NumberLine`
 
 
-* `#1296 <https://github.com/ManimCommunity/manim/pull/1296>`__: Fix random pipeline TeX failures
+* :pr:`1296`: Fix random pipeline TeX failures
 
 
-* `#1274 <https://github.com/ManimCommunity/manim/pull/1274>`__: Fix :meth:`~.VMobject.point_from_proportion` to account for the length of curves.
+* :pr:`1274`: Fix :meth:`~.VMobject.point_from_proportion` to account for the length of curves.
    - Add :meth:`~.VMobject.get_nth_curve_function_with_length` and associated functions.
    - Change :meth:`~.VMobject.point_from_proportion` to use these functions to account for curve length.
 
 Documentation-related changes
 -----------------------------
 
-* `#1430 <https://github.com/ManimCommunity/manim/pull/1430>`__: Un-deprecated GraphScene (will be deprecated later), fixed an old-style call to NumberPlane
+* :pr:`1430`: Un-deprecated GraphScene (will be deprecated later), fixed an old-style call to NumberPlane
    - More work is required in order to fully replace `GraphScene` via `Axes`, thus `GraphScene` is not deprecated yet.
    - Fixed one example in which the old `NumberPlane` syntax was used.
 
-* `#1425 <https://github.com/ManimCommunity/manim/pull/1425>`__: Added a "How to Cite Manim" section to the Readme
+* :pr:`1425`: Added a "How to Cite Manim" section to the Readme
 
 
-* `#1387 <https://github.com/ManimCommunity/manim/pull/1387>`__: Added Guide to Contribute Examples from GitHub Wiki to Documentation
+* :pr:`1387`: Added Guide to Contribute Examples from GitHub Wiki to Documentation
    Added a Guide
 
-* `#1424 <https://github.com/ManimCommunity/manim/pull/1424>`__: Fixed all current docbuild warnings
+* :pr:`1424`: Fixed all current docbuild warnings
 
 
-* `#1389 <https://github.com/ManimCommunity/manim/pull/1389>`__: Adding Admonitions Tutorial to docs
+* :pr:`1389`: Adding Admonitions Tutorial to docs
 
 
-* `#1341 <https://github.com/ManimCommunity/manim/pull/1341>`__: Reduce complexity of ThreeDSurfacePlot example
+* :pr:`1341`: Reduce complexity of ThreeDSurfacePlot example
 
 
-* `#1362 <https://github.com/ManimCommunity/manim/pull/1362>`__: Quick reference to modules
+* :pr:`1362`: Quick reference to modules
 
 
-* `#1376 <https://github.com/ManimCommunity/manim/pull/1376>`__: Add flake8 and isort in docs
+* :pr:`1376`: Add flake8 and isort in docs
    added 'flake8' and 'isort' usages to docs
 
-* `#1360 <https://github.com/ManimCommunity/manim/pull/1360>`__: Grammatical error corrections in documentation
+* :pr:`1360`: Grammatical error corrections in documentation
    changed a few sentences in docs/source
 
-* `#1351 <https://github.com/ManimCommunity/manim/pull/1351>`__: Some more typehints
+* :pr:`1351`: Some more typehints
 
 
-* `#1358 <https://github.com/ManimCommunity/manim/pull/1358>`__: Fixed link to installation instructions for developers
+* :pr:`1358`: Fixed link to installation instructions for developers
 
 
-* `#1338 <https://github.com/ManimCommunity/manim/pull/1338>`__: Added documentation guidelines for type hints
+* :pr:`1338`: Added documentation guidelines for type hints
 
 
-* `#1342 <https://github.com/ManimCommunity/manim/pull/1342>`__: Multiple ValueTracker example for docs
+* :pr:`1342`: Multiple ValueTracker example for docs
 
 
-* `#1210 <https://github.com/ManimCommunity/manim/pull/1210>`__: Added tutorial chapter on coordinates of an mobject
+* :pr:`1210`: Added tutorial chapter on coordinates of an mobject
 
 
-* `#1335 <https://github.com/ManimCommunity/manim/pull/1335>`__: Added import statements to examples in documentation
+* :pr:`1335`: Added import statements to examples in documentation
 
 
-* `#1245 <https://github.com/ManimCommunity/manim/pull/1245>`__: Added filled angle Example
+* :pr:`1245`: Added filled angle Example
 
 
-* `#1328 <https://github.com/ManimCommunity/manim/pull/1328>`__: Docs: Update Brace example
+* :pr:`1328`: Docs: Update Brace example
 
 
-* `#1326 <https://github.com/ManimCommunity/manim/pull/1326>`__: Improve documentation of :class:`~.ManimMagic` (in particular: fix documented order of CLI flags)
+* :pr:`1326`: Improve documentation of :class:`~.ManimMagic` (in particular: fix documented order of CLI flags)
 
 
-* `#1323 <https://github.com/ManimCommunity/manim/pull/1323>`__: Blacken Docs Strings
+* :pr:`1323`: Blacken Docs Strings
 
 
-* `#1300 <https://github.com/ManimCommunity/manim/pull/1300>`__: Added typehints for :class:`~.ValueTracker`
+* :pr:`1300`: Added typehints for :class:`~.ValueTracker`
 
 
-* `#1301 <https://github.com/ManimCommunity/manim/pull/1301>`__: Added further docstrings and typehints to :class:`~.Mobject`
+* :pr:`1301`: Added further docstrings and typehints to :class:`~.Mobject`
 
 
-* `#1298 <https://github.com/ManimCommunity/manim/pull/1298>`__: Add double backquotes for rst code samples (value_tracker.py)
+* :pr:`1298`: Add double backquotes for rst code samples (value_tracker.py)
 
 
-* `#1297 <https://github.com/ManimCommunity/manim/pull/1297>`__: Change docs to use viewcode extension instead of linkcode
+* :pr:`1297`: Change docs to use viewcode extension instead of linkcode
    Switched ``sphinx.ext.linkcode`` to ``sphinx.ext.viewcode`` and removed ``linkcode_resolve`` in ``conf.py``.
 
-* `#1246 <https://github.com/ManimCommunity/manim/pull/1246>`__: Added docstrings for :class:`~.ValueTracker`
+* :pr:`1246`: Added docstrings for :class:`~.ValueTracker`
 
 
-* `#1251 <https://github.com/ManimCommunity/manim/pull/1251>`__: Switch documentation from guzzle-sphinx-theme to furo
+* :pr:`1251`: Switch documentation from guzzle-sphinx-theme to furo
 
 
-* `#1232 <https://github.com/ManimCommunity/manim/pull/1232>`__: Further docstrings and examples for :class:`~.Mobject`
+* :pr:`1232`: Further docstrings and examples for :class:`~.Mobject`
 
 
-* `#1291 <https://github.com/ManimCommunity/manim/pull/1291>`__: Grammar improvements in README.md
+* :pr:`1291`: Grammar improvements in README.md
 
 
-* `#1269 <https://github.com/ManimCommunity/manim/pull/1269>`__: Add documentation about :meth:`~.set_color_by_tex`
+* :pr:`1269`: Add documentation about :meth:`~.set_color_by_tex`
 
 
-* `#1284 <https://github.com/ManimCommunity/manim/pull/1284>`__: Updated readme by providing the correct link to the example_scenes
+* :pr:`1284`: Updated readme by providing the correct link to the example_scenes
 
 
-* `#1029 <https://github.com/ManimCommunity/manim/pull/1029>`__: Added example jupyter notebook into the examples folders
+* :pr:`1029`: Added example jupyter notebook into the examples folders
 
 
-* `#1279 <https://github.com/ManimCommunity/manim/pull/1279>`__: Added sphinx requirements to pyproject.toml
+* :pr:`1279`: Added sphinx requirements to pyproject.toml
    New contributors who wanted to build the sphinx documentation had an extra step that could be removed by making use of ``poetry install``. This removes the developer's need for ``pip install -r requirements.txt``.
 
-* `#1268 <https://github.com/ManimCommunity/manim/pull/1268>`__: Added documentation explaining the differences between manim versions
+* :pr:`1268`: Added documentation explaining the differences between manim versions
 
 
-* `#1247 <https://github.com/ManimCommunity/manim/pull/1247>`__: Added warning for the usage of `animate`
+* :pr:`1247`: Added warning for the usage of `animate`
 
 
-* `#1242 <https://github.com/ManimCommunity/manim/pull/1242>`__: Added an example for the manim colormap
+* :pr:`1242`: Added an example for the manim colormap
 
 
-* `#1239 <https://github.com/ManimCommunity/manim/pull/1239>`__: Add TinyTex installation instructions
+* :pr:`1239`: Add TinyTex installation instructions
 
 
-* `#1231 <https://github.com/ManimCommunity/manim/pull/1231>`__: Improve changelog generation script
+* :pr:`1231`: Improve changelog generation script
 
 
 Changes concerning the testing system
 -------------------------------------
 
-* `#1299 <https://github.com/ManimCommunity/manim/pull/1299>`__: Red pixels (different value) now appear over green pixels (same value) in GraphicalUnitTest
+* :pr:`1299`: Red pixels (different value) now appear over green pixels (same value) in GraphicalUnitTest
 
 
 Changes to our development infrastructure
 -----------------------------------------
 
-* `#1436 <https://github.com/ManimCommunity/manim/pull/1436>`__: Cache poetry venv with `pyproject.toml` hash in key
+* :pr:`1436`: Cache poetry venv with `pyproject.toml` hash in key
    Cache poetry venv with `pyproject.toml` hash in key
 
-* `#1435 <https://github.com/ManimCommunity/manim/pull/1435>`__: CI: Update poetry cache when new version is released
+* :pr:`1435`: CI: Update poetry cache when new version is released
    Fix `test_version` failure in CI when using cached poetry venv
 
-* `#1427 <https://github.com/ManimCommunity/manim/pull/1427>`__: Add URL's to pyproject.toml
+* :pr:`1427`: Add URL's to pyproject.toml
 
 
-* `#1421 <https://github.com/ManimCommunity/manim/pull/1421>`__: Updated changelog generator's labels and removed pre-commit bot from changelog
+* :pr:`1421`: Updated changelog generator's labels and removed pre-commit bot from changelog
 
 
-* `#1339 <https://github.com/ManimCommunity/manim/pull/1339>`__: CI: Fix macOS installation error from creating file in read-only file system
+* :pr:`1339`: CI: Fix macOS installation error from creating file in read-only file system
 
 
-* `#1257 <https://github.com/ManimCommunity/manim/pull/1257>`__: CI: Caching ffmpeg, tinytex dependencies and poetry venv
+* :pr:`1257`: CI: Caching ffmpeg, tinytex dependencies and poetry venv
    CI: Caching ffmpeg, tinytex dependencies and poetry venv
 
-* `#1294 <https://github.com/ManimCommunity/manim/pull/1294>`__: Added mixed-line-ending to .pre-commit-config.yaml
+* :pr:`1294`: Added mixed-line-ending to .pre-commit-config.yaml
 
 
-* `#1278 <https://github.com/ManimCommunity/manim/pull/1278>`__: Fixed flake8 errors and removed linter/formatter workflows
+* :pr:`1278`: Fixed flake8 errors and removed linter/formatter workflows
 
 
-* `#1270 <https://github.com/ManimCommunity/manim/pull/1270>`__: Added isort to pre_commit file
+* :pr:`1270`: Added isort to pre_commit file
 
 
-* `#1263 <https://github.com/ManimCommunity/manim/pull/1263>`__: CI: Turn off experimental installer for poetry to fix installation errors
+* :pr:`1263`: CI: Turn off experimental installer for poetry to fix installation errors
    - Turn off experimental installer for poetry to prevent manim installation errors for packages.
    - Downgrade py39 to py38 for flake checks as `pip` does not enjoy py39, along with `poetry`.
 
-* `#1255 <https://github.com/ManimCommunity/manim/pull/1255>`__: CI: Fix macOS pipeline failure
+* :pr:`1255`: CI: Fix macOS pipeline failure
    Update `ci.yml` to update and upgrade brew if necessary before installing dependencies, and remove the unsupported `dvisvgm.86_64-darwin` package.
 
-* `#1254 <https://github.com/ManimCommunity/manim/pull/1254>`__: Removed the comment warning that GitHub doesn't allow uploading video in the issue templates.
+* :pr:`1254`: Removed the comment warning that GitHub doesn't allow uploading video in the issue templates.
 
 
-* `#1216 <https://github.com/ManimCommunity/manim/pull/1216>`__: Use actions/checkout for cloning repository; black-checks
+* :pr:`1216`: Use actions/checkout for cloning repository; black-checks
 
 
-* `#1235 <https://github.com/ManimCommunity/manim/pull/1235>`__: Fixed version of decorator at <5.0.0
+* :pr:`1235`: Fixed version of decorator at <5.0.0
 
 
 Code quality improvements and similar refactors
 -----------------------------------------------
 
-* `#1411 <https://github.com/ManimCommunity/manim/pull/1411>`__: Change `Union[float, int]` to just `float` according to PEP 484
+* :pr:`1411`: Change `Union[float, int]` to just `float` according to PEP 484
 
 
-* `#1241 <https://github.com/ManimCommunity/manim/pull/1241>`__: Type Annotations: Fixing errors showing up in static type checking tool mypy
+* :pr:`1241`: Type Annotations: Fixing errors showing up in static type checking tool mypy
 
 
-* `#1319 <https://github.com/ManimCommunity/manim/pull/1319>`__: Fix mean/meant typo
+* :pr:`1319`: Fix mean/meant typo
    Fix typo in docs
 
-* `#1313 <https://github.com/ManimCommunity/manim/pull/1313>`__: Singular typo fix on the Quickstart page in documentation
+* :pr:`1313`: Singular typo fix on the Quickstart page in documentation
 
 
-* `#1292 <https://github.com/ManimCommunity/manim/pull/1292>`__: Remove unnecessary imports from files
+* :pr:`1292`: Remove unnecessary imports from files
    Imports reduced in a bunch of files
 
-* `#1295 <https://github.com/ManimCommunity/manim/pull/1295>`__: Fix grammar and typos in the CODE OF CONDUCT
+* :pr:`1295`: Fix grammar and typos in the CODE OF CONDUCT
 
 
-* `#1293 <https://github.com/ManimCommunity/manim/pull/1293>`__: Minor fixes - reduce lines
+* :pr:`1293`: Minor fixes - reduce lines
    Remove unnecessary lines
 
-* `#1281 <https://github.com/ManimCommunity/manim/pull/1281>`__: Remove all Carriage Return characters in our files
+* :pr:`1281`: Remove all Carriage Return characters in our files
 
 
-* `#1178 <https://github.com/ManimCommunity/manim/pull/1178>`__: Format Imports using Isort
+* :pr:`1178`: Format Imports using Isort
 
 
-* `#1233 <https://github.com/ManimCommunity/manim/pull/1233>`__: Fix deprecation warning for ``--use_opengl_renderer`` and ``--use_webgl_renderer``
+* :pr:`1233`: Fix deprecation warning for ``--use_opengl_renderer`` and ``--use_webgl_renderer``
 
 
-* `#1282 <https://github.com/ManimCommunity/manim/pull/1282>`__: Fix typing hints in vectorized_mobject.py based on mypy
+* :pr:`1282`: Fix typing hints in vectorized_mobject.py based on mypy
 
 
 New releases
 ------------
 
-* `#1434 <https://github.com/ManimCommunity/manim/pull/1434>`__: Prepare v0.6.0
+* :pr:`1434`: Prepare v0.6.0

--- a/docs/source/changelog/0.7.0-changelog.rst
+++ b/docs/source/changelog/0.7.0-changelog.rst
@@ -87,20 +87,20 @@ A total of 87 pull requests were merged for this release.
 Breaking changes
 ----------------
 
-* `#1521 <https://github.com/ManimCommunity/manim/pull/1521>`__: Improve :class:`~.Animation` docs
+* :pr:`1521`: Improve :class:`~.Animation` docs
    - Improve documentation of the :class:`~.Animation` class.
    - Unify the signature of ``get_all_mobjects``. Now it always returns a sequence of :class:`Mobjects <.Mobject>`. This breaks using  ``FadeTransform.get_all_mobjects`` as ``Group``.
 
-* `#1470 <https://github.com/ManimCommunity/manim/pull/1470>`__: Drop support for Python 3.6
+* :pr:`1470`: Drop support for Python 3.6
    Manim won't work on Python 3.6 anymore.
 
 Highlights
 ----------
 
-* `#1447 <https://github.com/ManimCommunity/manim/pull/1447>`__: Added :class:`~.PolarPlane` for polar coordinates.
+* :pr:`1447`: Added :class:`~.PolarPlane` for polar coordinates.
 
 
-* `#1490 <https://github.com/ManimCommunity/manim/pull/1490>`__: Added :class:`~.Polygram`, rework the polygon inheritance tree, and add :class:`~.Star`
+* :pr:`1490`: Added :class:`~.Polygram`, rework the polygon inheritance tree, and add :class:`~.Star`
    - Add :class:`~.Polygram`, a generalized :class:`~.Polygon` that allows for disconnected sets of edges.
    - Make :class:`~.Polygon` inherit from :class:`~.Polygram`.
    - Add :func:`~.regular_vertices`
@@ -108,10 +108,10 @@ Highlights
    - Make :class:`~.RegularPolygon` inherit from :class:`~.RegularPolygram`.
    - Add :class:`~.Star`.
 
-* `#1462 <https://github.com/ManimCommunity/manim/pull/1462>`__: OpenGL: Added :class:`~.Shader`, :class:`~.Mesh`, and :class:`~.FullScreenQuad`
+* :pr:`1462`: OpenGL: Added :class:`~.Shader`, :class:`~.Mesh`, and :class:`~.FullScreenQuad`
    Add Shader and Mesh objects
 
-* `#1418 <https://github.com/ManimCommunity/manim/pull/1418>`__: Added project management commands
+* :pr:`1418`: Added project management commands
    - ``manim init`` - quickly sets up default files for a manim project.
    - ``manim new project`` - lets the user set project settings. It also creates the project inside a new folder of name <project_name>
    - ``manim new scene`` - used to quickly insert new scenes into files. If ``file name`` is not provided ``main.py`` is used as default.
@@ -119,281 +119,281 @@ Highlights
 Deprecated classes and functions
 --------------------------------
 
-* `#1598 <https://github.com/ManimCommunity/manim/pull/1598>`__: Update examples to use :class:`~.Axes` and deprecate :class:`~.GraphScene`
+* :pr:`1598`: Update examples to use :class:`~.Axes` and deprecate :class:`~.GraphScene`
    :class:`~.GraphScene` has been deprecated and its functionality has been shifted to :class:`~.Axes`. See the updated example gallery for sample usage.
 
-* `#1454 <https://github.com/ManimCommunity/manim/pull/1454>`__: Fading module enhancements
+* :pr:`1454`: Fading module enhancements
    Moved functionality of all Fading classes to :class:`~.FadeIn` and :class:`~.FadeOut`. All other fading classes have been deprecated.
 
-* `#1375 <https://github.com/ManimCommunity/manim/pull/1375>`__: Deleted the deprecated ``ShowCreation`` in favor of :class:`~.Create`
+* :pr:`1375`: Deleted the deprecated ``ShowCreation`` in favor of :class:`~.Create`
 
 
 New features
 ------------
 
-* `#1566 <https://github.com/ManimCommunity/manim/pull/1566>`__: Added the ability to add gridlines to a :class:`~.Rectangle`
+* :pr:`1566`: Added the ability to add gridlines to a :class:`~.Rectangle`
 
 
-* `#1548 <https://github.com/ManimCommunity/manim/pull/1548>`__: Added :class:`~.ArcBrace`, a subclass of :class:`~.Brace`.
+* :pr:`1548`: Added :class:`~.ArcBrace`, a subclass of :class:`~.Brace`.
 
 
-* `#1559 <https://github.com/ManimCommunity/manim/pull/1559>`__: Update VGroup to support item assignment (#1530)
+* :pr:`1559`: Update VGroup to support item assignment (#1530)
    Support indexed item-assignment for VGroup
 
-* `#1518 <https://github.com/ManimCommunity/manim/pull/1518>`__: Allow fading multiple Mobjects in one Animation
+* :pr:`1518`: Allow fading multiple Mobjects in one Animation
 
 
-* `#1422 <https://github.com/ManimCommunity/manim/pull/1422>`__: Added :func:`~.override_animation` decorator
+* :pr:`1422`: Added :func:`~.override_animation` decorator
 
 
-* `#1504 <https://github.com/ManimCommunity/manim/pull/1504>`__: Color module enhancements
+* :pr:`1504`: Color module enhancements
    - Replaced ``BLUE_E`` with what was previously ``DARK_BLUE`` and removed ``DARK_BLUE``
    - Added alias ``LIGHTER_GRAY`` for ``GRAY_A``
    - Added ``PURE_RED``, ``PURE_BLUE`` and renamed ``GREEN_SCREEN`` to ``PURE_GREEN``
    - All gray colors are now also available using British spelling (including ``GREY_BROWN``)
    - Replaced color example in the docs. It can now be used as a quick reference for all color names.
 
-* `#1272 <https://github.com/ManimCommunity/manim/pull/1272>`__: Implement metaclass approach in geometry module to make mobjects compatible with cairo and opengl rendering
+* :pr:`1272`: Implement metaclass approach in geometry module to make mobjects compatible with cairo and opengl rendering
 
 
-* `#1404 <https://github.com/ManimCommunity/manim/pull/1404>`__: Added two deprecation decorators
+* :pr:`1404`: Added two deprecation decorators
    Added two function decorators ``deprecated`` and ``deprecated_params`` as a consistent way of deprecating code.
 
 Enhancements
 ------------
 
-* `#1572 <https://github.com/ManimCommunity/manim/pull/1572>`__: OpenGL compatibility via metaclass: :class:`~.TracedPath`, :class:`~.ParametricFunction`, :class:`~.Brace`, :class:`~.VGroup`
+* :pr:`1572`: OpenGL compatibility via metaclass: :class:`~.TracedPath`, :class:`~.ParametricFunction`, :class:`~.Brace`, :class:`~.VGroup`
 
 
-* `#1472 <https://github.com/ManimCommunity/manim/pull/1472>`__: Porting methods from :class:`~.GraphScene` to :class:`~.CoordinateSystem`
+* :pr:`1472`: Porting methods from :class:`~.GraphScene` to :class:`~.CoordinateSystem`
 
 
-* `#1589 <https://github.com/ManimCommunity/manim/pull/1589>`__: OpenGL compatibility via metaclass: :class:`~.ValueTracker`
+* :pr:`1589`: OpenGL compatibility via metaclass: :class:`~.ValueTracker`
 
 
-* `#1564 <https://github.com/ManimCommunity/manim/pull/1564>`__: Add extra notes for TeX compilation errors
+* :pr:`1564`: Add extra notes for TeX compilation errors
    Add hint to use custom ``TexTemplate`` on TeX compilation errors
 
-* `#1584 <https://github.com/ManimCommunity/manim/pull/1584>`__: Added a check for ``0`` in :meth:`~.round_corners`
+* :pr:`1584`: Added a check for ``0`` in :meth:`~.round_corners`
 
 
-* `#1586 <https://github.com/ManimCommunity/manim/pull/1586>`__: Add OpenGLMobject support to all ``isinstance`` occurrences
+* :pr:`1586`: Add OpenGLMobject support to all ``isinstance`` occurrences
    This PR increases the support for OpenGL in the remaining animation classes and in other places where appropriate.
 
-* `#1577 <https://github.com/ManimCommunity/manim/pull/1577>`__: Added new metaclass ConvertToOpenGL (replacing MetaVMobject), restore IntelliSense
+* :pr:`1577`: Added new metaclass ConvertToOpenGL (replacing MetaVMobject), restore IntelliSense
 
 
-* `#1562 <https://github.com/ManimCommunity/manim/pull/1562>`__: Improved VectorField's Nudge Accuracy Per Step
+* :pr:`1562`: Improved VectorField's Nudge Accuracy Per Step
    Implemented the Runge-Kutta algorithm in VectorField's nudge function. This increases the accuracy as an object moves along a vector field. This also increases efficiency as the nudge function requires less loops to achieve accuracy than the previous implementation.
 
-* `#1480 <https://github.com/ManimCommunity/manim/pull/1480>`__: Add logging info to tex errors
+* :pr:`1480`: Add logging info to tex errors
 
 
-* `#1567 <https://github.com/ManimCommunity/manim/pull/1567>`__: Compatibility Fixes with ManimPango v0.3.0
+* :pr:`1567`: Compatibility Fixes with ManimPango v0.3.0
    - ManimPango v0.3.0+ is required for Manim now.
    - Show errors from Pango when Markup isn't correct
 
-* `#1512 <https://github.com/ManimCommunity/manim/pull/1512>`__: OpenGL compatibility via metaclass: graph
+* :pr:`1512`: OpenGL compatibility via metaclass: graph
 
 
-* `#1511 <https://github.com/ManimCommunity/manim/pull/1511>`__: OpenGL compatibility via metaclass: svg_mobject, text_mobject, tex_mobject
+* :pr:`1511`: OpenGL compatibility via metaclass: svg_mobject, text_mobject, tex_mobject
 
 
-* `#1502 <https://github.com/ManimCommunity/manim/pull/1502>`__: Added ``center`` parameter to :class:`~.Sphere` and ``point`` parameter to :class:`~.Dot3D`
+* :pr:`1502`: Added ``center`` parameter to :class:`~.Sphere` and ``point`` parameter to :class:`~.Dot3D`
 
 
-* `#1486 <https://github.com/ManimCommunity/manim/pull/1486>`__: Update of ``rate_functions``
+* :pr:`1486`: Update of ``rate_functions``
    Changed the picture for the non standard rate functions.
 
-* `#1495 <https://github.com/ManimCommunity/manim/pull/1495>`__: Ported value_tracker to OpenGL
+* :pr:`1495`: Ported value_tracker to OpenGL
 
 
-* `#1382 <https://github.com/ManimCommunity/manim/pull/1382>`__: Expand documentation, testing, and functionality of ValueTrackers; remove ExponentialValueTracker
+* :pr:`1382`: Expand documentation, testing, and functionality of ValueTrackers; remove ExponentialValueTracker
    Added more documentation and inline operators to ValueTracker and ComplexValueTracker. Brought coverage for value_tracker.py to 100%. Removed ExponentialValueTracker.
 
-* `#1475 <https://github.com/ManimCommunity/manim/pull/1475>`__: Add SVG elliptical arc support
+* :pr:`1475`: Add SVG elliptical arc support
 
 
 Fixed bugs
 ----------
 
-* `#1574 <https://github.com/ManimCommunity/manim/pull/1574>`__: Fixed error when processing SVG with omitted elliptical arc command
+* :pr:`1574`: Fixed error when processing SVG with omitted elliptical arc command
 
 
-* `#1596 <https://github.com/ManimCommunity/manim/pull/1596>`__: Fix indexing for non-whitespace tex arg separator
+* :pr:`1596`: Fix indexing for non-whitespace tex arg separator
    Fixes #1568
 
    Fix issue when setting the arg_separator of a Tex object as a non-whitespace character(s). The method `break_up_by_substrings(self)` was not accounting for the separator when setting the index.
 
-* `#1588 <https://github.com/ManimCommunity/manim/pull/1588>`__: Fixed multiple animations being saved in the same file
+* :pr:`1588`: Fixed multiple animations being saved in the same file
 
 
-* `#1571 <https://github.com/ManimCommunity/manim/pull/1571>`__: Fix tests after introducing parallelization
+* :pr:`1571`: Fix tests after introducing parallelization
 
 
-* `#1545 <https://github.com/ManimCommunity/manim/pull/1545>`__: Fix outdated parameters for :class:`LinearTransformationScene` and add an example + typing.
+* :pr:`1545`: Fix outdated parameters for :class:`LinearTransformationScene` and add an example + typing.
 
 
-* `#1513 <https://github.com/ManimCommunity/manim/pull/1513>`__: Fixed rotation of gradients while rotating a VMobject
+* :pr:`1513`: Fixed rotation of gradients while rotating a VMobject
    - Fixed the direction of gradient which remained the same while rotating VMobjects
    - Added ``rotate_sheen_direction()`` method in VMobject
 
-* `#1570 <https://github.com/ManimCommunity/manim/pull/1570>`__: Output errors to stderr
+* :pr:`1570`: Output errors to stderr
 
 
-* `#1560 <https://github.com/ManimCommunity/manim/pull/1560>`__: Declare ``*.npz`` ``*.wav`` ``*.png`` as binary in ``.gitattributes``
+* :pr:`1560`: Declare ``*.npz`` ``*.wav`` ``*.png`` as binary in ``.gitattributes``
 
 
-* `#1211 <https://github.com/ManimCommunity/manim/pull/1211>`__: Refactored scene caching and fixed issue when a different hash was produced when copying a mobject in the scene
+* :pr:`1211`: Refactored scene caching and fixed issue when a different hash was produced when copying a mobject in the scene
    Refactored internal scene-caching mechanism and fixed bug when an inconsistent hash was produced when copying a mobject.
 
-* `#1527 <https://github.com/ManimCommunity/manim/pull/1527>`__: Improved handling of substring isolation within sqrt, and fixed a bug with transform_mismatch for the matching shape transforms
+* :pr:`1527`: Improved handling of substring isolation within sqrt, and fixed a bug with transform_mismatch for the matching shape transforms
 
 
-* `#1526 <https://github.com/ManimCommunity/manim/pull/1526>`__: Fix fading
+* :pr:`1526`: Fix fading
 
 
-* `#1523 <https://github.com/ManimCommunity/manim/pull/1523>`__: Fix multiple FadeIn / Out only working on VMobjects
+* :pr:`1523`: Fix multiple FadeIn / Out only working on VMobjects
 
 
 Documentation-related changes
 -----------------------------
 
-* `#1599 <https://github.com/ManimCommunity/manim/pull/1599>`__: Added example for :class:`~.Annulus`
+* :pr:`1599`: Added example for :class:`~.Annulus`
 
 
-* `#1415 <https://github.com/ManimCommunity/manim/pull/1415>`__: New example for gallery and some docs refinements
+* :pr:`1415`: New example for gallery and some docs refinements
 
 
-* `#1509 <https://github.com/ManimCommunity/manim/pull/1509>`__: Copyedited Documentation
+* :pr:`1509`: Copyedited Documentation
    Added a link to Manim Community GitHub page in ``for_dev.rst``.
    Fixed :meth:`~.Mobject.get_start`  and added ``roll`` link in ``building_blocks-rst``
    Added language to code blocks in ``configuration.rst``
 
-* `#1384 <https://github.com/ManimCommunity/manim/pull/1384>`__: Added typings to space_ops.py
+* :pr:`1384`: Added typings to space_ops.py
    Added Typehints to most of the functions
 
-* `#1500 <https://github.com/ManimCommunity/manim/pull/1500>`__: Example for :meth:`~.apply_complex_function`
+* :pr:`1500`: Example for :meth:`~.apply_complex_function`
 
 
-* `#1551 <https://github.com/ManimCommunity/manim/pull/1551>`__: Fixed the typo for Admonitions
+* :pr:`1551`: Fixed the typo for Admonitions
 
 
-* `#1550 <https://github.com/ManimCommunity/manim/pull/1550>`__: Restructuring of Contribution Section
+* :pr:`1550`: Restructuring of Contribution Section
 
 
-* `#1541 <https://github.com/ManimCommunity/manim/pull/1541>`__: Fixing broken links and other minor doc things
+* :pr:`1541`: Fixing broken links and other minor doc things
 
 
-* `#1516 <https://github.com/ManimCommunity/manim/pull/1516>`__: Update docs to use ``t_range`` instead of ``t_min`` and ``t_max`` in :class:`~.ParametricFunction`
+* :pr:`1516`: Update docs to use ``t_range`` instead of ``t_min`` and ``t_max`` in :class:`~.ParametricFunction`
 
 
-* `#1508 <https://github.com/ManimCommunity/manim/pull/1508>`__: Update troubleshooting docs
+* :pr:`1508`: Update troubleshooting docs
 
 
-* `#1485 <https://github.com/ManimCommunity/manim/pull/1485>`__: Added :class:`~.Title` example for the docs
+* :pr:`1485`: Added :class:`~.Title` example for the docs
 
 
-* `#1439 <https://github.com/ManimCommunity/manim/pull/1439>`__: Cleaning ``Sequence`` typehints
+* :pr:`1439`: Cleaning ``Sequence`` typehints
 
 
-* `#1440 <https://github.com/ManimCommunity/manim/pull/1440>`__: Added Scoop installation docs (Windows)
+* :pr:`1440`: Added Scoop installation docs (Windows)
 
 
-* `#1452 <https://github.com/ManimCommunity/manim/pull/1452>`__: Refine typehints at :class:`~.Angle`
+* :pr:`1452`: Refine typehints at :class:`~.Angle`
 
 
-* `#1458 <https://github.com/ManimCommunity/manim/pull/1458>`__: Refine docs of :class:`~.Text` ( add ``disable_ligatures=True`` for t2c)
+* :pr:`1458`: Refine docs of :class:`~.Text` ( add ``disable_ligatures=True`` for t2c)
 
 
-* `#1449 <https://github.com/ManimCommunity/manim/pull/1449>`__: Added :class:`~.PointCloudDot` example
+* :pr:`1449`: Added :class:`~.PointCloudDot` example
 
 
-* `#1473 <https://github.com/ManimCommunity/manim/pull/1473>`__: Added easy example for :meth:`~.arrange_in_grid`
+* :pr:`1473`: Added easy example for :meth:`~.arrange_in_grid`
 
 
-* `#1402 <https://github.com/ManimCommunity/manim/pull/1402>`__: Added typestring parser checker
+* :pr:`1402`: Added typestring parser checker
 
 
-* `#1451 <https://github.com/ManimCommunity/manim/pull/1451>`__: Reduce complexity of AngleExample
+* :pr:`1451`: Reduce complexity of AngleExample
 
 
-* `#1441 <https://github.com/ManimCommunity/manim/pull/1441>`__: Add inheritance diagrams to reference page
+* :pr:`1441`: Add inheritance diagrams to reference page
    Added inheritance diagrams to the reference page as a quick navigation method.
 
-* `#1457 <https://github.com/ManimCommunity/manim/pull/1457>`__: Fixing broken doc links
+* :pr:`1457`: Fixing broken doc links
 
 
-* `#1445 <https://github.com/ManimCommunity/manim/pull/1445>`__: Remove $ from tutorial commands
+* :pr:`1445`: Remove $ from tutorial commands
 
 
 Changes concerning the testing system
 -------------------------------------
 
-* `#1556 <https://github.com/ManimCommunity/manim/pull/1556>`__: Try pytest-xdist for parallelization in tests
+* :pr:`1556`: Try pytest-xdist for parallelization in tests
 
 
 Changes to our development infrastructure
 -----------------------------------------
 
-* `#1505 <https://github.com/ManimCommunity/manim/pull/1505>`__: Add docs reference to PR template
+* :pr:`1505`: Add docs reference to PR template
    Added documentation link to the Pull Request Template.
 
-* `#1499 <https://github.com/ManimCommunity/manim/pull/1499>`__: Updated Discord links in the docs to point towards a standardized redirect
+* :pr:`1499`: Updated Discord links in the docs to point towards a standardized redirect
 
 
-* `#1461 <https://github.com/ManimCommunity/manim/pull/1461>`__: Build the docs - Logging
+* :pr:`1461`: Build the docs - Logging
 
 
-* `#1481 <https://github.com/ManimCommunity/manim/pull/1481>`__: pyproject.toml: poetry_core -> poetry-core
+* :pr:`1481`: pyproject.toml: poetry_core -> poetry-core
 
 
-* `#1477 <https://github.com/ManimCommunity/manim/pull/1477>`__: Update RDT sphinx package to version 3.5.3
+* :pr:`1477`: Update RDT sphinx package to version 3.5.3
 
 
-* `#1460 <https://github.com/ManimCommunity/manim/pull/1460>`__: Create CONTRIBUTING.md
+* :pr:`1460`: Create CONTRIBUTING.md
 
 
-* `#1453 <https://github.com/ManimCommunity/manim/pull/1453>`__: manim_directive: fix image links in docs - Windows
+* :pr:`1453`: manim_directive: fix image links in docs - Windows
    Use POSIX path on Windows to link images so documentation can build locally.
 
 Code quality improvements and similar refactors
 -----------------------------------------------
 
-* `#1465 <https://github.com/ManimCommunity/manim/pull/1465>`__: Added typings and description to some functions in :mod:`~.coordinate_systems`.
+* :pr:`1465`: Added typings and description to some functions in :mod:`~.coordinate_systems`.
 
 
-* `#1552 <https://github.com/ManimCommunity/manim/pull/1552>`__: Removed unwanted parameters in geometry
+* :pr:`1552`: Removed unwanted parameters in geometry
    Removed ``anchors_span_full_range``, ``close_new_points``, ``anchors_span_full_range``, ``preserve_tip_size_when_scaling``, ``mark_paths_closed`` and ``close_new_points``
 
-* `#1597 <https://github.com/ManimCommunity/manim/pull/1597>`__: Removed hilite_me and insert_line_numbers_in_html from global name space
+* :pr:`1597`: Removed hilite_me and insert_line_numbers_in_html from global name space
 
 
-* `#1535 <https://github.com/ManimCommunity/manim/pull/1535>`__: Update dependencies and fix tests
+* :pr:`1535`: Update dependencies and fix tests
 
 
-* `#1544 <https://github.com/ManimCommunity/manim/pull/1544>`__: Adding spell checker as a pre-commit hook
+* :pr:`1544`: Adding spell checker as a pre-commit hook
 
 
-* `#1542 <https://github.com/ManimCommunity/manim/pull/1542>`__: Swapping a pango markup link in docs
+* :pr:`1542`: Swapping a pango markup link in docs
 
 
-* `#1531 <https://github.com/ManimCommunity/manim/pull/1531>`__: Don't use deprecated methods in deprecation.py
+* :pr:`1531`: Don't use deprecated methods in deprecation.py
 
 
-* `#1492 <https://github.com/ManimCommunity/manim/pull/1492>`__: Remove stray print statements introduced in #1404
+* :pr:`1492`: Remove stray print statements introduced in #1404
 
 
-* `#1471 <https://github.com/ManimCommunity/manim/pull/1471>`__: Fix Some Warnings from lgtm
+* :pr:`1471`: Fix Some Warnings from lgtm
 
 
 Changes that needed to be reverted again
 ----------------------------------------
 
-* `#1606 <https://github.com/ManimCommunity/manim/pull/1606>`__: Bring back ``DARK_BLUE``
+* :pr:`1606`: Bring back ``DARK_BLUE``
 
 
 New releases
 ------------
 
-* `#1601 <https://github.com/ManimCommunity/manim/pull/1601>`__: Preparation for v0.7.0: added changelog and bumped version number
+* :pr:`1601`: Preparation for v0.7.0: added changelog and bumped version number

--- a/docs/source/changelog/0.8.0-changelog.rst
+++ b/docs/source/changelog/0.8.0-changelog.rst
@@ -77,258 +77,258 @@ A total of 76 pull requests were merged for this release.
 Deprecated classes and functions
 --------------------------------
 
-* `#1616 <https://github.com/ManimCommunity/manim/pull/1616>`__: Remove all functions and classes that were deprecated until ``v0.6.0``
+* :pr:`1616`: Remove all functions and classes that were deprecated until ``v0.6.0``
 
 
 New features
 ------------
 
-* `#1716 <https://github.com/ManimCommunity/manim/pull/1716>`__: Rewrite stroke and fill shaders
+* :pr:`1716`: Rewrite stroke and fill shaders
    Rewrite vectorized mobject shaders to be compatible with transformation matrices.
 
-* `#1695 <https://github.com/ManimCommunity/manim/pull/1695>`__: Add option to justify text with :class:`~.MarkupText`
+* :pr:`1695`: Add option to justify text with :class:`~.MarkupText`
    A new parameter ``justify`` is added to :class:`~.MarkupText`. It can be used to justify a paragraph of text.
 
-* `#1660 <https://github.com/ManimCommunity/manim/pull/1660>`__: Added support for ``.webm`` and transparency of videos in Jupyter notebooks
+* :pr:`1660`: Added support for ``.webm`` and transparency of videos in Jupyter notebooks
    - Added support for generating ``webm`` videos via the command line flag ``--format=webm``
    - Added transparency support for Jupyter notebooks
 
-* `#1553 <https://github.com/ManimCommunity/manim/pull/1553>`__: Add dearpygui integration
+* :pr:`1553`: Add dearpygui integration
 
 
 Enhancements
 ------------
 
-* `#1728 <https://github.com/ManimCommunity/manim/pull/1728>`__: Improved positioning and size of the OpenGL window; added some configuration options
+* :pr:`1728`: Improved positioning and size of the OpenGL window; added some configuration options
 
 
-* `#1733 <https://github.com/ManimCommunity/manim/pull/1733>`__: Let OpenGLMobject.copy return a deep copy by default
+* :pr:`1733`: Let OpenGLMobject.copy return a deep copy by default
 
 
-* `#1735 <https://github.com/ManimCommunity/manim/pull/1735>`__: Metaclass compatibility for `coordinate_system.py`, `Code` and `ParametricSurface`
+* :pr:`1735`: Metaclass compatibility for `coordinate_system.py`, `Code` and `ParametricSurface`
 
 
-* `#1585 <https://github.com/ManimCommunity/manim/pull/1585>`__: OpenGL compatibility via metaclass for :class:`~.Matrix`, :class:`~.DecimalNumber`, :class:`~.Variable`
+* :pr:`1585`: OpenGL compatibility via metaclass for :class:`~.Matrix`, :class:`~.DecimalNumber`, :class:`~.Variable`
 
 
-* `#1713 <https://github.com/ManimCommunity/manim/pull/1713>`__: Exit the command line interface gracefully if no scene was chosen
+* :pr:`1713`: Exit the command line interface gracefully if no scene was chosen
 
 
-* `#1652 <https://github.com/ManimCommunity/manim/pull/1652>`__: Refactored :class:`~.Mobject` and :class:`~.Scene` to no longer inherit from the abstract base class ``Container``
+* :pr:`1652`: Refactored :class:`~.Mobject` and :class:`~.Scene` to no longer inherit from the abstract base class ``Container``
    - Moved tests in ``test_container.py`` for :class:`Container` that test :class:`~.Scene` and :class:`~.Mobject` to their own files.
    - Corrected various instances of incorrectly passed keyword arguments, or unused keyword arguments.
 
-* `#1693 <https://github.com/ManimCommunity/manim/pull/1693>`__: Made the default arrowhead size for :class:`~.Arrow3D` smaller
+* :pr:`1693`: Made the default arrowhead size for :class:`~.Arrow3D` smaller
 
 
-* `#1678 <https://github.com/ManimCommunity/manim/pull/1678>`__: Allow some rate functions to assume values outside of [0, 1]; introduce clamping decorators
+* :pr:`1678`: Allow some rate functions to assume values outside of [0, 1]; introduce clamping decorators
    - Fixed animations so that certain rate functions (``running_start``, ``wiggle``, ``ease_in_back``, ``ease_out_back``, ``ease_in_out_back``, ``ease_in_elastic``, ``ease_out_elastic``, and ``ease_out_elastic``) can go outside the range from 0 to 1.
    - Fixed lag ratios so that they're spaced out evenly within the time interval and the rate functions are applied to each animation individually, rather than having the rate function determine when the animation starts.
    - Fixed faulty code for ``ease_in_out_expo``, ``ease_in_bounce``, ``ease_out_bounce``, and ``ease_in_out_bounce``.
 
-* `#1649 <https://github.com/ManimCommunity/manim/pull/1649>`__: Made video file names in Jupyter notebook more readable
+* :pr:`1649`: Made video file names in Jupyter notebook more readable
 
 
-* `#1667 <https://github.com/ManimCommunity/manim/pull/1667>`__: Determine the default number of decimal places for :class:`~.NumberLine` labels automatically from the step size
+* :pr:`1667`: Determine the default number of decimal places for :class:`~.NumberLine` labels automatically from the step size
    As an example: If the step size is set to 0.5, labels will now show at least one decimal place.
 
-* `#1608 <https://github.com/ManimCommunity/manim/pull/1608>`__: Color file paths in terminal; remove curly braces surrounding the file path in "Partial movie file written in..." messages
+* :pr:`1608`: Color file paths in terminal; remove curly braces surrounding the file path in "Partial movie file written in..." messages
 
 
-* `#1632 <https://github.com/ManimCommunity/manim/pull/1632>`__: OpenGL compatibility via metaclass: :class:`~.Group`
+* :pr:`1632`: OpenGL compatibility via metaclass: :class:`~.Group`
 
 
 Fixed bugs
 ----------
 
-* `#1740 <https://github.com/ManimCommunity/manim/pull/1740>`__: Fix pillow to <8.3.0
+* :pr:`1740`: Fix pillow to <8.3.0
 
 
-* `#1729 <https://github.com/ManimCommunity/manim/pull/1729>`__: Fix bug when using :class:`~.Text` with the OpenGL renderer
+* :pr:`1729`: Fix bug when using :class:`~.Text` with the OpenGL renderer
 
 
-* `#1675 <https://github.com/ManimCommunity/manim/pull/1675>`__: Fixed ignored fill and stroke colors for :class:`~.SVGMobject`
+* :pr:`1675`: Fixed ignored fill and stroke colors for :class:`~.SVGMobject`
 
 
-* `#1664 <https://github.com/ManimCommunity/manim/pull/1664>`__: Fixed accidental displacement in :class:`~.Axes` caused by ``include_numbers`` / ``numbers_to_include``
+* :pr:`1664`: Fixed accidental displacement in :class:`~.Axes` caused by ``include_numbers`` / ``numbers_to_include``
 
 
-* `#1670 <https://github.com/ManimCommunity/manim/pull/1670>`__: Fixed missing ``numpy`` import in OpenGL shader example
+* :pr:`1670`: Fixed missing ``numpy`` import in OpenGL shader example
 
 
-* `#1636 <https://github.com/ManimCommunity/manim/pull/1636>`__: Fixed bugs and added examples to methods and classes in :mod:`manim.mobject.matrix`
+* :pr:`1636`: Fixed bugs and added examples to methods and classes in :mod:`manim.mobject.matrix`
 
 
-* `#1614 <https://github.com/ManimCommunity/manim/pull/1614>`__: Fix tick issues and improve tick placement for :class:`~.NumberLine`
+* :pr:`1614`: Fix tick issues and improve tick placement for :class:`~.NumberLine`
 
 
-* `#1593 <https://github.com/ManimCommunity/manim/pull/1593>`__: Un-flip output of ``get_frame()`` when using the OpenGL renderer
+* :pr:`1593`: Un-flip output of ``get_frame()`` when using the OpenGL renderer
 
 
-* `#1619 <https://github.com/ManimCommunity/manim/pull/1619>`__: Fix output of automatically detected LaTeX errors
+* :pr:`1619`: Fix output of automatically detected LaTeX errors
 
 
-* `#1595 <https://github.com/ManimCommunity/manim/pull/1595>`__: Fixed a few CLI and rendering bugs
+* :pr:`1595`: Fixed a few CLI and rendering bugs
    - Corrected issue where gifs were being logged with an incorrect extension
    - Fixed issue where videos were output when format was set to png
    - Added logging for png output
    - Added precedence handling when the ``write_to_movie`` flag would conflict with ``--format``
    - Fixed issue that caused png image output to be ignored when caching was enabled
 
-* `#1635 <https://github.com/ManimCommunity/manim/pull/1635>`__: Added missing numpy import for :mod:`manim.mobject.probability`
+* :pr:`1635`: Added missing numpy import for :mod:`manim.mobject.probability`
 
 
-* `#1634 <https://github.com/ManimCommunity/manim/pull/1634>`__: Fixed OpenGL examples for MacOS
+* :pr:`1634`: Fixed OpenGL examples for MacOS
    Renamed deprecated ``gl_FragColor`` to ``fragColor``.
 
 Documentation-related changes
 -----------------------------
 
-* `#1732 <https://github.com/ManimCommunity/manim/pull/1732>`__: Remove reference to ``--plugins`` flag
+* :pr:`1732`: Remove reference to ``--plugins`` flag
 
 
-* `#1734 <https://github.com/ManimCommunity/manim/pull/1734>`__: Fix inheritance graph background color
+* :pr:`1734`: Fix inheritance graph background color
 
 
-* `#1698 <https://github.com/ManimCommunity/manim/pull/1698>`__: Added an example for :class:`~.PMobject`
+* :pr:`1698`: Added an example for :class:`~.PMobject`
 
 
-* `#1690 <https://github.com/ManimCommunity/manim/pull/1690>`__: Added an example for :class:`~.CoordinateSystem`
+* :pr:`1690`: Added an example for :class:`~.CoordinateSystem`
 
 
-* `#1510 <https://github.com/ManimCommunity/manim/pull/1510>`__: Add a tutorial for using :class:`~.Text` and :class:`~.Tex`
+* :pr:`1510`: Add a tutorial for using :class:`~.Text` and :class:`~.Tex`
 
 
-* `#1685 <https://github.com/ManimCommunity/manim/pull/1685>`__: Added an example and parameter description for :class:`~.AnnularSector`
+* :pr:`1685`: Added an example and parameter description for :class:`~.AnnularSector`
 
 
-* `#1687 <https://github.com/ManimCommunity/manim/pull/1687>`__: Updated imports in ``geometry.py`` and added example to :class:`~.Arrow`
+* :pr:`1687`: Updated imports in ``geometry.py`` and added example to :class:`~.Arrow`
 
 
-* `#1681 <https://github.com/ManimCommunity/manim/pull/1681>`__: Added an example for :class:`~.NumberLine`
+* :pr:`1681`: Added an example for :class:`~.NumberLine`
 
 
-* `#1697 <https://github.com/ManimCommunity/manim/pull/1697>`__: Added an example for :class:`~.PGroup`
+* :pr:`1697`: Added an example for :class:`~.PGroup`
 
 
-* `#1594 <https://github.com/ManimCommunity/manim/pull/1594>`__: Several improvements to the documentation design and layout
+* :pr:`1594`: Several improvements to the documentation design and layout
 
 
-* `#1696 <https://github.com/ManimCommunity/manim/pull/1696>`__: Added an example for :class:`~.DashedVMobject`
+* :pr:`1696`: Added an example for :class:`~.DashedVMobject`
 
 
-* `#1637 <https://github.com/ManimCommunity/manim/pull/1637>`__: Added an example for :class:`~.FunctionGraph`
+* :pr:`1637`: Added an example for :class:`~.FunctionGraph`
 
 
-* `#1626 <https://github.com/ManimCommunity/manim/pull/1626>`__: Added an example for :class:`~.Prism`
+* :pr:`1626`: Added an example for :class:`~.Prism`
 
 
-* `#1712 <https://github.com/ManimCommunity/manim/pull/1712>`__: Added a second example for :class:`~.DoubleArrow`
+* :pr:`1712`: Added a second example for :class:`~.DoubleArrow`
 
 
-* `#1710 <https://github.com/ManimCommunity/manim/pull/1710>`__: Update copyright year in documentation to 2020-2021
+* :pr:`1710`: Update copyright year in documentation to 2020-2021
 
 
-* `#1708 <https://github.com/ManimCommunity/manim/pull/1708>`__: Fixed link to interactive example notebook
+* :pr:`1708`: Fixed link to interactive example notebook
 
 
-* `#1657 <https://github.com/ManimCommunity/manim/pull/1657>`__: Added an example for :class:`~.ParametricSurface`
+* :pr:`1657`: Added an example for :class:`~.ParametricSurface`
 
 
-* `#1642 <https://github.com/ManimCommunity/manim/pull/1642>`__: Added examples and docstrings for :class:`~.BarChart`
+* :pr:`1642`: Added examples and docstrings for :class:`~.BarChart`
 
 
-* `#1700 <https://github.com/ManimCommunity/manim/pull/1700>`__: Added an example for :meth:`~.Mobject.scale`
+* :pr:`1700`: Added an example for :meth:`~.Mobject.scale`
 
 
-* `#1689 <https://github.com/ManimCommunity/manim/pull/1689>`__: Added an example for :class:`~.SurroundingRectangle`
+* :pr:`1689`: Added an example for :class:`~.SurroundingRectangle`
 
 
-* `#1627 <https://github.com/ManimCommunity/manim/pull/1627>`__: Added an example for :class:`~.Sphere`
+* :pr:`1627`: Added an example for :class:`~.Sphere`
 
 
-* `#1569 <https://github.com/ManimCommunity/manim/pull/1569>`__: Added example to demonstrate differences between :class:`~.Transform` and :class:`~.ReplacementTransform`
+* :pr:`1569`: Added example to demonstrate differences between :class:`~.Transform` and :class:`~.ReplacementTransform`
 
 
-* `#1647 <https://github.com/ManimCommunity/manim/pull/1647>`__: Added an example for :class:`~.Sector`
+* :pr:`1647`: Added an example for :class:`~.Sector`
 
 
-* `#1673 <https://github.com/ManimCommunity/manim/pull/1673>`__: Updated documentation examples for :class:`~.Text` and :class:`~.MarkupText`: set ``weight=BOLD`` instead of ``style``
+* :pr:`1673`: Updated documentation examples for :class:`~.Text` and :class:`~.MarkupText`: set ``weight=BOLD`` instead of ``style``
 
 
-* `#1650 <https://github.com/ManimCommunity/manim/pull/1650>`__: Added an example for :class:`~.ArcBetweenPoints`
+* :pr:`1650`: Added an example for :class:`~.ArcBetweenPoints`
 
 
-* `#1628 <https://github.com/ManimCommunity/manim/pull/1628>`__: Added an example for :class:`~.NumberPlane`
+* :pr:`1628`: Added an example for :class:`~.NumberPlane`
 
 
-* `#1646 <https://github.com/ManimCommunity/manim/pull/1646>`__: Added an example for :class:`~.Underline`
+* :pr:`1646`: Added an example for :class:`~.Underline`
 
 
-* `#1659 <https://github.com/ManimCommunity/manim/pull/1659>`__: Added more details to the Google Colab installation instructions
+* :pr:`1659`: Added more details to the Google Colab installation instructions
 
 
-* `#1658 <https://github.com/ManimCommunity/manim/pull/1658>`__: Updated python requirement in the documentation
+* :pr:`1658`: Updated python requirement in the documentation
 
 
-* `#1639 <https://github.com/ManimCommunity/manim/pull/1639>`__: Added an example for :class:`~.SampleSpace`
+* :pr:`1639`: Added an example for :class:`~.SampleSpace`
 
 
-* `#1640 <https://github.com/ManimCommunity/manim/pull/1640>`__: Added an example for :class:`~.Point`
+* :pr:`1640`: Added an example for :class:`~.Point`
 
 
-* `#1643 <https://github.com/ManimCommunity/manim/pull/1643>`__: Fixed ``RightArcAngleExample`` for :class:`~.Angle` in documentation
+* :pr:`1643`: Fixed ``RightArcAngleExample`` for :class:`~.Angle` in documentation
 
 
-* `#1617 <https://github.com/ManimCommunity/manim/pull/1617>`__: Visually improved an example in our tutorial
+* :pr:`1617`: Visually improved an example in our tutorial
 
 
-* `#1641 <https://github.com/ManimCommunity/manim/pull/1641>`__: Added an example for :class:`~.ComplexPlane`
+* :pr:`1641`: Added an example for :class:`~.ComplexPlane`
 
 
-* `#1644 <https://github.com/ManimCommunity/manim/pull/1644>`__: Added an example for :class:`~.BackgroundRectangle`
+* :pr:`1644`: Added an example for :class:`~.BackgroundRectangle`
 
 
-* `#1633 <https://github.com/ManimCommunity/manim/pull/1633>`__: Added an example for :class:`~.Integer`
+* :pr:`1633`: Added an example for :class:`~.Integer`
 
 
-* `#1630 <https://github.com/ManimCommunity/manim/pull/1630>`__: Added an example for :class:`~.Arc`
+* :pr:`1630`: Added an example for :class:`~.Arc`
 
 
-* `#1631 <https://github.com/ManimCommunity/manim/pull/1631>`__: Added an example for :class:`~.BulletedList`
+* :pr:`1631`: Added an example for :class:`~.BulletedList`
 
 
-* `#1620 <https://github.com/ManimCommunity/manim/pull/1620>`__: Fixed reference to command line interface help command
+* :pr:`1620`: Fixed reference to command line interface help command
 
 
 Changes to our development infrastructure
 -----------------------------------------
 
-* `#1623 <https://github.com/ManimCommunity/manim/pull/1623>`__: CI: branch rename: master -> main
+* :pr:`1623`: CI: branch rename: master -> main
 
 
-* `#1621 <https://github.com/ManimCommunity/manim/pull/1621>`__: Revert default template and add new templates
+* :pr:`1621`: Revert default template and add new templates
 
 
-* `#1573 <https://github.com/ManimCommunity/manim/pull/1573>`__: PR template for the manim hackathon
+* :pr:`1573`: PR template for the manim hackathon
 
 
 Code quality improvements and similar refactors
 -----------------------------------------------
 
-* `#1720 <https://github.com/ManimCommunity/manim/pull/1720>`__: Renamed incorrect references of ``master`` to ``main``
+* :pr:`1720`: Renamed incorrect references of ``master`` to ``main``
 
 
-* `#1692 <https://github.com/ManimCommunity/manim/pull/1692>`__: Removed redundant warning in CLI parsing
+* :pr:`1692`: Removed redundant warning in CLI parsing
 
 
-* `#1651 <https://github.com/ManimCommunity/manim/pull/1651>`__: Small code cleanup for :class:`~.Polygram`
+* :pr:`1651`: Small code cleanup for :class:`~.Polygram`
 
 
-* `#1610 <https://github.com/ManimCommunity/manim/pull/1610>`__: Changed one image extension to lowercase letters
+* :pr:`1610`: Changed one image extension to lowercase letters
 
 
 New releases
 ------------
 
-* `#1738 <https://github.com/ManimCommunity/manim/pull/1738>`__: Preparation for v0.8.0: added changelog and bumped version number
+* :pr:`1738`: Preparation for v0.8.0: added changelog and bumped version number

--- a/docs/source/changelog/0.9.0-changelog.rst
+++ b/docs/source/changelog/0.9.0-changelog.rst
@@ -71,17 +71,17 @@ A total of 55 pull requests were merged for this release.
 Highlights
 ----------
 
-* `#1677 <https://github.com/ManimCommunity/manim/pull/1677>`__: Added a new :class:`~.Table` mobject
+* :pr:`1677`: Added a new :class:`~.Table` mobject
    This brings easy-to-use and customizable tables to Manim. Several examples for this new mobject can be found at :mod:`the module documentation page <.mobject.table>` and its subpages.
 
 Deprecated classes and functions
 --------------------------------
 
-* `#1848 <https://github.com/ManimCommunity/manim/pull/1848>`__: Deprecated parameters for :class:`~.DashedLine` and :class:`~.DashedVMobject`
+* :pr:`1848`: Deprecated parameters for :class:`~.DashedLine` and :class:`~.DashedVMobject`
    - ``dash_spacing`` is an unused parameter
    - ``positive_space_ratio`` has been replaced with the shorter name ``dashed_ratio``
 
-* `#1773 <https://github.com/ManimCommunity/manim/pull/1773>`__: Remove all classes and functions that were deprecated until ``v0.7.0`` and ``v0.8.0``
+* :pr:`1773`: Remove all classes and functions that were deprecated until ``v0.7.0`` and ``v0.8.0``
    The classes ``FadeInFrom``, ``FadeOutAndShift``, ``FadeOutToPoint``, ``FadeInFromPoint``, ``FadeInFromLarge``, ``VFadeIn``, ``VFadeOut``, ``VFadeInThenOut`` have been removed, use :class:`~.FadeIn` or :class:`~.FadeOut` with appropriate
    keyword arguments instead.
 
@@ -91,190 +91,190 @@ Deprecated classes and functions
 
    Finally, the utility functions ``get_norm`` and ``cross`` have been removed (use the corresponding Numpy methods instead), and the function ``angle_between`` has been replaced with ``angle_between_vectors``.
 
-* `#1731 <https://github.com/ManimCommunity/manim/pull/1731>`__: Deprecated :class:`~.ParametricSurface` parameters
+* :pr:`1731`: Deprecated :class:`~.ParametricSurface` parameters
    - ``u_min`` and ``u_max`` have been replaced by ``u_range``.
    - ``v_min`` and ``v_max`` have been replaced by ``v_range``.
 
 New features
 ------------
 
-* `#1780 <https://github.com/ManimCommunity/manim/pull/1780>`__: Allow non-numerical values to be added to :class:`~.NumberLine` and :class:`~.Axes`
+* :pr:`1780`: Allow non-numerical values to be added to :class:`~.NumberLine` and :class:`~.Axes`
    - Added :meth:`.NumberLine.add_labels` method to :class:`~.NumberLine` which accepts a dictionary of positions/values.
    - :meth:`.CoordinateSystem.add_coordinates` now accepts a dictionary too.
 
-* `#1719 <https://github.com/ManimCommunity/manim/pull/1719>`__: Added a :class:`~.Broadcast` animation
+* :pr:`1719`: Added a :class:`~.Broadcast` animation
 
 
-* `#1765 <https://github.com/ManimCommunity/manim/pull/1765>`__: Added a static method :meth:`.Circle.from_three_points` for defining a circle from three points
+* :pr:`1765`: Added a static method :meth:`.Circle.from_three_points` for defining a circle from three points
    - Added a new :func:`~.perpendicular_bisector` function in ``space_ops.py``
 
-* `#1686 <https://github.com/ManimCommunity/manim/pull/1686>`__: Added :meth:`.ParametricSurface.set_fill_by_value`
+* :pr:`1686`: Added :meth:`.ParametricSurface.set_fill_by_value`
    This method enables a color gradient to be applied to a :class:`~.ParametricSurface`, including the ability to define at which points the colors should be centered.
 
 Enhancements
 ------------
 
-* `#1833 <https://github.com/ManimCommunity/manim/pull/1833>`__: Added OpenGL compatibility for :class:`~.VDict`, :meth:`~.Axes.get_line_graph` and :class:`~.FocusOn`
+* :pr:`1833`: Added OpenGL compatibility for :class:`~.VDict`, :meth:`~.Axes.get_line_graph` and :class:`~.FocusOn`
 
 
-* `#1760 <https://github.com/ManimCommunity/manim/pull/1760>`__: Added ``window_size`` flag to manually adjust the size of the OpenGL window
+* :pr:`1760`: Added ``window_size`` flag to manually adjust the size of the OpenGL window
    Accepts a tuple in the form: ``x,y``.
 
-* `#1823 <https://github.com/ManimCommunity/manim/pull/1823>`__: Reworked :class:`~.DashedVMobject`
+* :pr:`1823`: Reworked :class:`~.DashedVMobject`
    Rewritten the logic to generate dashes
 
-* `#1808 <https://github.com/ManimCommunity/manim/pull/1808>`__: OpenGL renderer updates
+* :pr:`1808`: OpenGL renderer updates
    - Adds model matrices to all OpenGLVMobjects
    - Improved performance on vectorized mobject shaders
    - Added updaters that are part of the scene rather than a mobject
 
-* `#1787 <https://github.com/ManimCommunity/manim/pull/1787>`__: Made :class:`~.DecimalNumber` apply color to the ellipsis
+* :pr:`1787`: Made :class:`~.DecimalNumber` apply color to the ellipsis
    Made color apply to the dots when `show_ellipsis` is set to true in `DecimalNumber`
 
-* `#1775 <https://github.com/ManimCommunity/manim/pull/1775>`__: Let :class:`~.Create` work on :class:`~.OpenGLSurface`
+* :pr:`1775`: Let :class:`~.Create` work on :class:`~.OpenGLSurface`
 
 
-* `#1757 <https://github.com/ManimCommunity/manim/pull/1757>`__: Added warning when there is a large number of items to hash.
+* :pr:`1757`: Added warning when there is a large number of items to hash.
 
 
-* `#1774 <https://github.com/ManimCommunity/manim/pull/1774>`__: Add the ``reverse`` parameter to :class:`~.Write`
+* :pr:`1774`: Add the ``reverse`` parameter to :class:`~.Write`
 
 
 Fixed bugs
 ----------
 
-* `#1722 <https://github.com/ManimCommunity/manim/pull/1722>`__: Fixed ``remover=True`` for :class:`~.AnimationGroup`
+* :pr:`1722`: Fixed ``remover=True`` for :class:`~.AnimationGroup`
 
 
-* `#1727 <https://github.com/ManimCommunity/manim/pull/1727>`__: Fixed some hot reload issues and compatibility with IDEs
+* :pr:`1727`: Fixed some hot reload issues and compatibility with IDEs
    - Fixed interactive embed issue where it would fail when running on non-tty terminals
    - Fixed issue where file observer would error after the second run as the first observer was not closed
 
-* `#1844 <https://github.com/ManimCommunity/manim/pull/1844>`__: Fixed the oversized :class:`~.Code` window with the OpenGL renderer
+* :pr:`1844`: Fixed the oversized :class:`~.Code` window with the OpenGL renderer
 
 
-* `#1821 <https://github.com/ManimCommunity/manim/pull/1821>`__: Fixed issues concerning ``frame_center`` in :class:`~.ThreeDScene`
+* :pr:`1821`: Fixed issues concerning ``frame_center`` in :class:`~.ThreeDScene`
    - Changing ``frame_center`` in a :class:`~.ThreeDScene` now actually changes the camera position.
    - An animation with only ``frame_center`` animated will now be rendered properly.
    - A black dot is not created at the origin once ``frame_center`` is animated.
 
-* `#1826 <https://github.com/ManimCommunity/manim/pull/1826>`__: Fixed scaling issue with :meth:`.BarChart.change_bar_values`
+* :pr:`1826`: Fixed scaling issue with :meth:`.BarChart.change_bar_values`
 
 
-* `#1839 <https://github.com/ManimCommunity/manim/pull/1839>`__: Allow passing arguments to ``.animate`` with the OpenGL renderer
+* :pr:`1839`: Allow passing arguments to ``.animate`` with the OpenGL renderer
 
 
-* `#1791 <https://github.com/ManimCommunity/manim/pull/1791>`__: :meth:`~.Mobject.set_z_index` now sets all submobjects' ``z_index`` value
+* :pr:`1791`: :meth:`~.Mobject.set_z_index` now sets all submobjects' ``z_index`` value
 
 
-* `#1792 <https://github.com/ManimCommunity/manim/pull/1792>`__: Fixed bug that caused dry runs to fail when using the PNG format
+* :pr:`1792`: Fixed bug that caused dry runs to fail when using the PNG format
 
 
-* `#1790 <https://github.com/ManimCommunity/manim/pull/1790>`__: Fixed an import from ``manimlib``
+* :pr:`1790`: Fixed an import from ``manimlib``
 
 
-* `#1782 <https://github.com/ManimCommunity/manim/pull/1782>`__: Fixed :class:`~.Tex` not working properly with the OpenGL renderer
+* :pr:`1782`: Fixed :class:`~.Tex` not working properly with the OpenGL renderer
 
 
-* `#1783 <https://github.com/ManimCommunity/manim/pull/1783>`__: Fixed :meth:`~.OpenGLMobject.shuffle` function and added :meth:`~.invert` to OpenGL
+* :pr:`1783`: Fixed :meth:`~.OpenGLMobject.shuffle` function and added :meth:`~.invert` to OpenGL
 
 
-* `#1786 <https://github.com/ManimCommunity/manim/pull/1786>`__: Fixed :class:`~.DecimalNumber` not working properly when the number of digits changes
+* :pr:`1786`: Fixed :class:`~.DecimalNumber` not working properly when the number of digits changes
 
 
-* `#1763 <https://github.com/ManimCommunity/manim/pull/1763>`__: Fixed not being able to set some CLI flags in the configuration file
+* :pr:`1763`: Fixed not being able to set some CLI flags in the configuration file
 
 
-* `#1776 <https://github.com/ManimCommunity/manim/pull/1776>`__: :meth:`.CoordinateSystem.get_riemann_rectangles` now uses the graph's range instead of the axes range
+* :pr:`1776`: :meth:`.CoordinateSystem.get_riemann_rectangles` now uses the graph's range instead of the axes range
    If no range specified, `get_riemann_rectangles` generates the rectangles only where the area is correctly bounded
 
-* `#1770 <https://github.com/ManimCommunity/manim/pull/1770>`__: Rewrote :meth:`.OpenGLMobject.put_start_and_end_on` to work correctly in 3D
+* :pr:`1770`: Rewrote :meth:`.OpenGLMobject.put_start_and_end_on` to work correctly in 3D
 
 
-* `#1736 <https://github.com/ManimCommunity/manim/pull/1736>`__: Fixed :class:`~.LinearTransformationScene` crashing on multiple animations
+* :pr:`1736`: Fixed :class:`~.LinearTransformationScene` crashing on multiple animations
 
 
 Documentation-related changes
 -----------------------------
 
-* `#1852 <https://github.com/ManimCommunity/manim/pull/1852>`__: Fixed docs for :meth:`.Coordinate_system.add_coordinates` and moved :class: `~.Code` example
+* :pr:`1852`: Fixed docs for :meth:`.Coordinate_system.add_coordinates` and moved :class: `~.Code` example
 
 
-* `#1807 <https://github.com/ManimCommunity/manim/pull/1807>`__: Updated installation instructions
+* :pr:`1807`: Updated installation instructions
    - Added a warning about the incompatibility of different versions of Manim in the README
    - Modified the admonition warning in the documentation
    - Removed duplicated information from the README (``pip install manim`` is already covered in the docs)
 
-* `#1739 <https://github.com/ManimCommunity/manim/pull/1739>`__: Added a section on creating a custom animation to the "Manim's building blocks" tutorial
+* :pr:`1739`: Added a section on creating a custom animation to the "Manim's building blocks" tutorial
 
 
-* `#1835 <https://github.com/ManimCommunity/manim/pull/1835>`__: Updated documentation with information about reworked graphical unit test system
+* :pr:`1835`: Updated documentation with information about reworked graphical unit test system
 
 
-* `#1845 <https://github.com/ManimCommunity/manim/pull/1845>`__: Improve ``ThreeDSurfacePlot`` example in example gallery
+* :pr:`1845`: Improve ``ThreeDSurfacePlot`` example in example gallery
 
 
-* `#1842 <https://github.com/ManimCommunity/manim/pull/1842>`__: Removed instructions on installing Poetry from Developer Installation documentation, reference Poetry's documentation instead
+* :pr:`1842`: Removed instructions on installing Poetry from Developer Installation documentation, reference Poetry's documentation instead
 
 
-* `#1829 <https://github.com/ManimCommunity/manim/pull/1829>`__: Switch the order of Scoop and Chocolatey in the docs for the Windows Installation
+* :pr:`1829`: Switch the order of Scoop and Chocolatey in the docs for the Windows Installation
 
 
-* `#1827 <https://github.com/ManimCommunity/manim/pull/1827>`__: Added ``robots.txt`` to prevent old versions of documentation from showing in search results
+* :pr:`1827`: Added ``robots.txt`` to prevent old versions of documentation from showing in search results
 
 
-* `#1819 <https://github.com/ManimCommunity/manim/pull/1819>`__: Removed mention of ``-h`` CLI flag from documentation
+* :pr:`1819`: Removed mention of ``-h`` CLI flag from documentation
 
 
-* `#1813 <https://github.com/ManimCommunity/manim/pull/1813>`__: Removed unused variables from tutorial
+* :pr:`1813`: Removed unused variables from tutorial
 
 
-* `#1815 <https://github.com/ManimCommunity/manim/pull/1815>`__: Added codespell to the list of used linters in the contribution guidelines
+* :pr:`1815`: Added codespell to the list of used linters in the contribution guidelines
 
 
-* `#1778 <https://github.com/ManimCommunity/manim/pull/1778>`__: Improve sidebar structure of the documentation's reference manual
+* :pr:`1778`: Improve sidebar structure of the documentation's reference manual
 
 
-* `#1749 <https://github.com/ManimCommunity/manim/pull/1749>`__: Added documentation and example for :meth:`.VMobject.set_fill`
+* :pr:`1749`: Added documentation and example for :meth:`.VMobject.set_fill`
 
 
-* `#1743 <https://github.com/ManimCommunity/manim/pull/1743>`__: Edited the developer installation instructions to include information on cloning the repository
+* :pr:`1743`: Edited the developer installation instructions to include information on cloning the repository
 
 
-* `#1706 <https://github.com/ManimCommunity/manim/pull/1706>`__: Rework example for :class:`~.Variable`
+* :pr:`1706`: Rework example for :class:`~.Variable`
 
 
 Changes concerning the testing system
 -------------------------------------
 
-* `#1836 <https://github.com/ManimCommunity/manim/pull/1836>`__: Converted all the graphical tests to the new syntax
+* :pr:`1836`: Converted all the graphical tests to the new syntax
 
 
-* `#1802 <https://github.com/ManimCommunity/manim/pull/1802>`__: Refactored graphical unit testing system, and implemented multi frames tests
+* :pr:`1802`: Refactored graphical unit testing system, and implemented multi frames tests
    This PR introduces a new ``@frames_comparison`` decorator which allows writing simple ``construct``-like functions as tests. Control data for new tests can be easily generated by calling ``pytest --set_test``.
 
 Changes to our development infrastructure
 -----------------------------------------
 
-* `#1830 <https://github.com/ManimCommunity/manim/pull/1830>`__: Be more concise about the documentation URL in the PR template
+* :pr:`1830`: Be more concise about the documentation URL in the PR template
 
 
 Code quality improvements and similar refactors
 -----------------------------------------------
 
-* `#1851 <https://github.com/ManimCommunity/manim/pull/1851>`__: Renamed ``Tabular`` to :class:`~.Table`
+* :pr:`1851`: Renamed ``Tabular`` to :class:`~.Table`
 
 
-* `#1817 <https://github.com/ManimCommunity/manim/pull/1817>`__: Remove pillow version requirement
+* :pr:`1817`: Remove pillow version requirement
 
 
-* `#1806 <https://github.com/ManimCommunity/manim/pull/1806>`__: Fixed spelling mistake
+* :pr:`1806`: Fixed spelling mistake
 
 
-* `#1745 <https://github.com/ManimCommunity/manim/pull/1745>`__: Updated the BibTeX template in the README to Manim v0.9.0
+* :pr:`1745`: Updated the BibTeX template in the README to Manim v0.9.0
 
 
 New releases
 ------------
 
-* `#1850 <https://github.com/ManimCommunity/manim/pull/1850>`__: Bump version number to ``v0.9.0`` and generate changelog
+* :pr:`1850`: Bump version number to ``v0.9.0`` and generate changelog

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -134,8 +134,8 @@ html_css_files = ["custom.css"]
 
 # external links
 extlinks = {
-    "issue": ("https://github.com/ManimCommunity/manim/issues/%s", "issue "),
-    "pr": ("https://github.com/ManimCommunity/manim/pull/%s", "pull request "),
+    "issue": ("https://github.com/ManimCommunity/manim/issues/%s", "#"),
+    "pr": ("https://github.com/ManimCommunity/manim/pull/%s", "#"),
 }
 
 # opengraph settings

--- a/docs/source/contributing/internationalization.rst
+++ b/docs/source/contributing/internationalization.rst
@@ -97,5 +97,5 @@ Source errors
 -------------
 
 If you spot an error with a source string, report it to us by opening an
-`issue <https://github.com/ManimCommunity/manim/issues/new/choose>`__ on
+:issue:`issue <new/choose>` on
 GitHub. Refrain from translating the string until the issue is resolved.

--- a/docs/source/contributing/internationalization.rst
+++ b/docs/source/contributing/internationalization.rst
@@ -26,9 +26,9 @@ Contributing
    When a developer implements a new feature, they are not forced to respect any translations.
    This means that parts of the translation might become outdated over time.
 
-   That being said, improving the documentation and making it more accessible is still highly encouraged.
-   And even if your work gets outdated and requires change, you or someone else can simply adjust the translation.
-   Your efforts are not in vail!
+That being said, improving the documentation and making it more accessible is still highly encouraged.
+And even if your work gets outdated and requires change, you or someone else can simply adjust the translation.
+Your efforts are not in vail!
 
 
 Voting

--- a/docs/source/installation/windows.rst
+++ b/docs/source/installation/windows.rst
@@ -118,15 +118,14 @@ of your choice (Chocolatey: ``choco install miktex.install``,
 Scoop: ``scoop install latex``).
 
 If you are concerned about disk space, there are some alternative,
-smaller distributions of LaTeX like:
+smaller distributions of LaTeX.
 
-- Using Chocolatey:
-If you used Chocolatey to install manim or are already a chocolatey user,
-then you can simply run ``choco install manim-latex``.
-It is a dedicated package for Manim based on TinyTeX which contains
-all the required packages that Manim interacts with.
+**Using Chocolatey:** If you used Chocolatey to install manim or are already
+a chocolatey user, then you can simply run ``choco install manim-latex``. It
+is a dedicated package for Manim based on TinyTeX which contains all the
+required packages that Manim interacts with.
 
-- Manual Installation:
+**Manual Installation:**
 You can also use `TinyTeX <https://yihui.org/tinytex/>`__ (Chocolatey: ``choco install tinytex``,
 Scoop: first ``scoop bucket add r-bucket https://github.com/cderv/r-bucket.git``,
 then ``scoop install tinytex``) alternative installation instructions can be found at their website.

--- a/scripts/dev_changelog.py
+++ b/scripts/dev_changelog.py
@@ -298,7 +298,7 @@ def main(token, prior, tag, additional, outfile):
                     url = PR.html_url
                     title = PR.title
                     label = PR.labels
-                    f.write(f"* `#{num} <{url}>`__: {title}\n")
+                    f.write(f"* :pr:`{num}`: {title}\n")
                     overview = get_summary(PR.body)
                     if overview:
                         f.write(indent(f"{overview}\n\n", "   "))


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

See title.

<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

We got a lot of warnings due to the links in the changelog not using the extlink `:pr:`, but the hard-coded version of it. I've regex-search-replaced all of them, the rendered output is the same. The changes reduced the number of warnings from over 600 to 8, locally.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
