### PR TITLE
Update docs built to python3.10

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,17 @@
 version: 2
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
   apt_packages:
     - libpango1.0-dev
     - ffmpeg
+
+sphinx:
+   configuration: docs/source/conf.py
+
 python:
-   version: "3.11"
    install:
       - requirements: docs/rtd-requirements.txt
       - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.10"
 
   apt_packages:
     - libpango1.0-dev

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ build:
     - libpango1.0-dev
     - ffmpeg
 python:
-   version: 3.8
+   version: "3.11"
    install:
       - requirements: docs/rtd-requirements.txt
       - requirements: docs/requirements.txt


### PR DESCRIPTION
This is just an experiment.
Readthedocs seems to support python3.11 now. 
Let's see what will happen when this version is changed.
https://docs.readthedocs.io/en/stable/config-file/v2.html
EDIT: update works with python 3.10