### PR TITLE
Allow using :meth:`.MovingCamera.auto_zoom` without animation

### DIFF
--- a/manim/camera/moving_camera.py
+++ b/manim/camera/moving_camera.py
@@ -175,7 +175,7 @@ class MovingCamera(Camera):
         """
         return [self.frame]
 
-    def auto_zoom(self, mobjects, margin=0, only_mobjects_in_frame=False):
+    def auto_zoom(self, mobjects, margin=0, only_mobjects_in_frame=False, animate=True):
         """Zooms on to a given array of mobjects (or a singular mobject)
         and automatically resizes to frame all the mobjects.
 
@@ -195,11 +195,14 @@ class MovingCamera(Camera):
         only_mobjects_in_frame
             If set to ``True``, only allows focusing on mobjects that are already in frame.
 
+        animate
+            If set to ``False``, applies the changes instead of returning the corresponding animation
+
         Returns
         -------
-        _AnimationBuilder
-            Returns an animation that zooms the camera view to a given
-            list of mobjects.
+        Union[_AnimationBuilder, ScreenRectangle]
+            _AnimationBuilder that zooms the camera view to a given list of mobjects
+            or ScreenRectangle with position and size updated to zoomed position.
 
         """
         scene_critical_x_left = None
@@ -242,8 +245,9 @@ class MovingCamera(Camera):
         new_width = abs(scene_critical_x_left - scene_critical_x_right)
         new_height = abs(scene_critical_y_up - scene_critical_y_down)
 
+        m_target = self.frame.animate if animate else self.frame
         # zoom to fit all mobjects along the side that has the largest size
         if new_width / self.frame.width > new_height / self.frame.height:
-            return self.frame.animate.set_x(x).set_y(y).set(width=new_width + margin)
+            return m_target.set_x(x).set_y(y).set(width=new_width + margin)
         else:
-            return self.frame.animate.set_x(x).set_y(y).set(height=new_height + margin)
+            return m_target.set_x(x).set_y(y).set(height=new_height + margin)

--- a/manim/camera/moving_camera.py
+++ b/manim/camera/moving_camera.py
@@ -13,8 +13,8 @@ __all__ = ["CameraFrame", "MovingCamera"]
 from .. import config
 from ..camera.camera import Camera
 from ..constants import DOWN, LEFT, ORIGIN, RIGHT, UP
-from ..mobject.mobject import Mobject
 from ..mobject.frame import ScreenRectangle
+from ..mobject.mobject import Mobject
 from ..mobject.types.vectorized_mobject import VGroup
 from ..utils.color import WHITE
 

--- a/manim/camera/moving_camera.py
+++ b/manim/camera/moving_camera.py
@@ -13,6 +13,7 @@ __all__ = ["CameraFrame", "MovingCamera"]
 from .. import config
 from ..camera.camera import Camera
 from ..constants import DOWN, LEFT, ORIGIN, RIGHT, UP
+from ..mobject.mobject import Mobject
 from ..mobject.frame import ScreenRectangle
 from ..mobject.types.vectorized_mobject import VGroup
 from ..utils.color import WHITE
@@ -175,7 +176,13 @@ class MovingCamera(Camera):
         """
         return [self.frame]
 
-    def auto_zoom(self, mobjects, margin=0, only_mobjects_in_frame=False, animate=True):
+    def auto_zoom(
+        self,
+        mobjects: list[Mobject],
+        margin: float = 0,
+        only_mobjects_in_frame: bool = False,
+        animate: bool = True,
+    ):
         """Zooms on to a given array of mobjects (or a singular mobject)
         and automatically resizes to frame all the mobjects.
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from manim import MovingCamera, Square
 
+
 def test_movingcamera_auto_zoom():
     camera = MovingCamera()
     square = Square()

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from manim import MovingCamera, Square
+
+def test_movingcamera_auto_zoom():
+    camera = MovingCamera()
+    square = Square()
+    margin = 0.5
+    camera.auto_zoom([square], margin=margin, animate=False)
+    assert camera.frame.height == square.height + margin


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

For Issue #2690 

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Allows auto zooming camera without having to play an animation by passing an `animation=False` argument
<!--changelog-end-->


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
