### PR TITLE
Remove cmake from the macos installation section

### DIFF
--- a/docs/source/installation/macos.rst
+++ b/docs/source/installation/macos.rst
@@ -34,7 +34,7 @@ are required, namely:
 
 .. code-block:: bash
 
-   brew install cmake pango scipy
+   brew install pango scipy
 
 After all required dependencies are installed, simply run:
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

mapbox-earcut already handles that for us, it installs [pybind11](https://github.com/skogler/mapbox_earcut_python/blob/master/pyproject.toml#L5) which installs [cmake](https://github.com/pybind/pybind11/blob/master/pyproject.toml#L2).


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
