### PR TITLE
Fixed broken :class:`.ShowPassingFlashWithThinningStrokeWidth`

### DIFF
--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -330,7 +330,7 @@ class ShowPassingFlashWithThinningStrokeWidth(AnimationGroup):
         super().__init__(
             *(
                 ShowPassingFlash(
-                    vmobject.deepcopy().set_stroke(width=stroke_width),
+                    vmobject.copy().set_stroke(width=stroke_width),
                     time_width=time_width,
                     **kwargs,
                 )


### PR DESCRIPTION
## Overview: What does this pull request change?

The `ShowPassingFlashWithThinningStrokeWidth` animation is currently broken because `VMobject.deepcopy` is called, which does not exist. This PR changes `deepcopy` to `copy`.