### PR TITLE
Include latex install instructions on ubuntu

### DIFF
--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -138,6 +138,12 @@ to install with your package manager. Usually,
 `TeX Live <https://www.tug.org/texlive/>`__ is a good candidate if you don't
 care too much about disk space.
 
+For Ubuntu, sufficient latex can be installed by running:
+
+.. code-block:: bash
+
+   sudo apt install texlive texlive-latex-extra
+
 Should you choose to work with some smaller TeX distribution like
 `TinyTeX <https://yihui.org/tinytex/>`__ , the full list
 of LaTeX packages which Manim interacts with in some way (a subset might


### PR DESCRIPTION
## Overview: What does this pull request change?

The PR adds instructions to install `latex` package on `Ubuntu`. `texlive-latex-extra` turned out to be [necessary](https://tex.stackexchange.com/a/270895/129251) to overcome the following error:

```
! LaTeX Error: File `standalone.cls' not found.
```

Tested on Ubuntu 22.04.1.

## Motivation and Explanation: Why and how do your changes improve the library?

I installed Manim for the first time in a year and on a new system, and was running into dependency issues when executing an example.

## Links to added or changed documentation pages

https://docs.manim.community/en/stable/installation/linux.html

- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
