### PR TITLE
perf: improve Mobject.add by checking for redundancy only once

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -430,13 +430,15 @@ class Mobject:
                 raise TypeError("All submobjects must be of type Mobject")
             if m is self:
                 raise ValueError("Mobject cannot contain self")
-            if any(mobjects.count(elem) > 1 for elem in mobjects):
-                logger.warning(
-                    "Attempted adding some Mobject as a child more than once, "
-                    "this is not possible. Repetitions are ignored.",
-                )
-                mobjects = remove_list_redundancies(mobjects)
-        self.submobjects = list_update(self.submobjects, mobjects)
+
+        unique_mobjects = remove_list_redundancies(mobjects)
+        if len(mobjects) != len(unique_mobjects):
+            logger.warning(
+                "Attempted adding some Mobject as a child more than once, "
+                "this is not possible. Repetitions are ignored.",
+            )
+
+        self.submobjects = list_update(self.submobjects, unique_mobjects)
         return self
 
     def insert(self, index: int, mobject: Mobject):


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
In my previous PR I noticed that `Mobject.add` was being inefficient (link: https://github.com/ManimCommunity/manim/pull/3091).

Here is the most relevant part:
```py
for m in mobjects:
    # ... verification code ...
    if any(mobjects.count(elem) > 1 for elem in mobjects):
        logger.warning("... warning message ...")
        mobjects = remove_list_redundancies(mobjects)
# ... update with mobjects and return self ...
```
This would check if there are any duplicate elements in `mobjects` and remove them.
However, this iterates over the mobjects too many times and, in my previous PR, was responsible for over 90% of `Surface.__init__`'s execution time.

Instead, I propose this:

```py
for m in mobjects:
    # ... verification code ...

unique_mobjects = remove_list_redundancies(mobjects)
if len(mobjects) != len(unique_mobjects):
    logger.warning("... warning message ...")

# ... update with unique_mobjects and return self ...
```
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
In my previous PR I was dealing with 1024 mobjects, so the original code for `Mobject.add` turned out to be extremely slow, because:
- every time it calls `mobjects.count(elem)` it iterates through all of the 1024 mobjects and counts how many times `elem` appears
- it does that for each one of the 1024 mobjects
- that procedure should only need to be done once, but instead is strangely inside the `for m in mobjects` loop which makes it execute 1024 times

All of this amounts to 1024x1024x1024 accesses to the mobjects.

If we instead do this:
```py
for m in mobjects:
    # ... verification code ...

unique_mobjects = remove_list_redundancies(mobjects)
if len(mobjects) != len(unique_mobjects):
    logger.warning("... warning message ...")

# ... update with unique_mobjects and return self ...
```

then it would take around 4x1024 accesses to the mobjects, which would be much better than 1024x1024x1024 accesses.

Here are some outputs from SnakeViz when applied to the following example, before and after the change:
```py
surface = Surface(
    lambda u, v: [u, v, u**2 + v**2],
    u_range=[-1, 1],
    v_range=[-1, 1],
    resolution=32
)
```

| Before | After |
| ------- | ------ |
|![imagen](https://user-images.githubusercontent.com/49853152/209484533-e1d29789-0a94-4019-a886-a4e19a0a9a9a.png)| ![image](https://user-images.githubusercontent.com/49853152/209498303-21d7718e-2c17-4de0-8363-603e1678690f.png)|


## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
