### PR TITLE
Speed up width/height/depth by reducing copying

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
             flake8-simplify==0.14.1,
           ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.0.1
     hooks:
       - id: mypy
         additional_dependencies:

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2010,9 +2010,9 @@ class Mobject:
     def length_over_dim(self, dim):
         """Measure the length of an :class:`~.Mobject` in a certain direction."""
         return self.reduce_across_dimension(
-            np.max,
+            max,
             dim,
-        ) - self.reduce_across_dimension(np.min, dim)
+        ) - self.reduce_across_dimension(min, dim)
 
     def get_coord(self, dim, direction=ORIGIN):
         """Meant to generalize ``get_x``, ``get_y`` and ``get_z``"""

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1845,14 +1845,19 @@ class Mobject:
     def reduce_across_dimension(self, reduce_func, dim: int) -> float:
         """Find the min or max value from a dimension across all points in this and submobjects."""
         assert dim >= 0 and dim <= 2
-        # base case: No submobjects.
-        if len(self.submobjects) == 0:
-            # If we have no points, return 0 (e.g. center)...
-            if len(self.points) == 0:
-                return 0
-            # ...otherwise, reduce over our points along that dimension
-            return reduce_func(self.points[:, dim])
-        rv = None
+        if len(self.submobjects) == 0 and len(self.points) == 0:
+            # If we have no points and no submobjects, return 0 (e.g. center)
+            return 0
+
+        # If we do not have points (but do have submobjects)
+        # use only the points from those.
+        if len(self.points) == 0:
+            rv = None
+        else:
+            # Otherwise, be sure to include our own points
+            rv = reduce_func(self.points[:, dim])
+        # Recursively ask submobjects (if any) for the biggest/
+        # smallest dimension they have and compare it to the return value.
         for mobj in self.submobjects:
             value = mobj.reduce_across_dimension(reduce_func, dim)
             if rv is None:

--- a/tests/module/mobject/mobject/test_mobject.py
+++ b/tests/module/mobject/mobject/test_mobject.py
@@ -150,7 +150,7 @@ def test_mobject_dimensions_has_points_and_children():
 
     # The width of a mobject should depend both on its points and
     # the points of all children mobjects.
-    assert outer_rect.width == 5  # 3 fom outer_rect, 2 from inner_rect
+    assert outer_rect.width == 5  # 3 from outer_rect, 2 from inner_rect
     assert outer_rect.height == 7  # 6 from outer_rect, 1 from inner_rect
     assert outer_rect.depth == 0
 

--- a/tests/module/mobject/mobject/test_mobject.py
+++ b/tests/module/mobject/mobject/test_mobject.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from manim import Circle, Mobject, Rectangle, Square, VGroup, UR, DL
+from manim import DL, UR, Circle, Mobject, Rectangle, Square, VGroup
 
 
 def test_mobject_add():

--- a/tests/module/mobject/mobject/test_mobject.py
+++ b/tests/module/mobject/mobject/test_mobject.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+import numpy as np
 
 from manim import Circle, Mobject, Rectangle, Square, VGroup
 
@@ -52,6 +53,18 @@ def test_mobject_remove():
 
 
 def test_mobject_dimensions_single_mobject():
+    # A Mobject with no points and no submobjects has no dimensions
+    empty = Mobject()
+    assert empty.width == 0
+    assert empty.height == 0
+    assert empty.depth == 0
+
+    has_points = Mobject()
+    has_points.points = np.array([[-1, -2, -3], [1, 3, 5]])
+    assert has_points.width == 2
+    assert has_points.height == 5
+    assert has_points.depth == 8
+
     rect = Rectangle(width=3, height=5)
 
     assert rect.width == 3
@@ -92,20 +105,56 @@ def test_mobject_dimensions_nested_mobjects():
                 s = Square().move_to([x, y, z / 10])
                 row += s
 
-    assert vg.width == 14.0, f"{vg.width}"
-    assert vg.height == 20.0, f"{vg.height}"
-    assert is_close(vg.depth, 0.9), f"{vg.depth}"
+    assert vg.width == 14.0, vg.width
+    assert vg.height == 20.0, vg.height
+    assert is_close(vg.depth, 0.9), vg.depth
 
     # Dimensions should be recalculated after scaling
     vg.scale(0.5)
-    assert vg.width == 7.0, f"{vg.width}"
-    assert vg.height == 10.0, f"{vg.height}"
-    assert is_close(vg.depth, 0.45), f"{vg.depth}"
+    assert vg.width == 7.0, vg.width
+    assert vg.height == 10.0, vg.height
+    assert is_close(vg.depth, 0.45), vg.depth
 
     # Adding a mobject changes the bounds/dimensions
     rect = Rectangle(width=3, height=5)
     rect.move_to([9, 3, 1])
     vg += rect
-    assert vg.width == 13.0, f"{vg.width}"
-    assert is_close(vg.height, 18.5), f"{vg.height}"
-    assert is_close(vg.depth, 0.775), f"{vg.depth}"
+    assert vg.width == 13.0, vg.width
+    assert is_close(vg.height, 18.5), vg.height
+    assert is_close(vg.depth, 0.775), vg.depth
+
+
+def test_mobject_dimensions_mobjects_with_no_points_are_at_origin():
+    rect = Rectangle(width=2, height=3)
+    rect.move_to([-4, -5, 0])
+    outer_group = VGroup(rect)
+
+    # This is as one would expect
+    assert outer_group.width == 2
+    assert outer_group.height == 3
+
+    # Adding a mobject with no points has a quirk of adding a "point"
+    # to [0, 0, 0] (the origin). This changes the size of the outer
+    # group because now the bottom left corner is at [-5, -6.5, 0]
+    # but the upper right corner is [0, 0, 0] instead of [-3, -3.5, 0]
+    outer_group.add(VGroup())
+    assert outer_group.width == 5
+    assert outer_group.height == 6.5
+
+
+def test_mobject_dimensions_has_points_and_children():
+    outer_rect = Rectangle(width=3, height=6)
+    inner_rect = Rectangle(width=2, height=1)
+    inner_rect.align_to(outer_rect.get_corner(UR), DL)
+    outer_rect.add(inner_rect)
+
+    # The width of a mobject should depend both on its points and
+    # the points of all children mobjects.
+    assert outer_rect.width == 5   # 3 fom outer_rect, 2 from inner_rect
+    assert outer_rect.height == 7  # 6 from outer_rect, 1 from inner_rect
+    assert outer_rect.depth == 0
+
+    assert inner_rect.width == 2
+    assert inner_rect.height == 1
+    assert inner_rect.depth == 0
+

--- a/tests/module/mobject/mobject/test_mobject.py
+++ b/tests/module/mobject/mobject/test_mobject.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from manim import Circle, Mobject, Rectangle, Square, VGroup
+from manim import Circle, Mobject, Rectangle, Square, VGroup, UR, DL
 
 
 def test_mobject_add():

--- a/tests/module/mobject/mobject/test_mobject.py
+++ b/tests/module/mobject/mobject/test_mobject.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from manim import Mobject
+from manim import Mobject, Circle, Rectangle, Square
 
 
 def test_mobject_add():
@@ -49,3 +49,65 @@ def test_mobject_remove():
     assert len(obj.submobjects) == 10
 
     assert obj.remove(Mobject()) is obj
+
+
+def test_mobject_dimensions_single_mobject():
+    rect = Rectangle(width=3, height=5)
+
+    assert rect.width == 3
+    assert rect.height == 5
+    assert rect.depth == 0
+
+    # Dimensions should be recalculated after scaling
+    rect.scale(2.0)
+    assert rect.width == 6
+    assert rect.height == 10
+    assert rect.depth == 0
+
+    # Dimensions should not be dependent on location
+    rect.move_to([-3, -4, -5])
+    assert rect.width == 6
+    assert rect.height == 10
+    assert rect.depth == 0
+
+    circ = Circle(radius=2)
+
+    assert circ.width == 4
+    assert circ.height == 4
+    assert circ.depth == 0
+
+def is_close(x, y):
+    return abs(x - y) < 0.00001
+
+def test_mobject_dimensions_nested_mobjects():
+    vg = VGroup()
+
+    for x in range(-5, 8, 1):
+        row = VGroup()
+        vg += row
+        for y in range(-17, 2, 1):
+            for z in range(0, 10, 1):
+                s = Square().move_to([x, y, z/10])
+                row += s
+
+    assert vg.width == 14.0, f"{vg.width}"
+    assert vg.height == 20.0, f"{vg.height}"
+    assert is_close(vg.depth, 0.9), f"{vg.depth}"
+
+    # Dimensions should be recalculated after scaling
+    vg.scale(0.5)
+    assert vg.width == 7.0, f"{vg.width}"
+    assert vg.height == 10.0, f"{vg.height}"
+    assert is_close(vg.depth, 0.45), f"{vg.depth}"
+
+    # Adding a mobject changes the bounds/dimensions
+    rect = Rectangle(width=3, height=5)
+    rect.move_to([9, 3, 1])
+    vg += rect
+    assert vg.width == 13.0, f"{vg.width}"
+    assert is_close(vg.height, 18.5), f"{vg.height}"
+    assert is_close(vg.depth, 0.775), f"{vg.depth}"
+
+
+
+

--- a/tests/module/mobject/mobject/test_mobject.py
+++ b/tests/module/mobject/mobject/test_mobject.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import pytest
 import numpy as np
+import pytest
 
 from manim import Circle, Mobject, Rectangle, Square, VGroup
 
@@ -150,11 +150,10 @@ def test_mobject_dimensions_has_points_and_children():
 
     # The width of a mobject should depend both on its points and
     # the points of all children mobjects.
-    assert outer_rect.width == 5   # 3 fom outer_rect, 2 from inner_rect
+    assert outer_rect.width == 5  # 3 fom outer_rect, 2 from inner_rect
     assert outer_rect.height == 7  # 6 from outer_rect, 1 from inner_rect
     assert outer_rect.depth == 0
 
     assert inner_rect.width == 2
     assert inner_rect.height == 1
     assert inner_rect.depth == 0
-

--- a/tests/module/mobject/mobject/test_mobject.py
+++ b/tests/module/mobject/mobject/test_mobject.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from manim import Mobject, Circle, Rectangle, Square
+from manim import Circle, Mobject, Rectangle, Square, VGroup
 
 
 def test_mobject_add():


### PR DESCRIPTION
## Overview: What does this pull request change?
<!--changelog-start-->
The `width`, `height`, and `depth` attributes on Mobjects are calculated more quickly and consume less memory.
<!--changelog-end-->

I noticed large `Code` objects had some performance issues. For example, creating one with 59 lines of code and 1822 characters (based on a [real-world usage](https://www.youtube.com/watch?v=-aFtJt1_T3k)) took about 24.9 seconds, and calculating `height` (or `width` or `depth`) after creation took about 0.27s on my machine. Creating a profile and using SnakeViz showed that during the creation of Code, `height` calls took over 5 seconds of that time, due to a large amount of copying.
![Before profile, showing large amount of time calculating height ](https://user-images.githubusercontent.com/6819944/223767326-e742580d-250c-4c92-b3ce-4ce754b4e576.png)
![Zoomed in profile, showing height and width calculations spending a lot of time copying](https://user-images.githubusercontent.com/6819944/223767315-2b009c48-af7e-492f-ae18-8f4f2ddeedd7.png)

Note that after the "big" test in the profile, I also called `width` 10 times in a loop to try to gather more precise profiling/timing data.

## Motivation and Explanation: Why and how do your changes improve the library?
I changed the length calculations to not call `get_all_points` (which requires a lot of allocations, and copies of arrays), but just recursively find the largest value from a certain dimension. This reduced the length calls on my machine to about `0.077` seconds (3x speedup) and reduced the Code creation down to about 20.5 seconds. I plan to see about improving this further in a future PR.
![Profile showing Code taking 20.5 seconds](https://user-images.githubusercontent.com/6819944/223768736-38706d36-67f7-4656-ae0a-96ce0b9bd1f9.png)
![Profile showing height and width calculations are now dominated by calls to min/max](https://user-images.githubusercontent.com/6819944/223768733-4c80406d-ff5d-459d-926b-859fd45efdb0.png)

I also documented some of the (semi-internal) functions I explored and added tests for width/height/depth.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
