### PR TITLE
Fixed docstring of  :meth:`.VMobject.get_end_anchors`

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1331,7 +1331,7 @@ class VMobject(Mobject):
         return self.points[0 :: self.n_points_per_cubic_curve]
 
     def get_end_anchors(self) -> np.ndarray:
-        """Return the starting anchors of the bezier curves.
+        """Return the end anchors of the bezier curves.
 
         Returns
         -------


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Small fix of the docstring of [`vm.get_end_anchors()`](https://docs.manim.community/en/stable/reference/manim.mobject.types.vectorized_mobject.VMobject.html#manim.mobject.types.vectorized_mobject.VMobject.get_end_anchors). Previous version was a copy of [`vm.get_start_anchors()`](https://docs.manim.community/en/stable/reference/manim.mobject.types.vectorized_mobject.VMobject.html#manim.mobject.types.vectorized_mobject.VMobject.get_start_anchors), so i changed  "starting" to "end".

## Motivation and Explanation: Why and how do your changes improve the library?
Fixes #2733.

## Links to added or changed documentation pages
https://docs.manim.community/en/stable/reference/manim.mobject.types.vectorized_mobject.VMobject.html#manim.mobject.types.vectorized_mobject.VMobject.get_end_anchors


## Further Information and Comments
In the comments of #2733, @behackl mentioned there were doubts about the documented return type being `np.ndarray`, since a list is being returned. In order to verify this, I created a simple Circle and proceeded to 
`print(type(circle.get_end_achors()))`
from which i obtained an output of `class numpy.ndarray`. To further investigate this, I used a foreach cycle and printed the types of each of the elements that composed the Circle, to which i also obtained several `class 'numpy.ndarray'`. With this I concluded that the return type of this function is indeed a `np.ndarray` of multiple `np.ndarray`'s.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
