### PR TITLE
fix: SoundExample video autoplaying with sound

### DIFF
--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -1497,6 +1497,7 @@ class Scene:
         Examples
         --------
         .. manim:: SoundExample
+            :no_autoplay:
 
             class SoundExample(Scene):
                 # Source of sound under Creative Commons 0 License. https://freesound.org/people/Druminfected/sounds/250551/

--- a/manim/utils/docbuild/manim_directive.py
+++ b/manim/utils/docbuild/manim_directive.py
@@ -47,6 +47,10 @@ directive:
         If this flag is present without argument,
         the source code is not displayed above the rendered video.
 
+    no_autoplay
+        If this flag is present without argument,
+        the video will not autoplay.
+
     quality : {'low', 'medium', 'high', 'fourk'}
         Controls render quality of the video, in analogy to
         the corresponding command line flags.
@@ -142,6 +146,7 @@ class ManimDirective(Directive):
     optional_arguments = 0
     option_spec = {
         "hide_source": bool,
+        "no_autoplay": bool,
         "quality": lambda arg: directives.choice(
             arg,
             ("low", "medium", "high", "fourk"),
@@ -190,6 +195,7 @@ class ManimDirective(Directive):
             classnamedict[clsname] += 1
 
         hide_source = "hide_source" in self.options
+        no_autoplay = "no_autoplay" in self.options
         save_as_gif = "save_as_gif" in self.options
         save_last_frame = "save_last_frame" in self.options
         assert not (save_as_gif and save_last_frame)
@@ -242,6 +248,7 @@ class ManimDirective(Directive):
 
         example_config = {
             "frame_rate": frame_rate,
+            "no_autoplay": no_autoplay,
             "pixel_height": pixel_height,
             "pixel_width": pixel_width,
             "save_last_frame": save_last_frame,
@@ -295,6 +302,7 @@ class ManimDirective(Directive):
             clsname_lowercase=clsname.lower(),
             hide_source=hide_source,
             filesrc_rel=Path(filesrc).relative_to(setup.confdir).as_posix(),
+            no_autoplay=no_autoplay,
             output_file=output_file,
             save_last_frame=save_last_frame,
             save_as_gif=save_as_gif,
@@ -382,7 +390,13 @@ TEMPLATE = r"""
 {% if not (save_as_gif or save_last_frame) %}
 .. raw:: html
 
-    <video class="manim-video" controls loop autoplay src="./{{ output_file }}.mp4"></video>
+    <video
+        class="manim-video"
+        controls
+        loop
+        {{ '' if no_autoplay else 'autoplay' }}
+        src="./{{ output_file }}.mp4">
+    </video>
 
 {% elif save_as_gif %}
 .. image:: /{{ filesrc_rel }}


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
It adds a no_autoplay option to the directive. This flag has been added to the SoundExample within the Scene documentation to prevent the video autoplaying with sound.
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
This is a bugfix that should improve user experience by added a more consistent browsing experience within the documentation.
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->

## Further Information and Comments
There is an alternative fix for this achieved by adding the muted attribute to the video tag. This would mute all videos by default.
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
