### PR TITLE
Fixed issue with ``manim init scene SCENE_NAME filename.py`` and removed necessity of ``main.py`` to be present in working directory

### DIFF
--- a/manim/cli/init/commands.py
+++ b/manim/cli/init/commands.py
@@ -149,9 +149,6 @@ def scene(**args):
 
     FILE is the name of file in which the SCENE will be inserted.
     """
-    if not Path("main.py").exists():
-        raise FileNotFoundError(f"{Path('main.py')} : Not a valid project directory.")
-
     template_name = click.prompt(
         "template",
         type=click.Choice(get_template_names(), False),
@@ -163,7 +160,10 @@ def scene(**args):
         scene = scene.replace(template_name + "Template", args["scene_name"], 1)
 
     if args["file_name"]:
-        file_name = Path(args["file_name"] + ".py")
+        if args["file_name"][-3:] == ".py":
+            file_name = args["file_name"]
+        else:
+            file_name = Path(args["file_name"] + ".py")
 
         if file_name.is_file():
             # file exists so we are going to append new scene to that file

--- a/manim/cli/init/commands.py
+++ b/manim/cli/init/commands.py
@@ -163,8 +163,9 @@ def scene(**args):
         if args["file_name"][-3:] == ".py":
             file_name = args["file_name"]
         else:
-            file_name = Path(args["file_name"] + ".py")
+            file_name = args["file_name"] + ".py"
 
+        file_name = Path(file_name)
         if file_name.is_file():
             # file exists so we are going to append new scene to that file
             with open(file_name, "a") as f:

--- a/tests/interface/test_commands.py
+++ b/tests/interface/test_commands.py
@@ -92,23 +92,27 @@ def test_manim_init_project(tmp_path):
         assert (Path(tmp_dir) / "testproject/main.py").exists()
         assert (Path(tmp_dir) / "testproject/manim.cfg").exists()
 
+
 def test_manim_init_scene(tmp_path):
     command_named = ["init", "scene", "NamedFileTestScene", "my_awesome_file.py"]
     command_unnamed = ["init", "scene", "DefaultFileTestScene"]
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path) as tmp_dir:
-        result = runner.invoke(main, command_named, prog_name="manim", input="Default\n")
+        result = runner.invoke(
+            main, command_named, prog_name="manim", input="Default\n"
+        )
         assert not result.exception
         assert (Path(tmp_dir) / "my_awesome_file.py").exists()
-        with open(Path(tmp_dir) / "my_awesome_file.py", "r") as f:
+        with open(Path(tmp_dir) / "my_awesome_file.py") as f:
             file_content = f.read()
             assert "NamedFileTestScene(Scene):" in file_content
-        result = runner.invoke(main, command_unnamed, prog_name="manim", input="Default\n")
+        result = runner.invoke(
+            main, command_unnamed, prog_name="manim", input="Default\n"
+        )
         assert (Path(tmp_dir) / "main.py").exists()
-        with open(Path(tmp_dir) / "main.py", "r") as f:
+        with open(Path(tmp_dir) / "main.py") as f:
             file_content = f.read()
             assert "DefaultFileTestScene(Scene):" in file_content
-
 
 
 def test_manim_new_command():

--- a/tests/interface/test_commands.py
+++ b/tests/interface/test_commands.py
@@ -92,6 +92,24 @@ def test_manim_init_project(tmp_path):
         assert (Path(tmp_dir) / "testproject/main.py").exists()
         assert (Path(tmp_dir) / "testproject/manim.cfg").exists()
 
+def test_manim_init_scene(tmp_path):
+    command_named = ["init", "scene", "NamedFileTestScene", "my_awesome_file.py"]
+    command_unnamed = ["init", "scene", "DefaultFileTestScene"]
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as tmp_dir:
+        result = runner.invoke(main, command_named, prog_name="manim", input="Default\n")
+        assert not result.exception
+        assert (Path(tmp_dir) / "my_awesome_file.py").exists()
+        with open(Path(tmp_dir) / "my_awesome_file.py", "r") as f:
+            file_content = f.read()
+            assert "NamedFileTestScene(Scene):" in file_content
+        result = runner.invoke(main, command_unnamed, prog_name="manim", input="Default\n")
+        assert (Path(tmp_dir) / "main.py").exists()
+        with open(Path(tmp_dir) / "main.py", "r") as f:
+            file_content = f.read()
+            assert "DefaultFileTestScene(Scene):" in file_content
+
+
 
 def test_manim_new_command():
     command = ["new"]


### PR DESCRIPTION
## Overview: What does this pull request change?
This PR resolves issue #2869. I.e. it does the following:
 - Removes the necessity of a `main.py` being present in the current working directory in order for the `manim init scene SCENE_NAME` command to be issued.
 - Manim
 - Fixes the issue with `.py` always being appended to filenames.

I suspect that there may be a bit more refining/updating required on this PR before it's ready for merge, but I'm not sure where. Just let me know what other changes should be made to this part of the project and I will happily implement them :)

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
