### PR TITLE
Fixed bug with setting CLI options from a config file

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -575,6 +575,7 @@ class ManimConfig(MutableMapping):
             "input_file",
             "output_file",
             "movie_file_extension",
+            "format",
             "background_color",
             "renderer",
             "webgl_renderer_path",
@@ -688,7 +689,8 @@ class ManimConfig(MutableMapping):
             self.input_file = Path(args.file).absolute()
 
         self.scene_names = args.scene_names if args.scene_names is not None else []
-        self.output_file = args.output_file
+        if args.output_file is not None:
+            self.output_file = args.output_file
 
         for key in [
             "notify_outdated_version",


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->
## Overview: What does this pull request change?
`format` was never included in the str keys when digesting the config file.
`output_name` was always overwritten.

These two behaviours have now been fixed.
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
Do you want me to add tests for this?


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
