### PR TITLE
Allow to use call_updater=True with a function without dt

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -971,7 +971,11 @@ class Mobject:
         else:
             self.updaters.insert(index, update_function)
         if call_updater:
-            update_function(self, 0)
+            parameters = get_parameters(update_function)
+            if "dt" in parameters :
+                update_function(self, 0)
+            else :
+                update_function(self)
         return self
 
     def remove_updater(self, update_function: Updater):

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -972,9 +972,9 @@ class Mobject:
             self.updaters.insert(index, update_function)
         if call_updater:
             parameters = get_parameters(update_function)
-            if "dt" in parameters :
+            if "dt" in parameters:
                 update_function(self, 0)
-            else :
+            else:
                 update_function(self)
         return self
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Currently the following code will trigger an error:
```python
dot.add_updater(lambda d: d.move_to(ax.coords_to_point(0, p.get_value())), call_updater=True)
```
To avoid the error we need to use
```python
dot.add_updater(lambda d, dt: d.move_to(ax.coords_to_point(0, p.get_value())), call_updater=True)
```
This allow to use the first syntax
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
