### PR TITLE
Unicode encoding in add_subcaption()

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -727,7 +727,7 @@ class SceneFileWriter:
     def write_subcaption_file(self):
         """Writes the subcaption file."""
         subcaption_file = Path(config.output_file).with_suffix(".srt")
-        subcaption_file.write_text(srt.compose(self.subcaptions))
+        subcaption_file.write_text(srt.compose(self.subcaptions), encoding="utf-8")
         logger.info(f"Subcaption file has been written as {subcaption_file}")
 
     def print_file_ready_message(self, file_path):


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

Fix issue with saving subtitles. See the discord forum post: https://discord.com/channels/581738731934056449/1048185098220085299

`add_subcaption()` causes an error on Windows with Vietnamese (and possibly with other non-ASCII) characters.

Note that this bug was experienced by another user, and I can't reproduce it on Mac. Here are the user's specs:

> I use Window 11 - 22H2 OS Build 22621.900 with Python 3.10.8.

I suggested to the user the fix included in this PR and they said it fixed their problem.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

I added the argument `encoding="utf-8"` to `file.write_text()`. Do you think this will account for all the edge cases in the future? Should we add some logic to retrieve the encoding from the string? My intuition says we don't need to, Unicode got us covered.

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

The error message:

```
| C:\Program Files\Python310\lib\site-packages\manim\cli\render\commands.py:115 in render          │
│                                                                                                  │
│   112 │   │   │   try:                                                                           │
│   113 │   │   │   │   with tempconfig({}):                                                       │
│   114 │   │   │   │   │   scene = SceneClass()                                                   │
│ ❱ 115 │   │   │   │   │   scene.render()                                                         │
│   116 │   │   │   except Exception:                                                              │
│   117 │   │   │   │   error_console.print_exception()                                            │
│   118 │   │   │   │   sys.exit(1)                                                                │
│                                                                                                  │
│ C:\Program Files\Python310\lib\site-packages\manim\scene\scene.py:233 in render                  │
│                                                                                                  │
│    230 │   │   │   return True                                                                   │
│    231 │   │   self.tear_down()                                                                  │
│    232 │   │   # We have to reset these settings in case of multiple renders.                    │
│ ❱  233 │   │   self.renderer.scene_finished(self)                                                │
│    234 │   │                                                                                     │
│    235 │   │   # Show info only if animations are rendered or to get image                       │
│    236 │   │   if (                                                                              │
│                                                                                                  │
│ C:\Program Files\Python310\lib\site-packages\manim\renderer\cairo_renderer.py:259 in             │
│ scene_finished                                                                                   │
│                                                                                                  │
│   256 │   def scene_finished(self, scene):                                                       │
│   257 │   │   # If no animations in scene, render an image instead                               │
│   258 │   │   if self.num_plays:                                                                 │
│ ❱ 259 │   │   │   self.file_writer.finish()                                                      │
│   260 │   │   elif config.write_to_movie:                                                        │
│   261 │   │   │   config.save_last_frame = True                                                  │
│   262 │   │   │   config.write_to_movie = False                                                  │
│                                                                                                  │
│ C:\Program Files\Python310\lib\site-packages\manim\scene\scene_file_writer.py:468 in finish      │
│                                                                                                  │
│   465 │   │   │   target_dir = self.image_file_path.parent / self.image_file_path.stem           │
│   466 │   │   │   logger.info("\n%i images ready at %s\n", self.frame_count, str(target_dir))    │
│   467 │   │   if self.subcaptions:                                                               │
│ ❱ 468 │   │   │   self.write_subcaption_file()                                                   │
│   469 │                                                                                          │
│   470 │   def open_movie_pipe(self, file_path=None):                                             │
│   471 │   │   """                                                                                │
│                                                                                                  │
│ C:\Program Files\Python310\lib\site-packages\manim\scene\scene_file_writer.py:730 in             │
│ write_subcaption_file                                                                            │
│                                                                                                  │
│   727 │   def write_subcaption_file(self):                                                       │
│   728 │   │   """Writes the subcaption file."""                                                  │
│   729 │   │   subcaption_file = Path(config.output_file).with_suffix(".srt")                     │
│ ❱ 730 │   │   subcaption_file.write_text(srt.compose(self.subcaptions))                          │
│   731 │   │   logger.info(f"Subcaption file has been written as {subcaption_file}")              │
│   732 │                                                                                          │
│   733 │   def print_file_ready_message(self, file_path):                                         │
│                                                                                                  │
│ C:\Program Files\Python310\lib\pathlib.py:1155 in write_text                                     │
│                                                                                                  │
│   1152 │   │   │   │   │   │   │   data.__class__.__name__)                                      │
│   1153 │   │   encoding = io.text_encoding(encoding)                                             │
│   1154 │   │   with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f  │
│ ❱ 1155 │   │   │   return f.write(data)                                                          │
│   1156 │                                                                                         │
│   1157 │   def readlink(self):                                                                   │
│   1158 │   │   """                                                                               │
│                                                                                                  │
│ C:\Program Files\Python310\lib\encodings\cp1252.py:19 in encode                                  │
│                                                                                                  │
│    16                                                                                            │
│    17 class IncrementalEncoder(codecs.IncrementalEncoder):                                       │
│    18 │   def encode(self, input, final=False):                                                  │
│ ❱  19 │   │   return codecs.charmap_encode(input,self.errors,encoding_table)[0]                  │
│    20                                                                                            │
│    21 class IncrementalDecoder(codecs.IncrementalDecoder):                                       │
│    22 │   def decode(self, input, final=False):                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
UnicodeEncodeError: 'charmap' codec can't encode characters in position 48-50: character maps to <undefined>
```

The Python file that raised the error. (I guess there could be a more minimal MWE, but I don't think it's worth the time as the fix is obvious.)

```
python from manim import *
from manim_voiceover import VoiceoverScene
from manim_voiceover.services.gtts import GTTSService

class vietnam(VoiceoverScene):
    def construct(self):
        # Set the lang argument to another language code.
        self.set_speech_service(GTTSService(lang="vi"))

        circle = Circle()
        square = Square().shift(2 * RIGHT)

        with self.voiceover(text="Vòng tròn này được vẽ khi tôi nói.") as tracker:
            self.play(Create(circle), run_time=tracker.duration)

        with self.voiceover(text="Hãy chuyển nó sang bên trái 2 đơn vị.") as tracker:
            self.play(circle.animate.shift(2 * LEFT), run_time=tracker.duration)

        with self.voiceover(
            text="Bây giờ hãy biến nó thành một hình vuông."
        ) as tracker:
            self.play(Transform(circle, square), run_time=tracker.duration)

        with self.voiceover(text="Cảm ơn vì đã xem."):
            self.play(Uncreate(circle))

        self.wait()
```


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
