### PR TITLE
Import svg_path during init so that SVGPathMobject is accessible.

### DIFF
--- a/manim/__init__.py
+++ b/manim/__init__.py
@@ -73,6 +73,7 @@ from .mobject.opengl.dot_cloud import *
 from .mobject.opengl.opengl_point_cloud_mobject import *
 from .mobject.svg.brace import *
 from .mobject.svg.svg_mobject import *
+from .mobject.svg.svg_path import *
 from .mobject.table import *
 from .mobject.text.code_mobject import *
 from .mobject.text.numbers import *


### PR DESCRIPTION
## Overview: What does this pull request change?
Import the svg_path module by default so that SVGPathMobject is accessible when importing * from manim.

## Motivation and Explanation: Why and how do your changes improve the library?
The svg_path module was not loaded in `__init__.py` along with the other SVG modules, making SVGPathMobject inaccessible by default. This commit fixes #2943.

## Links to added or changed documentation pages
N/A

## Further Information and Comments
N/A

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
