### PR TITLE
Updating ci syntax for runner version >=2.298.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: test on 3.8 and 3.11
-        python: ["3.10.7"]
+        python: ["3.8.16", "3.11.1"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
         with:
           packages: texlive texlive-latex-extra texlive-fonts-extra texlive-latex-recommended texlive-science texlive-fonts-extra tipa python3-opengl libpango1.0-dev xvfb
           version: 1.0
+          execute_install_scripts: true
 
       - name: Set screen size (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,16 +79,16 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
+      - name: Install Poetry
+        run: |
+          pipx install poetry
+          poetry config virtualenvs.prefer-active-python true
+
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           cache: "poetry"
-
-      - name: Install Poetry
-        run: |
-          pipx install poetry
-          poetry config virtualenvs.prefer-active-python true
 
       - name: Setup macOS PATH
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
         run: |
           cd docs && poetry run make doctest O=-tskip-manim
 
-
   test:
     runs-on: ${{ matrix.os }}
     env:
@@ -96,8 +95,8 @@ jobs:
         shell: bash
         id: cache-vars
         run: |
-          echo "::set-output name=poetry-venv-dir::$(poetry config virtualenvs.path)"
-          echo "::set-output name=date::$(/bin/date -u "+%m%w%Y")"
+          echo "poetry-venv-dir=$(poetry config virtualenvs.path)" >> $GITHUB_STATE
+          echo "date=bin/date -u "+%m%w%Y")" >> $GITHUB_STATE >> $GITHUB_STATE
 
       - name: Setup Poetry cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: self-hosted
     env:
       DISPLAY: :0
-      PYTEST_ADDOPTS: "--color=yes" # colors in pytest
+      PYTEST_ADDOPTS: '--color=yes' # colors in pytest
     strategy:
       fail-fast: false
       matrix:
         # TODO: test on 3.8 and 3.11
-        python: ["3.10.7"]
+        python: ['3.10.7']
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -65,12 +65,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       DISPLAY: :0
-      PYTEST_ADDOPTS: "--color=yes" # colors in pytest
+      PYTEST_ADDOPTS: '--color=yes' # colors in pytest
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout the repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
+          cache-dependency-path: "./docs/requirements.txt"
 
       - name: Installing Python ${{matrix.python}} doctest Requirements
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
         shell: bash
         id: cache-vars
         run: |
-          echo "poetry-venv-dir=$(poetry config virtualenvs.path)" >> $GITHUB_STATE
-          echo "date=bin/date -u "+%m%w%Y")" >> $GITHUB_STATE >> $GITHUB_STATE
+          echo 'poetry-venv-dir=$(poetry config virtualenvs.path)' >> $GITHUB_STATE
+          echo 'date=bin/date -u "+%m%w%Y")' >> $GITHUB_STATE
 
       - name: Setup Poetry cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,14 @@ jobs:
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: dtexlive texlive-latex-extra texlive-fonts-extra texlive-latex-recommended texlive-science texlive-fonts-extra tipa python3-opengl libpango1.0-dev xvfb
+          version: 1.0
+
+      - name: Set screen size (Linux)
+        if: runner.os == 'Linux'
         run: |
-          sudo apt update
-          sudo apt-get -y install texlive texlive-latex-extra texlive-fonts-extra texlive-latex-recommended texlive-science texlive-fonts-extra tipa python3-opengl libpango1.0-dev xvfb
           # start xvfb in background
           sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         uses: teatimeguest/setup-texlive-action@v2
         with:
           cache: true
-          packages: scheme-basic standalone inputenc fontenc setspace tipa relsize mathrsfs calligra wasysym ragged2e physics xcolor microtype preview
+          packages: scheme-basic inputenc fontenc tipa mathrsfs calligra xcolor standalone preview doublestroke ms everysel setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english gnu-freefont mathastext cbfonts-fd
 
       - name: Set screen size (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         uses: teatimeguest/setup-texlive-action@v2
         with:
           cache: true
-          packages: scheme-basic standalone inputenc fontenc setspace tipa relsize mathrsfs calligra wasysym ragged2e physics xcolor microtype
+          packages: scheme-basic standalone inputenc fontenc setspace tipa relsize mathrsfs calligra wasysym ragged2e physics xcolor microtype preview
 
       - name: Set screen size (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
         shell: bash
         id: cache-vars
         run: |
-          echo 'poetry-venv-dir=$(poetry config virtualenvs.path)' >> $GITHUB_STATE
-          echo 'date=$(/bin/date -u "+%m%w%Y")' >> $GITHUB_STATE
+          echo 'poetry-venv-dir=$(poetry config virtualenvs.path)' >> $GITHUB_OUTPUT
+          echo 'date=$(/bin/date -u "+%m%w%Y")' >> $GITHUB_OUTPUT
 
       - name: Setup Poetry cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         uses: teatimeguest/setup-texlive-action@v2
         with:
           cache: true
-          packages: scheme-basic inputenc fontenc tipa mathrsfs calligra xcolor standalone preview doublestroke ms everysel setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english gnu-freefont mathastext cbfonts-fd
+          packages: scheme-basic fontspec inputenc fontenc tipa mathrsfs calligra xcolor standalone preview doublestroke ms everysel setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english gnu-freefont mathastext cbfonts-fd
 
       - name: Set screen size (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: dtexlive texlive-latex-extra texlive-fonts-extra texlive-latex-recommended texlive-science texlive-fonts-extra tipa python3-opengl libpango1.0-dev xvfb
+          packages: texlive texlive-latex-extra texlive-fonts-extra texlive-latex-recommended texlive-science texlive-fonts-extra tipa python3-opengl libpango1.0-dev xvfb
           version: 1.0
 
       - name: Set screen size (Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,16 +114,15 @@ jobs:
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: texlive texlive-latex-extra texlive-fonts-extra texlive-latex-recommended texlive-science tipa python3-opengl libpango1.0-dev xvfb
+          packages: tipa python3-opengl libpango1.0-dev xvfb
           version: 1.0
-          execute_install_scripts: true
 
       - name: Install Texlive (Linux)
         if: runner.os == 'Linux'
         uses: teatimeguest/setup-texlive-action@v2
         with:
           cache: true
-          packages: latex-extra fonts-extra latex-recommended science
+          packages: scheme-basic
 
       - name: Set screen size (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-          cache: "pip"
-          cache-dependency-path: "./docs/requirements.txt"
-
-      - name: Installing Python ${{matrix.python}} doctest Requirements
-        run: |
-          pip install -r ./docs/requirements.txt
+          cache: "poetry"
 
       - name: Install Poetry
         run: |
@@ -104,14 +99,7 @@ jobs:
         shell: bash
         id: cache-vars
         run: |
-          echo "poetry-venv-dir=$(poetry config virtualenvs.path)" >> $GITHUB_OUTPUT
           echo "date=$(/bin/date -u "+%m%w%Y")" >> $GITHUB_OUTPUT
-
-      - name: Setup Poetry cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.cache-vars.outputs.poetry-venv-dir }}
-          key: ${{ runner.os }}-poetry-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('poetry.lock') }}-1
 
       - name: Install and cache ffmpeg (all OS)
         uses: FedericoCarboni/setup-ffmpeg@v2
@@ -143,7 +131,6 @@ jobs:
         uses: actions/cache@v3
         id: cache-macos
         if: runner.os == 'macOS'
-
         with:
           path: ${{ github.workspace }}/macos-cache
           key: ${{ runner.os }}-dependencies-tinytex-${{ hashFiles('.github/manimdependency.json') }}-${{ steps.cache-vars.outputs.date }}-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,16 @@ jobs:
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: texlive texlive-latex-extra texlive-fonts-extra texlive-latex-recommended texlive-science texlive-fonts-extra tipa python3-opengl libpango1.0-dev xvfb
+          packages: texlive texlive-latex-extra texlive-fonts-extra texlive-latex-recommended texlive-science tipa python3-opengl libpango1.0-dev xvfb
           version: 1.0
           execute_install_scripts: true
+
+      - name: Install Texlive (Linux)
+        if: runner.os == 'Linux'
+        uses: teatimeguest/setup-texlive-action@v2
+        with:
+          cache: true
+          packages: latex-extra fonts-extra latex-recommended science
 
       - name: Set screen size (Linux)
         if: runner.os == 'Linux'
@@ -125,9 +132,10 @@ jobs:
           sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
 
       - name: Setup macOS cache
+        uses: actions/cache@v3
         id: cache-macos
         if: runner.os == 'macOS'
-        uses: actions/cache@v3
+
         with:
           path: ${{ github.workspace }}/macos-cache
           key: ${{ runner.os }}-dependencies-tinytex-${{ hashFiles('.github/manimdependency.json') }}-${{ steps.cache-vars.outputs.date }}-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: test on 3.8 and 3.11
-        python: ['3.10.7']
+        python: ["3.10.7"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout the repository
@@ -96,7 +96,7 @@ jobs:
         id: cache-vars
         run: |
           echo 'poetry-venv-dir=$(poetry config virtualenvs.path)' >> $GITHUB_STATE
-          echo 'date=bin/date -u "+%m%w%Y")' >> $GITHUB_STATE
+          echo 'date=$(/bin/date -u "+%m%w%Y")' >> $GITHUB_STATE
 
       - name: Setup Poetry cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         id: cache-vars
         run: |
           echo 'poetry-venv-dir=$(poetry config virtualenvs.path)' >> $GITHUB_OUTPUT
-          echo 'date=$(/bin/date -u "+%m%w%Y")' >> $GITHUB_OUTPUT
+          echo "date=$(/bin/date -u "+%m%w%Y")" >> $GITHUB_OUTPUT
 
       - name: Setup Poetry cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           cache: true
           packages: scheme-basic fontspec inputenc fontenc tipa mathrsfs calligra xcolor standalone preview doublestroke ms everysel setspace rsfs relsize ragged2e fundus-calligra microtype wasysym physics dvisvgm jknapltx wasy cm-super babel-english gnu-freefont mathastext cbfonts-fd
 
-      - name: Set screen size (Linux)
+      - name: Start virtual display (Linux)
         if: runner.os == 'Linux'
         run: |
           # start xvfb in background

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          cache: "pip"
+        run: |
+          pip install -r ./docs/requirements.txt
 
       - name: Install Poetry
         run: |
@@ -219,7 +222,7 @@ jobs:
 
       - name: Run doctests in rst files
         run: |
-          cd docs && pip install -r requirements.txt && poetry run make doctest O=-tskip-manim
+          cd docs && poetry run make doctest O=-tskip-manim
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: tipa python3-opengl libpango1.0-dev xvfb
+          packages: python3-opengl libpango1.0-dev xvfb
           version: 1.0
 
       - name: Install Texlive (Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
+
+      - name: Installing Python ${{matrix.python}} doctest Requirements
         run: |
           pip install -r ./docs/requirements.txt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: self-hosted
     env:
       DISPLAY: :0
-      PYTEST_ADDOPTS: '--color=yes' # colors in pytest
+      PYTEST_ADDOPTS: "--color=yes" # colors in pytest
     strategy:
       fail-fast: false
       matrix:
         # TODO: test on 3.8 and 3.11
-        python: ['3.10.7']
+        python: ["3.10.7"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -65,12 +65,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       DISPLAY: :0
-      PYTEST_ADDOPTS: '--color=yes' # colors in pytest
+      PYTEST_ADDOPTS: "--color=yes" # colors in pytest
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout the repository
@@ -95,7 +95,7 @@ jobs:
         shell: bash
         id: cache-vars
         run: |
-          echo 'poetry-venv-dir=$(poetry config virtualenvs.path)' >> $GITHUB_OUTPUT
+          echo "poetry-venv-dir=$(poetry config virtualenvs.path)" >> $GITHUB_OUTPUT
           echo "date=$(/bin/date -u "+%m%w%Y")" >> $GITHUB_OUTPUT
 
       - name: Setup Poetry cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         uses: teatimeguest/setup-texlive-action@v2
         with:
           cache: true
-          packages: scheme-basic standalone inputenc fontenc lmodern dsfont setspace tipa relsize textcomp mathrsfs calligra wasysym ragged2e physics xcolor microtype
+          packages: scheme-basic standalone inputenc fontenc setspace tipa relsize mathrsfs calligra wasysym ragged2e physics xcolor microtype
 
       - name: Set screen size (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
         run: |
           cd docs && poetry run make doctest O=-tskip-manim
 
+      # upload coverage report
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+
   test:
     runs-on: ${{ matrix.os }}
     env:
@@ -225,6 +229,3 @@ jobs:
       - name: Run doctests in rst files
         run: |
           cd docs && poetry run make doctest O=-tskip-manim
-
-      - name: Upload coverage
-        uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         uses: teatimeguest/setup-texlive-action@v2
         with:
           cache: true
-          packages: scheme-basic standalone inputenc fontenc lmodern amssymb dsfont setspace tipa relsize textcomp mathrsfs calligra wasysym ragged2e physics xcolor microtype
+          packages: scheme-basic standalone inputenc fontenc lmodern dsfont setspace tipa relsize textcomp mathrsfs calligra wasysym ragged2e physics xcolor microtype
 
       - name: Set screen size (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         uses: teatimeguest/setup-texlive-action@v2
         with:
           cache: true
-          packages: scheme-basic
+          packages: scheme-basic standalone inputenc fontenc lmodern amssymb dsfont setspace tipa relsize textcomp mathrsfs calligra wasysym ragged2e physics xcolor microtype
 
       - name: Set screen size (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
Updating runner to new syntax according to [Github Blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and [Documentation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter)

`save-state` and `set-output` are going to be deprecated the new syntax uses `$GITHUB_STATE` and `$GITHUB_OUTPUT`


Also added caching for the Linux apt packages with [cache-apt-packages-action](https://github.com/marketplace/actions/cache-apt-packages)