### PR TITLE
Fixed example using reverse with `Write` 

### DIFF
--- a/manim/animation/creation.py
+++ b/manim/animation/creation.py
@@ -301,7 +301,7 @@ class Write(DrawBorderThenFill):
 
         class ShowWriteReversed(Scene):
             def construct(self):
-                self.play(Write(Text("Hello", font_size=144), reverse=True))
+                self.play(Write(Text("Hello", font_size=144), reverse=True, remover=False))
 
     Tests
     -----


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

If you use `Write` with kwarg `reverse=True` the animation of object, say the text, will start from right to left, which is the intended action, and it does work, however once the animation ends, the object just disappear. A fix to the issue is to add `remover=False`. I updated the example given in the docs.

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

The instruction in the docs didn't mention that so I added it to make it more clear.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

I created an issue #3135  to demonstrate the problem 

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
