### PR TITLE
Fix Circumscribe (#2563)

### DIFF
--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -559,7 +559,7 @@ class Wiggle(Animation):
         )
 
 
-class Circumscribe(Succession):
+class Circumscribe(AnimationGroup):
     """Draw a temporary line surrounding the mobject.
 
     Parameters
@@ -633,21 +633,27 @@ class Circumscribe(Succession):
 
         if fade_in and fade_out:
             super().__init__(
+                Succession(
                 FadeIn(frame, run_time=run_time / 2),
-                FadeOut(frame, run_time=run_time / 2),
+                FadeOut(frame, run_time=run_time / 2)
+                ),
                 **kwargs,
             )
         elif fade_in:
             frame.reverse_direction()
             super().__init__(
+                Succession(
                 FadeIn(frame, run_time=run_time / 2),
-                Uncreate(frame, run_time=run_time / 2),
+                Uncreate(frame, run_time=run_time / 2)
+                ),
                 **kwargs,
             )
         elif fade_out:
             super().__init__(
+                Succession(
                 Create(frame, run_time=run_time / 2),
-                FadeOut(frame, run_time=run_time / 2),
+                FadeOut(frame, run_time=run_time / 2)
+                ),
                 **kwargs,
             )
         else:

--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -634,8 +634,8 @@ class Circumscribe(AnimationGroup):
         if fade_in and fade_out:
             super().__init__(
                 Succession(
-                FadeIn(frame, run_time=run_time / 2),
-                FadeOut(frame, run_time=run_time / 2)
+                    FadeIn(frame, run_time=run_time / 2),
+                    FadeOut(frame, run_time=run_time / 2),
                 ),
                 **kwargs,
             )
@@ -643,16 +643,16 @@ class Circumscribe(AnimationGroup):
             frame.reverse_direction()
             super().__init__(
                 Succession(
-                FadeIn(frame, run_time=run_time / 2),
-                Uncreate(frame, run_time=run_time / 2)
+                    FadeIn(frame, run_time=run_time / 2),
+                    Uncreate(frame, run_time=run_time / 2),
                 ),
                 **kwargs,
             )
         elif fade_out:
             super().__init__(
                 Succession(
-                Create(frame, run_time=run_time / 2),
-                FadeOut(frame, run_time=run_time / 2)
+                    Create(frame, run_time=run_time / 2),
+                    FadeOut(frame, run_time=run_time / 2),
                 ),
                 **kwargs,
             )


### PR DESCRIPTION

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Fix the problem that the argument run_time is not successfully passed to `Circumscribe` when it is passed inside `Scene.play()` but outside `Circumscribe()`.
Change the superclass of `Circumscribe` from `Succession` to `AnimationGroup` and call the class `Succession` later in the class `Circumscribe` when there are multiple animations in succession.

<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
bugfix(#2563)
Now the run time of circumscribe can be set in `Scene.play()`

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
