### PR TITLE
fix(constants.py,image_mobject.py,opengl_image_mobject.py): Update de…

### DIFF
--- a/manim/constants.py
+++ b/manim/constants.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import numpy as np
 from cloup import Context
-from PIL import Image
+from PIL.Image import Resampling
 
 __all__ = [
     "NOT_SETTING_FONT_MSG",
@@ -113,16 +113,16 @@ HEAVY: str = "HEAVY"
 ULTRAHEAVY: str = "ULTRAHEAVY"
 
 RESAMPLING_ALGORITHMS = {
-    "nearest": Image.NEAREST,
-    "none": Image.NEAREST,
-    "lanczos": Image.LANCZOS,
-    "antialias": Image.LANCZOS,
-    "bilinear": Image.BILINEAR,
-    "linear": Image.BILINEAR,
-    "bicubic": Image.BICUBIC,
-    "cubic": Image.BICUBIC,
-    "box": Image.BOX,
-    "hamming": Image.HAMMING,
+    "nearest": Resampling.NEAREST,
+    "none": Resampling.NEAREST,
+    "lanczos": Resampling.LANCZOS,
+    "antialias": Resampling.LANCZOS,
+    "bilinear": Resampling.BILINEAR,
+    "linear": Resampling.BILINEAR,
+    "bicubic": Resampling.BICUBIC,
+    "cubic": Resampling.BICUBIC,
+    "box": Resampling.BOX,
+    "hamming": Resampling.HAMMING,
 }
 
 # Geometry: directions

--- a/manim/mobject/opengl/opengl_image_mobject.py
+++ b/manim/mobject/opengl/opengl_image_mobject.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import numpy as np
 from PIL import Image
+from PIL.Image import Resampling
 
 from manim.mobject.opengl.opengl_surface import OpenGLSurface, OpenGLTexturedSurface
 from manim.utils.images import get_full_raster_image_path
@@ -20,7 +21,7 @@ class OpenGLImageMobject(OpenGLTexturedSurface):
         width: float = None,
         height: float = None,
         image_mode: str = "RGBA",
-        resampling_algorithm: int = Image.BICUBIC,
+        resampling_algorithm: int = Resampling.BICUBIC,
         opacity: float = 1,
         gloss: float = 0,
         shadow: float = 0,

--- a/manim/mobject/types/image_mobject.py
+++ b/manim/mobject/types/image_mobject.py
@@ -9,6 +9,7 @@ import pathlib
 import colour
 import numpy as np
 from PIL import Image
+from PIL.Image import Resampling
 
 from manim.mobject.geometry.shape_matchers import SurroundingRectangle
 
@@ -38,7 +39,7 @@ class AbstractImageMobject(Mobject):
         self,
         scale_to_resolution,
         pixel_array_dtype="uint8",
-        resampling_algorithm=Image.BICUBIC,
+        resampling_algorithm=Resampling.BICUBIC,
         **kwargs,
     ):
         self.pixel_array_dtype = pixel_array_dtype


### PR DESCRIPTION
# Update deprecated pillow constants

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Changed Image.<filter constant> to Resampling.<filter constant> as mentioned in the pillow deprecation message! (Introduces missing typehints from the pillow library 🤔) 
<!--changelog-end-->


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
