### PR TITLE
Fix graph animation when adding vertex and edge together

### DIFF
--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -834,16 +834,12 @@ class Graph(VMobject, metaclass=ConvertToOpenGL):
         animation = anim_args.pop("animation", Create)
 
         vertex_mobjects = self._create_vertices(*args, **kwargs)
-
-        def on_finish(scene: Scene):
-            for v in vertex_mobjects:
-                scene.remove(v[-1])
-                self._add_created_vertex(*v)
+        for v in vertex_mobjects:
+            self._add_created_vertex(*v)
 
         return AnimationGroup(
             *(animation(v[-1], **anim_args) for v in vertex_mobjects),
             group=self,
-            _on_finish=on_finish,
         )
 
     def _remove_vertex(self, vertex):


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

Vertex and edges when added using `.animate` results in error.

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

When vertex and edges are added using `.animate` to a graph simulatenously, the vertex doesn't update the graph till its animation is finished. In the meantime, edge animation will place new edges on its own, overriding the vertex positioning, and an error shows when the vertex animation finally finishes and calls `on_finish` to update the graph.
Instead, we can update the graph before playing the vertex animation and everything works as expected

```py

self.play(
    LaggedStart(
        g.animate.add_vertices(
            3, 4, positions={3: UP, 4: DOWN},
        ),
        g.animate.add_edges((1, 3), (3, 2), (1, 4), (4, 2)),
        lag_ratio=0.2,
    )
)

```
#### Before:

`ValueError: Vertex identifier '3' is already used for a vertex in this graph.`

#### After:

https://user-images.githubusercontent.com/43041139/179371632-65017dff-42c4-45ab-90c2-4ada717c8684.mp4



## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->




## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
