### PR TITLE
polish: Add implicit docker.io/ URL base

### DIFF
--- a/docs/source/installation/jupyter.rst
+++ b/docs/source/installation/jupyter.rst
@@ -26,7 +26,7 @@ a way that allows them to be shared interactively via Binder as well:
 
    .. code-block:: dockerfile
 
-      FROM docker.io/manimcommunity/manim::v0.9.0
+      FROM docker.io/manimcommunity/manim:v0.9.0
 
       COPY --chown=manimuser:manimuser . /manim
 

--- a/docs/source/installation/jupyter.rst
+++ b/docs/source/installation/jupyter.rst
@@ -26,7 +26,7 @@ a way that allows them to be shared interactively via Binder as well:
 
    .. code-block:: dockerfile
 
-      FROM manimcommunity/manim:v0.9.0
+      FROM docker.io/manimcommunity/manim::v0.9.0
 
       COPY --chown=manimuser:manimuser . /manim
 


### PR DESCRIPTION
## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
`docker.io/` is often skipped, but it is not the only image registry. Some software or setups do not have it as default.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
