### PR TITLE
Add encoding for `open()` function in text_file_writing module

### DIFF
--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -250,7 +250,7 @@ def print_all_tex_errors(log_file, tex_compiler, tex_file):
             f"{tex_compiler} failed but did not produce a log file. "
             "Check your LaTeX installation.",
         )
-    with open(log_file) as f:
+    with open(log_file, encoding="utf-8") as f:
         tex_compilation_log = f.readlines()
         error_indices = [
             index


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->
Fixes reading tex error logs when it contains utf-8 characters.

## Motivation and Explanation: Why and how do your changes improve the library?
Saw this message https://discord.com/channels/581738731934056449/1030665460280197220/1030665460280197220 and found that the `open` is missing the `encoding` parameter which was the root cause of that error. By default, on windows, `open` doesn't use `utf-8` encoding and that's why it was throwing an error.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
