### PR TITLE
perf: add faces to Surface one by one in Surface._setup_in_uv_space

### DIFF
--- a/manim/mobject/three_d/three_dimensions.py
+++ b/manim/mobject/three_d/three_dimensions.py
@@ -147,7 +147,6 @@ class Surface(VGroup, metaclass=ConvertToOpenGL):
 
     def _setup_in_uv_space(self):
         u_values, v_values = self._get_u_values_and_v_values()
-        faces = VGroup()
         for i in range(len(u_values) - 1):
             for j in range(len(v_values) - 1):
                 u1, u2 = u_values[i : i + 2]
@@ -162,20 +161,21 @@ class Surface(VGroup, metaclass=ConvertToOpenGL):
                         [u1, v1, 0],
                     ],
                 )
-                faces.add(face)
                 face.u_index = i
                 face.v_index = j
                 face.u1 = u1
                 face.u2 = u2
                 face.v1 = v1
                 face.v2 = v2
-        faces.set_fill(color=self.fill_color, opacity=self.fill_opacity)
-        faces.set_stroke(
-            color=self.stroke_color,
-            width=self.stroke_width,
-            opacity=self.stroke_opacity,
-        )
-        self.add(*faces)
+                face.set_fill(color=self.fill_color, opacity=self.fill_opacity)
+                face.set_stroke(
+                    color=self.stroke_color,
+                    width=self.stroke_width,
+                    opacity=self.stroke_opacity,
+                )
+
+                self.add(face)
+
         if self.checkerboard_colors:
             self.set_fill_by_checkerboard(*self.checkerboard_colors)
 


### PR DESCRIPTION
### UPDATE: I made a new PR which, if accepted, would render this PR useless. Please review it here: https://github.com/ManimCommunity/manim/pull/3092

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Originally, `Surface._setup_in_uv_space` would create all the `ThreeDVMobject`s which represent the `Surface` faces, and add them all to a `VGroup` called `faces`. Then it would **add all the faces at once** to `Surface` by performing `Surface.add(*faces)`. This is very slow because of how `Mobject.add` works, which probably needs a second PR. I'll explain below why.

This PR changes this behaviour: rather than adding every single face into `faces` and then performing `Surface.add(*faces)`, this PR gets rid of `faces` and instead **adds every face individually** and directly into `Surface`, by doing `Surface.add(face)` inside the for loops where the faces are being initialized.

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
This code example initializes a simple `Surface` with its default resolution of 32, which means this `Surface` will be comprised of 32x32 = 1024 faces which are `ThreeDVMobject`s:

```py
surface = Surface(
    lambda u, v: [u, v, u**2 + v**2],
    u_range=[-1, 1],
    v_range=[-1, 1],
    resolution=32
)
```

The above code takes between 15 and 20 seconds to execute on my computer. Note that there's no rendering, this is only a `Surface` initialization.

Profiling the code with SnakeViz returned the following output for me (see "Before"):

| Before | After |
| ------- | ------ |
|![imagen](https://user-images.githubusercontent.com/49853152/209484533-e1d29789-0a94-4019-a886-a4e19a0a9a9a.png)|![imagen](https://user-images.githubusercontent.com/49853152/209488817-d23c411c-30de-49c5-8e34-25d3d497c497.png)


The problem is the following: when `Surface._setup_in_uv_space` (which is called in `Surface.__init__`) initializes all of `Surface`'s faces, it first adds all of them into a `VGroup` called `faces`, and then performs `Surface.add(*faces)`.

Now, `Surface.add` makes a call to `VGroup.add`, which in turn makes a call to `VMobject.add`, which finally makes a call to `Mobject.add`. This is where the real problem lies on:

```py
for m in mobjects:
    # ...
    if any(mobjects.count(elem) > 1 for elem in mobjects):
        # ...
        mobjects = remove_list_redundancies(mobjects)
```

Here `mobjects` would be an iterable containing the 1024 faces of `Surface`.

This snippet would filter duplicates, but apparently it's doing it in a very inefficient way.
Going inside out, first it takes a face from `mobjects` and iterates through all the 1024 faces to count how many times it appears.
It does this for each one of the 1024 faces, and then it asks if any of these counts is greater than 1.
Not only it could be made more efficient, but this process should occur only once. Instead, it's inside the `for m in mobjects` loop, which makes it occur 1024 times.
So we are visiting every single element 1024x1024x1024 times. That's why there's more than 80% time spent in `<method 'count' of 'tuple' objects>`.

(I noticed all of this while writing this text, so maybe I should write a 2nd PR addressing this duplicate filtering. This PR would only address the inefficiency caused in `Surface._setup_in_uv_space` as a consequence of this)

Anyways, to fix the problem in `Surface._setup_in_uv_space`, what I propose in this PR is to instead add every single face to `Surface` individually, instead of adding them to `faces` and then doing `Surface.add(*faces)`. That way, `Mobject.add` would only check each face individually instead of the whole iterable, which caused the problem.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
