### PR TITLE
(Re)set background color of :class:`.OpenGLRenderer` when initializing scene

### DIFF
--- a/manim/renderer/opengl_renderer.py
+++ b/manim/renderer/opengl_renderer.py
@@ -246,7 +246,7 @@ class OpenGLRenderer:
         # Initialize texture map.
         self.path_to_texture_id = {}
 
-        self._background_color = color_to_rgba(config["background_color"], 1.0)
+        self.background_color = config["background_color"]
 
     def init_scene(self, scene):
         self.partial_movie_files = []
@@ -255,6 +255,7 @@ class OpenGLRenderer:
             scene.__class__.__name__,
         )
         self.scene = scene
+        self.background_color = config["background_color"]
         if not hasattr(self, "window"):
             if self.should_create_window():
                 from .opengl_renderer_window import Window


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->

In contrast to the Cairo renderer, the OpenGL renderer is initialized before the scene file is read when using the CLI. This causes eventual changes to `config.background_color` in the scene file not to be respected.

With this PR, the background color is set again upon initialization of the scene object.

<!--changelog-start-->

<!--changelog-end-->


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
