### PR TITLE
Re-added :mod:`.value_tracker` documentation

### DIFF
--- a/docs/source/reference_index/mobjects.rst
+++ b/docs/source/reference_index/mobjects.rst
@@ -18,4 +18,5 @@ Mobjects
    ~mobject.text
    ~mobject.three_d
    ~mobject.types
+   ~mobject.value_tracker
    ~mobject.vector_field


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

As a side effect of changing the module structure, the `value_tracker` module was moved and at some point forgotten to be added back (pretty sure by myself; apologies!).

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
https://manimce--2617.org.readthedocs.build/en/2617/reference/manim.mobject.value_tracker.html



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
