### PR TITLE
Fixed setting ``run_time`` of :class:`.Succession` after creating the animation object

### DIFF
--- a/manim/animation/composition.py
+++ b/manim/animation/composition.py
@@ -166,7 +166,7 @@ class Succession(AnimationGroup):
         self.update_active_animation(self.active_index + 1)
 
     def interpolate(self, alpha: float) -> None:
-        current_time = self.rate_func(alpha) * self.run_time
+        current_time = self.rate_func(alpha) * self.max_end_time
         while self.active_end_time is not None and current_time >= self.active_end_time:
             self.next_animation()
         if self.active_animation is not None and self.active_start_time is not None:

--- a/tests/module/animation/test_composition.py
+++ b/tests/module/animation/test_composition.py
@@ -90,6 +90,26 @@ def test_succession_in_succession_timing():
     assert nested_succession.active_animation is None
 
 
+def test_timescaled_succession():
+    s1, s2, s3 = Square(), Square(), Square()
+    anim = Succession(
+        FadeIn(s1, run_time=2),
+        FadeIn(s2),
+        FadeIn(s3),
+    )
+    anim.scene = MagicMock()
+    anim.run_time = 42
+    anim.begin()
+    anim.interpolate(0.2)
+    assert anim.active_index == 0
+    anim.interpolate(0.4)
+    assert anim.active_index == 0
+    anim.interpolate(0.6)
+    assert anim.active_index == 1
+    anim.interpolate(0.8)
+    assert anim.active_index == 2
+
+
 def test_animationbuilder_in_group():
     sqr = Square()
     circ = Circle()


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

Fixes #2563, fixes #2711: For `Succsession`, the animation run time was not processed correctly if the `run_time` attribute was set after creation of the animation object. This happens, for example, if the `run_time` keyword argument of `Scene.play` is passed like this:

```py
self.play(
    Succession(anim1, anim2, ...),
    run_time=42
)
```

This also supersedes #2913. I have also included a test for this fix.