### PR TITLE
Implemented fallback save behavior for `pytest --show_diff`

### DIFF
--- a/manim/utils/testing/_frames_testers.py
+++ b/manim/utils/testing/_frames_testers.py
@@ -49,7 +49,12 @@ class _FramesTester:
             self._frames_compared += 1
         except AssertionError as e:
             if self._show_diff:
-                show_diff_helper(frame_number, frame, self._frames[frame_number])
+                show_diff_helper(
+                    frame_number,
+                    frame,
+                    self._frames[frame_number],
+                    self._file_path.name,
+                )
             raise e
 
 

--- a/manim/utils/testing/_show_diff.py
+++ b/manim/utils/testing/_show_diff.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import logging
 import warnings
 
@@ -53,4 +54,3 @@ def show_diff_helper(
                 "Interactive matplotlib interface not available,"
                 f" diff saved to {filename}."
             )
-

--- a/manim/utils/testing/_show_diff.py
+++ b/manim/utils/testing/_show_diff.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import logging
+import warnings
 
 import numpy as np
 
@@ -7,6 +9,7 @@ def show_diff_helper(
     frame_number: int,
     frame_data: np.ndarray,
     expected_frame_data: np.ndarray,
+    control_data_filename: str,
 ):
     """Will visually display with matplotlib differences between frame generated and the one expected."""
     import matplotlib.gridspec as gridspec
@@ -18,11 +21,11 @@ def show_diff_helper(
 
     ax = fig.add_subplot(gs[0, 0])
     ax.imshow(frame_data)
-    ax.set_title("Generated :")
+    ax.set_title("Generated")
 
     ax = fig.add_subplot(gs[0, 1])
     ax.imshow(expected_frame_data)
-    ax.set_title("Expected :")
+    ax.set_title("Expected")
 
     ax = fig.add_subplot(gs[1, :])
     diff_im = expected_frame_data.copy()
@@ -37,6 +40,17 @@ def show_diff_helper(
         np.array([255, 0, 0, 255], dtype="uint8"),
     )  # Set any different pixels to red
     ax.imshow(diff_im, interpolation="nearest")
-    ax.set_title("Differences summary : (green = same, red = different)")
+    ax.set_title("Difference summary: (green = same, red = different)")
 
-    plt.show()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        try:
+            plt.show()
+        except UserWarning:
+            filename = f"{control_data_filename[:-4]}-diff.pdf"
+            plt.savefig(filename)
+            logging.warning(
+                "Interactive matplotlib interface not available,"
+                f" diff saved to {filename}."
+            )
+


### PR DESCRIPTION
In my current setup, `matplotlib` loads with a backend (`agg`) without support for opening an interactive plot via the `.show` method. With this minor adjustment, the diff summary is saved in a .pdf file if displaying the plot interactively fails.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
