### PR TITLE
Fixed docbuild warnings

### DIFF
--- a/docs/source/installation/windows.rst
+++ b/docs/source/installation/windows.rst
@@ -55,7 +55,7 @@ the :ref:`optional dependencies <win-optional-dependencies>` section
 below.
 
 Winget
-*****
+******
 
 While there is no recipe for installing Manim with Winget directly,
 you can install all requirements by running:


### PR DESCRIPTION
This adds one asterisk to make the underline of one subsection long enough.