### PR TITLE
Prepare new release: v0.17.3

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ authors:
   -
     name: "The Manim Community Developers"
 cff-version: "1.2.0"
-date-released: 2023-03-29
+date-released: 2023-03-31
 license: MIT
 message: "We acknowledge the importance of good software to support research, and we note that research becomes more valuable when it is communicated effectively. To demonstrate the value of Manim, we ask that you cite Manim in your work."
 title: Manim – Mathematical Animation Framework

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ authors:
   -
     name: "The Manim Community Developers"
 cff-version: "1.2.0"
-date-released: 2023-03-31
+date-released: 2023-04-06
 license: MIT
 message: "We acknowledge the importance of good software to support research, and we note that research becomes more valuable when it is communicated effectively. To demonstrate the value of Manim, we ask that you cite Manim in your work."
 title: Manim – Mathematical Animation Framework

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,10 +4,10 @@ authors:
   -
     name: "The Manim Community Developers"
 cff-version: "1.2.0"
-date-released: 2022-12-26
+date-released: 2023-03-29
 license: MIT
 message: "We acknowledge the importance of good software to support research, and we note that research becomes more valuable when it is communicated effectively. To demonstrate the value of Manim, we ask that you cite Manim in your work."
 title: Manim – Mathematical Animation Framework
 url: "https://www.manim.community/"
-version: "v0.17.2"
+version: "v0.17.3"
 ...

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 .. toctree::
 
+    changelog/0.17.3-changelog
     changelog/0.17.2-changelog
     changelog/0.17.1-changelog
     changelog/0.17.0-changelog

--- a/docs/source/changelog/0.17.3-changelog.rst
+++ b/docs/source/changelog/0.17.3-changelog.rst
@@ -2,12 +2,12 @@
 v0.17.3
 *******
 
-:Date: March 31, 2023
+:Date: April 06, 2023
 
 Contributors
 ============
 
-A total of 32 people contributed to this
+A total of 35 people contributed to this
 release. People with a '+' by their names authored a patch for the first
 time.
 
@@ -17,7 +17,9 @@ time.
 * Elyanah Aco +
 * Francisco Manríquez Novoa
 * Fredrik Lundström +
+* Frédéric Crozatier
 * Ikko Eltociear Ashimine +
+* ItIsJoeyG +
 * JinchuLi2002 +
 * Kevin Lubick
 * KingAndCross +
@@ -35,6 +37,7 @@ time.
 * davidot +
 * icedcoffeeee
 * karpfediem +
+* vahndi
 
 
 The patches included in this release have been reviewed by
@@ -42,6 +45,7 @@ the following contributors.
 
 * Benjamin Hackl
 * Fredrik Lundström
+* Frédéric Crozatier
 * Hugues Devimeux
 * Kevin Lubick
 * KingAndCross
@@ -55,7 +59,7 @@ the following contributors.
 Pull requests merged
 ====================
 
-A total of 34 pull requests were merged for this release.
+A total of 42 pull requests were merged for this release.
 
 Deprecated classes and functions
 --------------------------------
@@ -66,13 +70,18 @@ Deprecated classes and functions
 New features
 ------------
 
+* :pr:`2974`: Added :class:`.DiGraph`, a mobject representing directed graphs
+
+
 * :pr:`3042`: Added :meth:`.Scene.replace` and use in :class:`.ReplacementTransform`
-   ReplacementTransform now preserves the draw order of the (old) mobject when replacing it with `target_mobject`. This uses the new `Scene.replace` method.
 
 * :pr:`3155`: Added support for individualized radius values in :meth:`.Polygram.round_corners` 
 
 
 * :pr:`3159`: Added :meth:`.set_opacity_by_tex` method for setting the opacity of parts of Tex mobjects
+
+
+* :pr:`3201`: New tip shape :class:`.StealthTip`, allow specifying tip shape of :class:`.NumberLine`
 
 
 Enhancements
@@ -91,20 +100,22 @@ Enhancements
 
 
 * :pr:`3180`: Performance: Speed up width/height/depth calculations by reducing copying
-   The `width`, `height`, and `depth` attributes on Mobjects are calculated more quickly and consume less memory.
+
 
 * :pr:`3181`: Improved creation time for large :class:`.Text` mobjects
-   - Reduce memory allocations when creating `Text` Mobjects (including `Code` and `Paragraph`)
-   - Make the SVGMobject cache optional, and have `Text` Mobjects skip the cache by default.
+
 
 * :pr:`3182`: Reduce memory allocations when building :class:`.SVGMobject`
 
 
 * :pr:`3191`: Fixed OpenGL rendering in named threads
-   Narrowed condition for disabling direct rendering in interactive embed mode.
+
 
 Fixed bugs
 ----------
+
+* :pr:`3015`: Fixed bug with ``label_constructor`` in :meth:`.NumberLine.add_labels`
+
 
 * :pr:`3095`: Fixed ``get_axis_labels`` for :class:`.Axes` and :class:`.ThreeDAxes`
 
@@ -151,6 +162,12 @@ Documentation-related changes
 * :pr:`3189`: Corrected the hinted return type for :func:`angle_between_vectors`
 
 
+* :pr:`3199`: Updated ``winget`` command for installing MiKTeX in documentation
+
+
+* :pr:`3204`: Fixed docstring formatting of :meth:`.Scene.replace` and improved its error handling
+
+
 Code quality improvements and similar refactors
 -----------------------------------------------
 
@@ -169,6 +186,9 @@ Code quality improvements and similar refactors
 * :pr:`3165`: Removed deprecated keyword argument in :meth:`.Mobject.align_to`
 
 
+* :pr:`3166`: Made :class:`.ArrowTriangleTip`, :class:`.ArrowTriangleFilledTip` available to module namespace
+
+
 * :pr:`3179`: Fixed deprecation warning in :class:`.ParametricFunction` with ``use_vectorized=True``
 
 
@@ -176,3 +196,12 @@ Code quality improvements and similar refactors
 
 
 * :pr:`3196`: CI: updated PATH for recent changed in TinyTex
+
+
+* :pr:`3200`: Made import from ``moderngl`` compatible with more recent versions
+
+
+New releases
+------------
+
+* :pr:`3198`: Prepare new release: v0.17.3

--- a/docs/source/changelog/0.17.3-changelog.rst
+++ b/docs/source/changelog/0.17.3-changelog.rst
@@ -2,7 +2,7 @@
 v0.17.3
 *******
 
-:Date: March 29, 2023
+:Date: March 31, 2023
 
 Contributors
 ============
@@ -50,22 +50,24 @@ the following contributors.
 * Tristan Schulz
 * coreyp1
 * davidot
-* github-code-scanning[bot]
 * strager
 
 Pull requests merged
 ====================
 
-A total of 32 pull requests were merged for this release.
+A total of 34 pull requests were merged for this release.
 
 Deprecated classes and functions
 --------------------------------
 
-* :pr:`3103`: Remove deprecated function from `opengl_surface.py`
-   Remove deprecated function `~.set_fill_by_value()` from `opengl_surface.py`.
+* :pr:`3103`: Removed deprecated function ``OpenGLSurface.set_fill_by_value``
+
 
 New features
 ------------
+
+* :pr:`3042`: Added :meth:`.Scene.replace` and use in :class:`.ReplacementTransform`
+   ReplacementTransform now preserves the draw order of the (old) mobject when replacing it with `target_mobject`. This uses the new `Scene.replace` method.
 
 * :pr:`3155`: Added support for individualized radius values in :meth:`.Polygram.round_corners` 
 
@@ -76,82 +78,83 @@ New features
 Enhancements
 ------------
 
-* :pr:`3083`: Minor performance improvement in bezier.py with preallocating array.
+* :pr:`3046`: Add warning if font is not found for Text, Code, and MarkupText
 
 
-* :pr:`3092`: perf: improve Mobject.add by checking for redundancy only once
+* :pr:`3083`: Minor performance improvement in :mod:`.bezier` with preallocating array
 
 
-* :pr:`3134`: Store color data to prevent opengl embed lag
+* :pr:`3092`: Improved :meth:`.Mobject.add` performance by checking for redundancy only once
 
 
-* :pr:`3180`: Speed up width/height/depth calculations by reducing copying
+* :pr:`3134`: Performance: Store color data of ``OpenGLSurface`` to prevent OpenGL embed lag
+
+
+* :pr:`3180`: Performance: Speed up width/height/depth calculations by reducing copying
    The `width`, `height`, and `depth` attributes on Mobjects are calculated more quickly and consume less memory.
 
-* :pr:`3182`: Reduce memory allocations when building SVGMobject
+* :pr:`3181`: Improved creation time for large :class:`.Text` mobjects
+   - Reduce memory allocations when creating `Text` Mobjects (including `Code` and `Paragraph`)
+   - Make the SVGMobject cache optional, and have `Text` Mobjects skip the cache by default.
+
+* :pr:`3182`: Reduce memory allocations when building :class:`.SVGMobject`
 
 
-* :pr:`3191`: Fixed rendering in named threads, limit condition to interactive OpenGL mode
-   - Narrowed condition for disabling direct rendering in interactive embed mode
+* :pr:`3191`: Fixed OpenGL rendering in named threads
+   Narrowed condition for disabling direct rendering in interactive embed mode.
 
 Fixed bugs
 ----------
 
-* :pr:`3106`: Fixes ignored depth_test parameter for OpenGLVMobjects
-   Adds assignments from `self.depth_test` to `SHADER_WRAPPER.depth_test` in the `update_SHADER_WRAPPER` methods of `OpenGLVMobject`. Without this assignment, the `depth_test` parameter would not be given to the shaders and thus effectively ignored (as it is only assigned to `self.depth_test`, but not used further).
-
-* :pr:`3152`: Fixed behavior of `Wait` with specified `stop_condition`
+* :pr:`3095`: Fixed ``get_axis_labels`` for :class:`.Axes` and :class:`.ThreeDAxes`
 
 
-* :pr:`3195`: Fix: Axes Scaling Had No Effect on plot_implicit_curve()
+* :pr:`3106`: Fixed ignored ``depth_test`` argument for ``OpenGLVMobjects``
+
+
+* :pr:`3149`: Allow to use ``call_updater=True`` in :meth:`.Mobject.add_updater` with non-timebased updaters too
+
+
+* :pr:`3152`: Fixed behavior of :class:`.Wait` and :meth:`.Scene.wait` with specified ``stop_condition``
+
+
+* :pr:`3163`: Fixed :class:`.BraceLabel` not passing additional keyword arguments to :class:`.Brace`
+
+
+* :pr:`3195`: Fixed :class:`.Axes` scaling for :meth:`.plot_implicit_curve`
 
 
 Documentation-related changes
 -----------------------------
 
-* :pr:`3109`: Clean-up, type-hints and documentation for `three_dimensions.py`
-   Added type-hints and documentation for three dimensional Mobjects, and removed a deprecated parameter on `Surface.set_fill_by_value()`.
-
-* :pr:`3124`: Fix docstring of ThreeDCamera get_value_trackers
-   Fix the docstring of ThreeDCamera.get_value_trackers
-
-* :pr:`3126`: Change links redirecting to dead troubleshooting page
+* :pr:`3105`: Converted types specified in docstrings to proper type hints in :mod:`.three_dimensions`
 
 
-* :pr:`3160`: typo(docs): Fix grammar
+* :pr:`3108`: Clarified documentation for ``--resolution`` command line flag
 
 
-* :pr:`3186`: Fixed extlinks in docs to work with latest version of Sphinx.
+* :pr:`3109`: Clean-up, type-hints and documentation for :mod:`.three_dimensions`
+
+
+* :pr:`3124`: Fixed docstring of :meth:`.ThreeDCamera.get_value_trackers`
+
+
+* :pr:`3126`: Fixed dead links to troubleshooting page
+
+
+* :pr:`3137`: Fixed example using ``reverse=True`` with :class:`.Write` 
+
+
+* :pr:`3160`: Fixed a typo
+
+
+* :pr:`3189`: Corrected the hinted return type for :func:`angle_between_vectors`
 
 
 Code quality improvements and similar refactors
 -----------------------------------------------
 
-* :pr:`3165`: Remove deprecated arg in M.object.align_to()
-
-
-Unclassified changes
---------------------
-
-* :pr:`3042`: Add scene.replace() and use in ReplacementTransform
-   ReplacementTransform now preserves the draw order of the (old) mobject when replacing it with `target_mobject`. This uses the new `Scene.replace` method.
-
-* :pr:`3095`: Fixed ``get_axis_labels`` for :class:`.Axes` and :class:`.ThreeDAxes`
-   Moves `~.get_axis_labels()` out of `CoordinateSystem` and into `Axes` and `ThreeDAxes`.  This allows for `~.get_axis_labels()` to be used with both 2D and 3D axes.  Fixed some documentation in the process.
-
-* :pr:`3105`: Convert docstring param type to type-hint in three_dimensions.py
-
-
-* :pr:`3108`: Clarified documentation for --resolution flag
-
-
-* :pr:`3137`: Fixed example using reverse with `Write` 
-   If you use `Write` with kwarg `reverse=True` the animation of object, say the text, will start from right to left, which is the intended action, and it does work, however once the animation ends, the object just disappear. A fix to the issue is to add `remover=False`. I updated the example given in the docs.
-
-* :pr:`3144`: Fix typo in stripUntranslatable.awk
-
-
-* :pr:`3149`: Allow to use call_updater=True with a function without dt
+* :pr:`3144`: Fixed typo in ``stripUntranslatable.awk``
 
 
 * :pr:`3154`: Bump ipython from 8.7.0 to 8.10.0
@@ -160,18 +163,16 @@ Unclassified changes
 * :pr:`3156`: CI: Remove actions using self-hosted runners
 
 
-* :pr:`3163`: fix: BraceLabel not passing **kwargs to Brace
-   This PR fixes a bug in which the you can't pass arguments to the Brace constructor. My solution imitates the Axes approach, adding a parameter (brace_config) for the arguments to be passed to Brace.
-
 * :pr:`3164`: Bump markdown-it-py from 2.1.0 to 2.2.0
 
 
-* :pr:`3179`: fix deprecation warning
-   Fix issue #3178 Warning when using ParametricFunction with use_vectorized=True
-
-* :pr:`3189`: Corrected the hinted return type for :func:`angle_between_vectors`
+* :pr:`3165`: Removed deprecated keyword argument in :meth:`.Mobject.align_to`
 
 
-* :pr:`3196`: CI: update PATH for recent changed in TinyTex
+* :pr:`3179`: Fixed deprecation warning in :class:`.ParametricFunction` with ``use_vectorized=True``
 
 
+* :pr:`3186`: Updated extlinks to work with latest version of Sphinx
+
+
+* :pr:`3196`: CI: updated PATH for recent changed in TinyTex

--- a/docs/source/changelog/0.17.3-changelog.rst
+++ b/docs/source/changelog/0.17.3-changelog.rst
@@ -75,7 +75,7 @@ New features
 
 * :pr:`3042`: Added :meth:`.Scene.replace` and use in :class:`.ReplacementTransform`
 
-* :pr:`3155`: Added support for individualized radius values in :meth:`.Polygram.round_corners` 
+* :pr:`3155`: Added support for individualized radius values in :meth:`.Polygram.round_corners`
 
 
 * :pr:`3159`: Added :meth:`.set_opacity_by_tex` method for setting the opacity of parts of Tex mobjects
@@ -153,7 +153,7 @@ Documentation-related changes
 * :pr:`3126`: Fixed dead links to troubleshooting page
 
 
-* :pr:`3137`: Fixed example using ``reverse=True`` with :class:`.Write` 
+* :pr:`3137`: Fixed example using ``reverse=True`` with :class:`.Write`
 
 
 * :pr:`3160`: Fixed a typo

--- a/docs/source/changelog/0.17.3-changelog.rst
+++ b/docs/source/changelog/0.17.3-changelog.rst
@@ -1,0 +1,177 @@
+*******
+v0.17.3
+*******
+
+:Date: March 29, 2023
+
+Contributors
+============
+
+A total of 32 people contributed to this
+release. People with a '+' by their names authored a patch for the first
+time.
+
+* Alex Lembcke
+* Benjamin Hackl
+* DegrangeM +
+* Elyanah Aco +
+* Francisco Manríquez Novoa
+* Fredrik Lundström +
+* Ikko Eltociear Ashimine +
+* JinchuLi2002 +
+* Kevin Lubick
+* KingAndCross +
+* M. A. Ali +
+* Matthew Lee +
+* Max Coplan +
+* Naveen M K
+* NotWearingPants
+* Oscar Rangel +
+* Papierkorb2292 +
+* Phoenix2157 +
+* Tristan Schulz
+* ciobaca +
+* coreyp1 +
+* davidot +
+* icedcoffeeee
+* karpfediem +
+
+
+The patches included in this release have been reviewed by
+the following contributors.
+
+* Benjamin Hackl
+* Fredrik Lundström
+* Hugues Devimeux
+* Kevin Lubick
+* KingAndCross
+* Matthew Lee
+* Naveen M K
+* Tristan Schulz
+* coreyp1
+* davidot
+* github-code-scanning[bot]
+* strager
+
+Pull requests merged
+====================
+
+A total of 32 pull requests were merged for this release.
+
+Deprecated classes and functions
+--------------------------------
+
+* :pr:`3103`: Remove deprecated function from `opengl_surface.py`
+   Remove deprecated function `~.set_fill_by_value()` from `opengl_surface.py`.
+
+New features
+------------
+
+* :pr:`3155`: Added support for individualized radius values in :meth:`.Polygram.round_corners` 
+
+
+* :pr:`3159`: Added :meth:`.set_opacity_by_tex` method for setting the opacity of parts of Tex mobjects
+
+
+Enhancements
+------------
+
+* :pr:`3083`: Minor performance improvement in bezier.py with preallocating array.
+
+
+* :pr:`3092`: perf: improve Mobject.add by checking for redundancy only once
+
+
+* :pr:`3134`: Store color data to prevent opengl embed lag
+
+
+* :pr:`3180`: Speed up width/height/depth calculations by reducing copying
+   The `width`, `height`, and `depth` attributes on Mobjects are calculated more quickly and consume less memory.
+
+* :pr:`3182`: Reduce memory allocations when building SVGMobject
+
+
+* :pr:`3191`: Fixed rendering in named threads, limit condition to interactive OpenGL mode
+   - Narrowed condition for disabling direct rendering in interactive embed mode
+
+Fixed bugs
+----------
+
+* :pr:`3106`: Fixes ignored depth_test parameter for OpenGLVMobjects
+   Adds assignments from `self.depth_test` to `SHADER_WRAPPER.depth_test` in the `update_SHADER_WRAPPER` methods of `OpenGLVMobject`. Without this assignment, the `depth_test` parameter would not be given to the shaders and thus effectively ignored (as it is only assigned to `self.depth_test`, but not used further).
+
+* :pr:`3152`: Fixed behavior of `Wait` with specified `stop_condition`
+
+
+* :pr:`3195`: Fix: Axes Scaling Had No Effect on plot_implicit_curve()
+
+
+Documentation-related changes
+-----------------------------
+
+* :pr:`3109`: Clean-up, type-hints and documentation for `three_dimensions.py`
+   Added type-hints and documentation for three dimensional Mobjects, and removed a deprecated parameter on `Surface.set_fill_by_value()`.
+
+* :pr:`3124`: Fix docstring of ThreeDCamera get_value_trackers
+   Fix the docstring of ThreeDCamera.get_value_trackers
+
+* :pr:`3126`: Change links redirecting to dead troubleshooting page
+
+
+* :pr:`3160`: typo(docs): Fix grammar
+
+
+* :pr:`3186`: Fixed extlinks in docs to work with latest version of Sphinx.
+
+
+Code quality improvements and similar refactors
+-----------------------------------------------
+
+* :pr:`3165`: Remove deprecated arg in M.object.align_to()
+
+
+Unclassified changes
+--------------------
+
+* :pr:`3042`: Add scene.replace() and use in ReplacementTransform
+   ReplacementTransform now preserves the draw order of the (old) mobject when replacing it with `target_mobject`. This uses the new `Scene.replace` method.
+
+* :pr:`3095`: Fixed ``get_axis_labels`` for :class:`.Axes` and :class:`.ThreeDAxes`
+   Moves `~.get_axis_labels()` out of `CoordinateSystem` and into `Axes` and `ThreeDAxes`.  This allows for `~.get_axis_labels()` to be used with both 2D and 3D axes.  Fixed some documentation in the process.
+
+* :pr:`3105`: Convert docstring param type to type-hint in three_dimensions.py
+
+
+* :pr:`3108`: Clarified documentation for --resolution flag
+
+
+* :pr:`3137`: Fixed example using reverse with `Write` 
+   If you use `Write` with kwarg `reverse=True` the animation of object, say the text, will start from right to left, which is the intended action, and it does work, however once the animation ends, the object just disappear. A fix to the issue is to add `remover=False`. I updated the example given in the docs.
+
+* :pr:`3144`: Fix typo in stripUntranslatable.awk
+
+
+* :pr:`3149`: Allow to use call_updater=True with a function without dt
+
+
+* :pr:`3154`: Bump ipython from 8.7.0 to 8.10.0
+
+
+* :pr:`3156`: CI: Remove actions using self-hosted runners
+
+
+* :pr:`3163`: fix: BraceLabel not passing **kwargs to Brace
+   This PR fixes a bug in which the you can't pass arguments to the Brace constructor. My solution imitates the Axes approach, adding a parameter (brace_config) for the arguments to be passed to Brace.
+
+* :pr:`3164`: Bump markdown-it-py from 2.1.0 to 2.2.0
+
+
+* :pr:`3179`: fix deprecation warning
+   Fix issue #3178 Warning when using ParametricFunction with use_vectorized=True
+
+* :pr:`3189`: Corrected the hinted return type for :func:`angle_between_vectors`
+
+
+* :pr:`3196`: CI: update PATH for recent changed in TinyTex
+
+

--- a/manim/mobject/graphing/coordinate_systems.py
+++ b/manim/mobject/graphing/coordinate_systems.py
@@ -2098,10 +2098,11 @@ class Axes(VGroup, CoordinateSystem, metaclass=ConvertToOpenGL):
         x_label: float | str | Mobject = "x",
         y_label: float | str | Mobject = "y",
     ) -> VGroup:
-        """Defines labels for the x_axis and y_axis of the graph.
+        """Defines labels for the x-axis and y-axis of the graph.
 
         For increased control over the position of the labels,
-        use :meth:`get_x_axis_label` and :meth:`get_y_axis_label`.
+        use :meth:`~.CoordinateSystem.get_x_axis_label` and
+        :meth:`~.CoordinateSystem.get_y_axis_label`.
 
         Parameters
         ----------
@@ -2117,8 +2118,8 @@ class Axes(VGroup, CoordinateSystem, metaclass=ConvertToOpenGL):
 
 
         .. seealso::
-            :meth:`.get_x_axis_label`
-            :meth:`.get_y_axis_label`
+            :meth:`~.CoordinateSystem.get_x_axis_label`
+            :meth:`~.CoordinateSystem.get_y_axis_label`
 
         Examples
         --------
@@ -2487,7 +2488,9 @@ class ThreeDAxes(Axes):
         """Defines labels for the x_axis and y_axis of the graph.
 
         For increased control over the position of the labels,
-        use :meth:`.get_x_axis_label` and :meth:`.get_y_axis_label`.
+        use :meth:`~.CoordinateSystem.get_x_axis_label`,
+        :meth:`~.ThreeDAxes.get_y_axis_label`, and
+        :meth:`~.ThreeDAxes.get_z_axis_label`.
 
         Parameters
         ----------
@@ -2505,9 +2508,9 @@ class ThreeDAxes(Axes):
 
 
         .. seealso::
-            :meth:`.get_x_axis_label`
-            :meth:`.get_y_axis_label`
-            :meth:`.get_z_axis_label`
+            :meth:`~.CoordinateSystem.get_x_axis_label`
+            :meth:`~.ThreeDAxes.get_y_axis_label`
+            :meth:`~.ThreeDAxes.get_z_axis_label`
 
         Examples
         --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,10 @@ classifiers= [
     "Topic :: Scientific/Engineering",
     "Topic :: Multimedia :: Video",
     "Topic :: Multimedia :: Graphics",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Natural Language :: English",
     ]
 exclude = ["scripts/","logo/","readme-assets/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "manim"
-version = "0.17.2"
+version = "0.17.3"
 description = "Animation engine for explanatory math videos."
 authors = ["The Manim Community Developers <contact@manim.community>", "3b1b <grant@3blue1brown.com>"]
 license="MIT"


### PR DESCRIPTION
This PR prepares the release of `v0.17.3`.

Rendered changelog: https://manimce--3198.org.readthedocs.build/en/3198/changelog/0.17.3-changelog.html