### PR TITLE
Fixed behavior of `Wait` with specified `stop_condition`

### DIFF
--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -528,8 +528,8 @@ class Wait(Animation):
     stop_condition
         A function without positional arguments that evaluates to a boolean.
         The function is evaluated after every new frame has been rendered.
-        Playing the animation only stops after the return value is truthy.
-        Overrides the specified ``run_time``.
+        Playing the animation stops after the return value is truthy, or
+        after the specified ``run_time`` has passed.
     frozen_frame
         Controls whether or not the wait animation is static, i.e., corresponds
         to a frozen frame. If ``False`` is passed, the render loop still

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -1058,7 +1058,8 @@ class Scene:
         stop_condition
             A function without positional arguments that is evaluated every time
             a frame is rendered. The animation only stops when the return value
-            of the function is truthy. Overrides any value passed to ``duration``.
+            of the function is truthy, or when the time specified in ``duration``
+            passes.
         frozen_frame
             If True, updater functions are not evaluated, and the animation outputs
             a frozen frame. If False, updater functions are called and frames
@@ -1095,18 +1096,15 @@ class Scene:
         self.wait(duration=duration, frozen_frame=True)
 
     def wait_until(self, stop_condition: Callable[[], bool], max_time: float = 60):
-        """
-        Like a wrapper for wait().
-        You pass a function that determines whether to continue waiting,
-        and a max wait time if that is never fulfilled.
+        """Wait until a condition is satisfied, up to a given maximum duration.
 
         Parameters
         ----------
         stop_condition
-            The function whose boolean return value determines whether to continue waiting
-
+            A function with no arguments that determines whether or not the
+            scene should keep waiting.
         max_time
-            The maximum wait time in seconds, if the stop_condition is never fulfilled.
+            The maximum wait time in seconds.
         """
         self.wait(max_time, stop_condition=stop_condition)
 

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -383,6 +383,7 @@ class Scene:
             should_update = (
                 self.always_update_mobjects
                 or self.updaters
+                or wait_animation.stop_condition is not None
                 or any(
                     [
                         mob.has_time_based_updater()
@@ -974,10 +975,7 @@ class Scene:
         """
 
         if len(animations) == 1 and isinstance(animations[0], Wait):
-            if animations[0].stop_condition is not None:
-                return 0
-            else:
-                return animations[0].duration
+            return animations[0].duration
 
         else:
             return np.max([animation.run_time for animation in animations])

--- a/tests/test_scene_rendering/test_play_logic.py
+++ b/tests/test_scene_rendering/test_play_logic.py
@@ -72,6 +72,20 @@ def test_non_static_wait_detection(using_temp_config, disabling_caching):
     assert not scene.animations[0].is_static_wait
     assert not scene.is_current_animation_frozen_frame()
 
+def test_wait_with_stop_condition(using_temp_config, disabling_caching):
+    class TestScene(Scene):
+        def construct(self):
+            self.wait_until(lambda: self.renderer.time >= 1)
+            assert self.renderer.time >= 1
+            d = Dot()
+            d.add_updater(lambda mobj, dt: self.add(Mobject()))
+            self.add(d)
+            self.play(Wait(run_time=5, stop_condition=lambda: len(self.mobjects) > 5))
+            assert len(self.mobjects) > 5
+            assert self.renderer.time < 2
+
+    scene = TestScene()
+    scene.render()
 
 def test_frozen_frame(using_temp_config, disabling_caching):
     scene = SceneForFrozenFrameTests()

--- a/tests/test_scene_rendering/test_play_logic.py
+++ b/tests/test_scene_rendering/test_play_logic.py
@@ -72,6 +72,7 @@ def test_non_static_wait_detection(using_temp_config, disabling_caching):
     assert not scene.animations[0].is_static_wait
     assert not scene.is_current_animation_frozen_frame()
 
+
 def test_wait_with_stop_condition(using_temp_config, disabling_caching):
     class TestScene(Scene):
         def construct(self):
@@ -86,6 +87,7 @@ def test_wait_with_stop_condition(using_temp_config, disabling_caching):
 
     scene = TestScene()
     scene.render()
+
 
 def test_frozen_frame(using_temp_config, disabling_caching):
     scene = SceneForFrozenFrameTests()


### PR DESCRIPTION
Fixes #3147, and corrects the documentation of the `stop_condition` keyword argument in `Wait`, `Scene.wait`, and `Scene.wait_until`.

To be more precise:
- This fixed one issue where a `Wait` with a non-`None` `stop_condition` was not recognized as a non-static `Wait`,
- and it fixed another issue where the `run_time` of a `Wait` animation with set `stop_condition` was set to be 0 (which might have been intended as a special value allowing for indefinite wait times) -- but this has not been implemented at any point, so it led to the condition never being evaluated.

The other changes consist of updates to the documentation, and the addition of a dedicated test.