### PR TITLE
Updating of old URL (Pango Markup formatting page)

### DIFF
--- a/docs/i18n/gettext/reference/manim.mobject.text.text_mobject.MarkupText.pot
+++ b/docs/i18n/gettext/reference/manim.mobject.text.text_mobject.MarkupText.pot
@@ -147,7 +147,7 @@ msgid "Escaping of special characters: ``>`` **should** be written as ``&gt;`` w
 msgstr ""
 
 #: ../../../manim/mobject/text/text_mobject.py:docstring of manim.mobject.text.text_mobject.MarkupText:103
-msgid "You can find more information about Pango markup formatting at the corresponding documentation page: `Pango Markup <https://developer.gnome.org/pango/stable/pango-Markup.html>`_. Please be aware that not all features are supported by this class and that the ``<gradient>`` tag mentioned above is not supported by Pango."
+msgid "You can find more information about Pango markup formatting at the corresponding documentation page: `Pango Markup <https://docs.gtk.org/Pango/pango_markup.html>`_. Please be aware that not all features are supported by this class and that the ``<gradient>`` tag mentioned above is not supported by Pango."
 msgstr ""
 
 #: ../../../manim/mobject/text/text_mobject.py:docstring of manim.mobject.text.text_mobject.MarkupText:0


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
The old URL https://developer.gnome.org/pango/stable/pango-Markup.html redirects to https://docs.gtk.org/Pango/ which is a generic page, not specific to the Pango Markup formatting. I replace it with the new address of the documentation:  https://docs.gtk.org/Pango/pango_markup.html


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
