### PR TITLE
Corrected error in the ``PolygonOnAxes`` example

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -415,8 +415,8 @@ Plotting with Manim
             return [
                 (top_right[0], top_right[1]),
                 (bottom_left[0], top_right[1]),
-                (bottom_left[0], bottom_left[0]),
-                (top_right[0], bottom_left[0]),
+                (bottom_left[0], bottom_left[1]),
+                (top_right[0], bottom_left[1]),
             ]
 
         def construct(self):


### PR DESCRIPTION
The PolygonOnAxes example get_rectangle_corners was only using the x coordinates of the bottom left corner of the rectangle, not its y coordinate.

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

Corrected the example to use the y coordinates of for the rectangle's bottom left corner.

<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--2892.org.readthedocs.build/en/2892/, where #### represents the PR number. -->
https://manimce--2892.org.readthedocs.build/en/2892/examples.html#polygononaxes


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [X] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [n/a] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [n/a] If applicable: newly added functions and classes are tested
