### PR TITLE
fix deprecation warning

### DIFF
--- a/manim/mobject/graphing/functions.py
+++ b/manim/mobject/graphing/functions.py
@@ -158,7 +158,7 @@ class ParametricFunction(VMobject, metaclass=ConvertToOpenGL):
                 x, y, z = self.function(t_range)
                 if not isinstance(z, np.ndarray):
                     z = np.zeros_like(x)
-                points = np.stack(zip(x, y, z), axis=0)
+                points = np.stack([x, y, z], axis=1)
             else:
                 points = np.array([self.function(t) for t in t_range])
 


### PR DESCRIPTION
## Overview: What does this pull request change?
<!--changelog-start-->
Fix issue #3178 Warning when using ParametricFunction with use_vectorized=True 
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
For future Numpy compatibility.

## Further Information and Comments
See details in the issue report.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
