### PR TITLE
Bugfix: Fix arc start angle type

### DIFF
--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -282,8 +282,8 @@ class Arc(TipableVMobject):
     def __init__(
         self,
         radius: float = 1.0,
-        start_angle=0,
-        angle=TAU / 4,
+        start_angle: float = 0,
+        angle: float = TAU / 4,
         num_components=9,
         arc_center=ORIGIN,
         **kwargs,

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -160,7 +160,7 @@ class Mobject:
             The animation type to be overridden
         override_func
             The function returning an animation replacing the default animation. It gets
-            passed the parameters given to the animnation constructor.
+            passed the parameters given to the animation constructor.
 
         Raises
         ------


### PR DESCRIPTION
The `start_angle` argument of `Arc` is incorrectly typed as `int`. Since no explicit type is assigned, and the default value is the literal `0`, the implicit type is `int`, not `float`. This PR fixes this issue by adding the explicit `float` type.

This PR also corrects a misspelling of the word `animation` in the documentation of `Mobject`'s `add_animation_override`.

## Links to added or changed documentation pages
[`Arc`](https://docs.manim.community/en/stable/_modules/manim/mobject/geometry/arc.html#Arc)
[`add_animation_override`](https://docs.manim.community/en/stable/reference/manim.mobject.mobject.Mobject.html?highlight=animation_override#manim.mobject.mobject.Mobject.add_animation_override)

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added functions and classes are tested
