### PR TITLE
Always expand user when validating file-paths

### DIFF
--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -125,8 +125,8 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
         if self.file_name is None:
             raise Exception("Must specify file for SVGMobject")
 
-        if self.file_name.exists():
-            self.file_path = self.file_name
+        if self.file_name.expanduser().exists():
+            self.file_path = self.file_name.expanduser()
             return
 
         relative = Path.cwd() / self.file_name

--- a/manim/mobject/text/code_mobject.py
+++ b/manim/mobject/text/code_mobject.py
@@ -285,7 +285,7 @@ class Code(VGroup):
             raise Exception("Must specify file for Code")
         possible_paths = [
             os.path.join(os.path.join("assets", "codes"), self.file_name),
-            self.file_name,
+            os.path.expanduser(self.file_name),
         ]
         for path in possible_paths:
             if os.path.exists(path):

--- a/manim/utils/file_ops.py
+++ b/manim/utils/file_ops.py
@@ -161,7 +161,7 @@ def guarantee_empty_existence(path: Path) -> Path:
 def seek_full_path_from_defaults(
     file_name: str, default_dir: Path, extensions: list[str]
 ) -> Path:
-    possible_paths = [Path(file_name)]
+    possible_paths = [Path(file_name).expanduser()]
     possible_paths += [
         Path(default_dir) / f"{file_name}{extension}" for extension in ["", *extensions]
     ]


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->
Fixes #2878 
The users are expanded when providing a file-path for the following
mobjects:
- CodeMobjects
- ImageMobjects (or any class/object that calls `file_ops.seek_full_path_from_defaults`)
- SVGMobjects

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
Should probably shift usage to pathlib.Path in places where `os.path` is used, lemme know if you wanna have that be a part of this PR.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
