### PR TITLE
Default to utf-8 when reading files in :class:`.Code`

### DIFF
--- a/manim/mobject/text/code_mobject.py
+++ b/manim/mobject/text/code_mobject.py
@@ -199,7 +199,7 @@ class Code(VGroup):
         self.file_name = file_name
         if self.file_name:
             self._ensure_valid_file()
-            with open(self.file_path, encoding='utf-8') as f:
+            with open(self.file_path, encoding="utf-8") as f:
                 self.code_string = f.read()
         elif code:
             self.code_string = code

--- a/manim/mobject/text/code_mobject.py
+++ b/manim/mobject/text/code_mobject.py
@@ -199,7 +199,7 @@ class Code(VGroup):
         self.file_name = file_name
         if self.file_name:
             self._ensure_valid_file()
-            with open(self.file_path) as f:
+            with open(self.file_path, encoding='utf-8') as f:
                 self.code_string = f.read()
         elif code:
             self.code_string = code


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

fixed the bug of file reading in `Code` mobject

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
The `Code` mobject has an encoding bug on the file mode. If we use file name to read a code file with CJK annotation, the python function `open` in windows with zh-CN language setting will use 'gbk' encoding by default, and cause "UnicodeDecodeError". By explictly set the encoding as 'UTF-8', we can fix this bug.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
