### PR TITLE
Fixed rendering in named threads, limit condition to interactive OpenGL mode

### DIFF
--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -1053,8 +1053,12 @@ class Scene:
             All other keywords are passed to the renderer.
 
         """
-        # Make sure this is running on the main thread
-        if threading.current_thread().name != "MainThread":
+        # If we are in interactive embedded mode, make sure this is running on the main thread (required for OpenGL)
+        if (
+            self.interactive_mode
+            and config.renderer == RendererType.OPENGL
+            and threading.current_thread().name != "MainThread"
+        ):
             kwargs.update(
                 {
                     "subcaption": subcaption,


### PR DESCRIPTION
Fixes #3183 by limiting the condition to interactive OpenGL mode.

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Changed to render directly within named threads, as long as manim is not in interactive embedded mode using OpenGL renderer
Previously rendering was prevented in **any** named threads (see #3183 )
<!--changelog-start-->
- Narrowed condition for disabling direct rendering in interactive embed mode
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
I am using multiple instances of manim within threads, so relying on the hardcoded thread name "MainThread" to detect if Manim operates within interactive embedded mode to fix a OpenGL crash (see #2734 ) is not suitable.
This fix was a breaking change included in manim v0.16.0 #2734 

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
See MRE for #3183 in https://github.com/karpfediem/manim-use_with_threading  


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
