### PR TITLE
Fix `DecimalNumber` with `show_ellipsis=True` work on OpenGL renderer

### DIFF
--- a/manim/mobject/text/numbers.py
+++ b/manim/mobject/text/numbers.py
@@ -66,7 +66,7 @@ class DecimalNumber(VMobject, metaclass=ConvertToOpenGL):
         fill_opacity: float = 1.0,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(**kwargs, stroke_width=stroke_width)
         self.number = number
         self.num_decimal_places = num_decimal_places
         self.include_sign = include_sign
@@ -78,7 +78,6 @@ class DecimalNumber(VMobject, metaclass=ConvertToOpenGL):
         self.include_background_rectangle = include_background_rectangle
         self.edge_to_fix = edge_to_fix
         self._font_size = font_size
-        self.stroke_width = stroke_width
         self.fill_opacity = fill_opacity
 
         self.initial_config = kwargs.copy()


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->
DecimalNumber: Don't set the `stroke_width` attribute directly
Instead, set it through the super object init method. For some reason, on OpenGL renderer, `stroke_width` is needed as a different datatype, rather than an integer as in Cairo renderer. To avoid problems, set `stroke_width` while calling super's init method.

## Motivation and Explanation: Why and how do your changes improve the library?
Without those changes, the below snippet doesn't render when using the OpenGL renderer
```py
class Test(Scene):
    def construct(self):
        self.play(
            FadeIn(
                DecimalNumber(
                    0,
                    show_ellipsis=True,
                )
            )
        )
```


<details><summary>Traceback</summary>

```
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /usr/local/lib/python3.8/site-packages/manim/cli/render/commands.py:97 in    │
│ render                                                                       │
│                                                                              │
│    94 │   │   │   │   for SceneClass in scene_classes_from_file(file):       │
│    95 │   │   │   │   │   with tempconfig({}):                               │
│    96 │   │   │   │   │   │   scene = SceneClass(renderer)                   │
│ ❱  97 │   │   │   │   │   │   rerun = scene.render()                         │
│    98 │   │   │   │   │   if rerun or config["write_all"]:                   │
│    99 │   │   │   │   │   │   renderer.num_plays = 0                         │
│   100 │   │   │   │   │   │   continue                                       │
│                                                                              │
│ /usr/local/lib/python3.8/site-packages/manim/scene/scene.py:223 in render    │
│                                                                              │
│    220 │   │   """                                                           │
│    221 │   │   self.setup()                                                  │
│    222 │   │   try:                                                          │
│ ❱  223 │   │   │   self.construct()                                          │
│    224 │   │   except EndSceneEarlyException:                                │
│    225 │   │   │   pass                                                      │
│    226 │   │   except RerunSceneException as e:                              │
│                                                                              │
│ /manim/script.py:6 in construct                                              │
│                                                                              │
│    3 │   def construct(self):                                                │
│    4 │   │   self.play(                                                      │
│    5 │   │   │   FadeIn(                                                     │
│ ❱  6 │   │   │   │   DecimalNumber(                                          │
│    7 │   │   │   │   │   0,                                                  │
│    8 │   │   │   │   │   show_ellipsis=True,                                 │
│    9 │   │   │   │   )                                                       │
│                                                                              │
│ /usr/local/lib/python3.8/site-packages/manim/mobject/text/numbers.py:101 in  │
│ __init__                                                                     │
│                                                                              │
│    98 │   │   │   },                                                         │
│    99 │   │   )                                                              │
│   100 │   │                                                                  │
│ ❱ 101 │   │   self._set_submobjects_from_number(number)                      │
│   102 │   │   self.init_colors()                                             │
│   103 │                                                                      │
│   104 │   @property                                                          │
│                                                                              │
│ /usr/local/lib/python3.8/site-packages/manim/mobject/text/numbers.py:131 in  │
│ _set_submobjects_from_number                                                 │
│                                                                              │
│   128 │   │   # Add non-numerical bits                                       │
│   129 │   │   if self.show_ellipsis:                                         │
│   130 │   │   │   self.add(                                                  │
│ ❱ 131 │   │   │   │   self._string_to_mob("\\dots", SingleStringMathTex, col │
│   132 │   │   │   )                                                          │
│   133 │   │                                                                  │
│   134 │   │   if self.unit is not None:                                      │
│                                                                              │
│ /usr/local/lib/python3.8/site-packages/manim/mobject/opengl/opengl_vectorize │
│ d_mobject.py:394 in get_color                                                │
│                                                                              │
│    391 │   │   return self.get_stroke_opacities()[0]                         │
│    392 │                                                                     │
│    393 │   def get_color(self):                                              │
│ ❱  394 │   │   if self.has_stroke():                                         │
│    395 │   │   │   return self.get_stroke_color()                            │
│    396 │   │   return self.get_fill_color()                                  │
│    397                                                                       │
│                                                                              │
│ /usr/local/lib/python3.8/site-packages/manim/mobject/opengl/opengl_vectorize │
│ d_mobject.py:413 in has_stroke                                               │
│                                                                              │
│    410 │   │   return (                                                      │
│    411 │   │   │   stroke_widths is not None                                 │
│    412 │   │   │   and stroke_opacities is not None                          │
│ ❱  413 │   │   │   and any(stroke_widths)                                    │
│    414 │   │   │   and any(stroke_opacities)                                 │
│    415 │   │   )                                                             │
│    416                                                                       │
╰──────────────────────────────────────────────────────────────────────────────╯
TypeError: 'int' object is not iterable
```

</details>

## Further Information and Comments
I noticed that the `stroke_width` attribute's datatype is different on the OpenGL renderer, should we keep it the same way? Or should we keep it as an integer like it's in the Cairo renderer, and only internally convert that as required?

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
