### PR TITLE
Disabled "Edit on GitHub" button in documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -99,6 +99,10 @@ html_favicon = str(Path("_static/favicon.ico"))
 html_static_path = ["_static"]
 
 html_theme_options = {
+    "source_repository": "https://github.com/ManimCommunity/manim/",
+    "source_branch": "main",
+    "source_directory": "docs/source/",
+    "top_of_page_button": None,
     "light_logo": "manim-logo-sidebar.svg",
     "dark_logo": "manim-logo-sidebar-dark.svg",
     "light_css_variables": {


### PR DESCRIPTION
The "Edit on GitHub" button from the `furo` theme is currently implemented in a way that does not support autodoc-generated pages.

This disables the button for now (but also provides the correct configuration in case autodoc-generated pages are supported at some point).

Closes #2960.