### PR TITLE
enable z_index in Circumscribe

### DIFF
--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -612,17 +612,17 @@ class Circumscribe(Succession):
         color: Color = YELLOW,
         run_time=1,
         stroke_width=DEFAULT_STROKE_WIDTH,
+        z_index: int = 0,
         **kwargs
     ):
         if shape is Rectangle:
             frame = SurroundingRectangle(
-                mobject,
-                color,
-                buff,
-                stroke_width=stroke_width,
+                mobject, color, buff, stroke_width=stroke_width, z_index=z_index
             )
         elif shape is Circle:
-            frame = Circle(color=color, stroke_width=stroke_width).surround(
+            frame = Circle(
+                color=color, stroke_width=stroke_width, z_index=z_index
+            ).surround(
                 mobject,
                 buffer_factor=1,
             )


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
adds `z_index` parameter to `Circumscribe` constructor so it can be used for the `z_index` of the `frame` (`SurroundingRectangle` or `Circle`)
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
