### PR TITLE
Fix Code mobject wrong indentation

### DIFF
--- a/manim/mobject/text/code_mobject.py
+++ b/manim/mobject/text/code_mobject.py
@@ -404,6 +404,11 @@ class Code(VGroup):
         # print(self.default_color,self.background_color)
         for i in range(3, -1, -1):
             self.html_string = self.html_string.replace("</" + " " * i, "</")
+
+        # handle pygments bug
+        # https://github.com/pygments/pygments/issues/961
+        self.html_string = self.html_string.replace("<span></span>", "")
+
         for i in range(10, -1, -1):
             self.html_string = self.html_string.replace(
                 "</span>" + " " * i,

--- a/tests/test_code_mobject.py
+++ b/tests/test_code_mobject.py
@@ -1,0 +1,15 @@
+from manim.mobject.text.code_mobject import Code
+
+
+def test_code_indentation():
+    co = Code(
+        code="""\
+    def test()
+        print("Hi")
+        """,
+        language="Python",
+        indentation_chars="    ",
+    )
+
+    assert co.tab_spaces[0] == 1
+    assert co.tab_spaces[1] == 2


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

Fixed Code mobject wrong indentation at the first line.

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Before:
![2](https://user-images.githubusercontent.com/75878387/169220931-fb5bc86e-3f0a-4dec-b295-036b48386983.png)
After:
![3](https://user-images.githubusercontent.com/75878387/169220936-b6f14853-e227-4339-b210-e404bb3f2d84.png)

Edit: made it into an executable test code 
```python
from manim import *


class CodeIndentationTest(Scene):
    def construct(self):
        co = Code(
            code="""\
            def test():
                print("Hello")""",
            language="Python",
            insert_line_no=False,
        )

        self.add(co)
        self.wait()


with tempconfig(
    {
        "quality": "medium_quality",
        "preview": True,
        "save_last_frame": True,
        "write_to_movie": False,
    }
):
    scene = CodeIndentationTest()
    scene.render()
```

<!--changelog-end-->

This is caused by pygments' bug. And It seems that they don't have the motivation to change this. https://github.com/pygments/pygments/issues/961

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

I also added the test code `test_code_mobject.py`.

I'm new here, so please point out any problems 😍😍😍


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [x] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [x] If applicable: newly added functions and classes are tested
