### PR TITLE
Fixed bug in :meth:`.Circle.point_at_angle` when the angle is not in the interval :math:`[0, 2\pi]`

### DIFF
--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -575,7 +575,9 @@ class Circle(Arc):
         """
 
         start_angle = angle_of_vector(self.points[0] - self.get_center())
-        return self.point_from_proportion((angle - start_angle) / TAU)
+        proportion = (angle - start_angle) / TAU
+        proportion -= math.floor(proportion)
+        return self.point_from_proportion(proportion)
 
     @staticmethod
     def from_three_points(

--- a/tests/test_vectorized_mobject.py
+++ b/tests/test_vectorized_mobject.py
@@ -289,3 +289,9 @@ def test_vmobject_different_num_points_and_submobjects_become():
     a.become(b)
     assert np.array_equal(a.points, b.points)
     assert len(a.submobjects) == len(b.submobjects)
+
+
+def test_vmobject_point_at_angle():
+    a = Circle()
+    p = a.point_at_angle(4 * PI)
+    assert np.array_equal(a.points[0], p)


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

When the angle passed to `Circle.point_at_angle` is not in the interval `[0, 2 * pi]`, an error is thrown. This commit maps all angles into the interval `[0, 2 * pi]`.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

Fixes #2612.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
