### PR TITLE
docs: Fixed typo in docstring

### DIFF
--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -1021,7 +1021,7 @@ class Angle(VMobject, metaclass=ConvertToOpenGL):
     ) -> Angle:
         """The angle between the lines AB and BC.
 
-        This constructs the angle :math:`\angle ABC`.
+        This constructs the angle :math:`\\angle ABC`.
 
         Parameters
         ----------


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Fixes [this open issue](https://github.com/ManimCommunity/manim/issues/2718)
There was a typo in the docstring which caused an error in how it was displayed.
<!--changelog-end-->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
[Old Documentation Page with Error](https://docs.manim.community/en/stable/reference/manim.mobject.geometry.line.Angle.html#manim.mobject.geometry.line.Angle.from_three_points)
[Fixed Documentation Page](https://manimce--2720.org.readthedocs.build/en/2720/reference/manim.mobject.geometry.line.Angle.html#manim.mobject.geometry.line.Angle.from_three_points)

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
