### PR TITLE
Fix: Axes Scaling Had No Effect on plot_implicit_curve()

### DIFF
--- a/manim/mobject/graphing/coordinate_systems.py
+++ b/manim/mobject/graphing/coordinate_systems.py
@@ -715,8 +715,10 @@ class CoordinateSystem:
                     )
                     self.add(ax, a)
         """
+        x_scale = self.get_x_axis().scaling
+        y_scale = self.get_y_axis().scaling
         graph = ImplicitFunction(
-            func=func,
+            func=(lambda x, y: func(x_scale.function(x), y_scale.function(y))),
             x_range=self.x_range[:2],
             y_range=self.y_range[:2],
             min_depth=min_depth,


### PR DESCRIPTION
Closes #3145
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview
Initially, calling plot_implicit_curve() on a CoordinateSystem whose axes were scaled would have no effect, as if the axes hadn't been scaled at all. This PR fixed it by applying the scalings when creating ImplicitFunction object under plot_implicit_curve()
## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
### Test code: 
```python
from manim import *


class Test(Scene):
    def construct(self):
        numberplane = NumberPlane(
            axis_config=dict(
                scaling=LinearBase(scale_factor=0.5),
                decimal_number_config=dict(
                    num_decimal_places=1,
                ),
            ),
        ).add_coordinates()

        unit_circle = numberplane.plot_implicit_curve(
            lambda x, y: (x) ** 2 + (y) ** 2 - 1, color=BLUE
        )

        self.add(numberplane, unit_circle)
```
### Original output (incorrect):
![image](https://user-images.githubusercontent.com/63861808/228089482-8118a011-1a58-4c7f-b74c-0d4cc278dbe0.png)

### New output: 
<img width="1219" alt="Screen Shot 2023-03-27 at 7 30 46 PM" src="https://user-images.githubusercontent.com/63861808/228089636-f01278db-aea0-43d1-9b43-02c9f13d2e7b.png">


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
