### PR TITLE
Fix OpenGL segfaulting when running self.play or self.wait

### DIFF
--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -1008,6 +1008,22 @@ class Scene:
             All other keywords are passed to the renderer.
 
         """
+        # Make sure this is running on the main thread
+        if threading.current_thread().name != "MainThread":
+            self.queue.put(
+                (
+                    "play",
+                    args,
+                    kwargs
+                    | {
+                        "subcaption": subcaption,
+                        "subcaption_duration": subcaption_duration,
+                        "subcaption_offset": subcaption_offset,
+                    },
+                )
+            )
+            return
+
         start_time = self.renderer.time
         self.renderer.play(self, *args, **kwargs)
         run_time = self.renderer.time - start_time

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -1010,16 +1010,18 @@ class Scene:
         """
         # Make sure this is running on the main thread
         if threading.current_thread().name != "MainThread":
+            kwargs.update(
+                {
+                    "subcaption": subcaption,
+                    "subcaption_duration": subcaption_duration,
+                    "subcaption_offset": subcaption_offset,
+                }
+            )
             self.queue.put(
                 (
                     "play",
                     args,
-                    kwargs
-                    | {
-                        "subcaption": subcaption,
-                        "subcaption_duration": subcaption_duration,
-                        "subcaption_offset": subcaption_offset,
-                    },
+                    kwargs,
                 )
             )
             return


### PR DESCRIPTION
## Overview: What does this pull request change?
self.play checks if it's running on the main thread; If it isn't, it schedules the play method to run using the queue.
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
`self.wait` and `self.play` no longer segfault when using the OpenGL renderer.


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
Closes #2669.

The cause (as much as I understand) has to do with calling OpenGL rendering from the subthread which segfaults. Therefore, attempting to run the `self.play` method from the subthread rather than through the (execution?) queue segfaults.
While it could have been nice to do something like
```python
local_namespace["self"].play = local_namespace["play"]
```
so that it just calls the "good" play, I think it's using the same object as the main thread(?) so changing the subthread's self.play changes the main's one which then probably leads to infinite recursion :(


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
