### PR TITLE
Scene.remove: retain mobject while removing matching submobjects

### DIFF
--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -611,7 +611,8 @@ class Scene:
     def get_restructured_mobject_list(self, mobjects: list, to_remove: list):
         """
         Given a list of mobjects and a list of mobjects to be removed, this
-        filters out the removable mobjects from the list of mobjects.
+        filters out the removable mobjects from the list of mobjects
+        and from the submobjects of those mobjects.
 
         Parameters
         ----------

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -628,19 +628,23 @@ class Scene:
             The list of mobjects with the mobjects to remove removed.
         """
 
-        new_mobjects = []
-
         def add_safe_mobjects_from_list(list_to_examine, set_to_remove):
+            new_mobjects = []
             for mob in list_to_examine:
                 if mob in set_to_remove:
                     continue
                 intersect = set_to_remove.intersection(mob.get_family())
                 if intersect:
-                    add_safe_mobjects_from_list(mob.submobjects, intersect)
+                    mob.submobjects = add_safe_mobjects_from_list(
+                        mob.submobjects, intersect
+                    )
+                    new_mobjects += [mob]
                 else:
-                    new_mobjects.append(mob)
+                    new_mobjects += [mob]
 
-        add_safe_mobjects_from_list(mobjects, set(to_remove))
+            return new_mobjects
+
+        new_mobjects = add_safe_mobjects_from_list(mobjects, set(to_remove))
         return new_mobjects
 
     # TODO, remove this, and calls to this

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -636,10 +636,11 @@ class Scene:
                     continue
                 intersect = set_to_remove.intersection(mob.get_family())
                 if intersect:
-                    mob.submobjects = add_safe_mobjects_from_list(
+                    newmob = mob.copy()
+                    newmob.submobjects = add_safe_mobjects_from_list(
                         mob.submobjects, intersect
                     )
-                    new_mobjects += [mob]
+                    new_mobjects += [newmob]
                 else:
                     new_mobjects += [mob]
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
The scene.remove, when it finds an intersection of the mobject family with the set of targets, will now retain the containing mobject while removing the matching submobjects.

Previously it entirely replacing the mobject with its submobjects before removing the matches.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
The motivation for this was the behaviour of the number line in [this](https://github.com/ManimCommunity/manim/issues/3027#issuecomment-1321851304) comment, where attempting to remove the numbers from the number line would actually remove the line itself, leaving only the tickmarks. The cause of this was that when trying to remove a submobject (ie. the DecimalNumbers), the NumberLine was expanded into its submobjects first. Therefore the line itself was missing.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
