### PR TITLE
[docs] Add Debian dependencies required for pycairo and manimpango

### DIFF
--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -39,7 +39,7 @@ simply run:
 .. code-block:: bash
 
    sudo apt update
-   sudo apt install libcairo2-dev libpango1.0-dev ffmpeg
+   sudo apt install build-essential python3-dev libcairo2-dev libpango1.0-dev ffmpeg
 
 If you don't have python3-pip installed, install it via:
 


### PR DESCRIPTION
Without these packages, using `poetry install` fails installing the pycairo and manimpango packages because there is no C++ compiler nor python headers to compile parts of those packages.

## Overview: What does this pull request change?
I needed these instructions when setting up a dev environment on Linux (technically the Linux on Windows subsystem, but it probably is needed for normal Debian/Ubuntu as well).

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
