### PR TITLE
Fix typo: "Whetherer" to "Whether"

### DIFF
--- a/manim/mobject/graphing/scale.py
+++ b/manim/mobject/graphing/scale.py
@@ -124,7 +124,7 @@ class LogBase(_ScaleBase):
             The base of the log, by default 10.
         custom_labels
             For use with :class:`~.Axes`:
-            Whetherer or not to include ``LaTeX`` axis labels, by default True.
+            Whether or not to include ``LaTeX`` axis labels, by default True.
 
         Examples
         --------


### PR DESCRIPTION
In manim/mobjet/graphing/scale.py, line 127, fixing typo "whetherer" to "whether". Ignore this if it's not a typo.