### PR TITLE
Fixed Display Issue with Custom Axis Labels When ```renderer=opengl```

### DIFF
--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from manim.mobject.opengl.opengl_vectorized_mobject import OpenGLVMobject
+
 __all__ = ["NumberLine", "UnitInterval"]
 
 
@@ -626,7 +628,7 @@ class NumberLine(Line):
         """
         if label_constructor is None:
             label_constructor = self.label_constructor
-        if isinstance(label_tex, VMobject):
+        if isinstance(label_tex, (VMobject, OpenGLVMobject)):
             return label_tex
         else:
             return label_constructor(label_tex, **kwargs)


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->
Closes #3069 


## Overview: What does this pull request change?

Fixes the issue causing axis labels being rendered incorrectly when ```renderer=opengl```.

Typically when custom labels are applied (ex. LogScaling), ```NumberLine``` creates the labels by calling ```label_constructor``` with ```label_tex``` if ```label_tex``` is not a ```VMobject``` instance.

Issues arise when ```label_tex``` is of instance ```OpenGLVMobject```. Since ```label_constructor``` is class ```MathTex``` by default which is supposed to take ```str``` as arguments, ```OpenGLMobject.__str__``` is therefore called and passed into ```label_constructor```.



## Further Information and Comments
### Example: Logarithmic Scaling

<details>
<summary>Test code</summary>

```python
from manim import *
class LogScalingExample(Scene):
    def construct(self):
        ax = Axes(
            x_range=[0, 10, 1],
            y_range=[-2, 6, 1],
            tips=False,
            axis_config={"include_numbers": True},
            y_axis_config={"scaling": LogBase(custom_labels=True)},
        )

        # x_min must be > 0 because log is undefined at 0.
        graph = ax.plot(lambda x: x ** 2, x_range=[0.001, 10], use_smoothing=False)
        self.add(ax, graph)

with tempconfig({"quality": "high_quality", "preview": True, "renderer": "opengl"}):
    scene = LogScalingExample()
    scene.render()
``` 

</details>

<details>
<summary>Before</summary>

<img width="1167" alt="Screen Shot 2023-04-09 at 8 00 34 PM" src="https://user-images.githubusercontent.com/63861808/230802608-78276a7b-9d5f-431c-a558-614eda49e07b.png">

</details>

<details>
<summary>After</summary>

<img width="1167" alt="Screen Shot 2023-04-09 at 8 00 56 PM" src="https://user-images.githubusercontent.com/63861808/230802623-35ab0091-e865-423f-ba68-fc3f9ea06cde.png">

</details>


### Example: Change Axis Label

<details>
<summary>Test code</summary>

```python
from manim import *
class GetAxisLabelsExample(Scene):
    def construct(self):
        ax = Axes()
        labels = ax.get_axis_labels(
            Tex("x-axis").scale(0.7), Text("y-axis").scale(0.45)
        )
        self.add(ax, labels)

with tempconfig({"quality": "high_quality", "preview": True, "renderer": "opengl"}):
    scene = GetAxisLabelsExample()
    scene.render()
```
</details>

<details>
<summary>Before</summary>

<img width="1130" alt="Screen Shot 2023-04-09 at 7 59 15 PM" src="https://user-images.githubusercontent.com/63861808/230802554-1de4d624-2eab-4754-b82b-37f97f5a6f01.png">

</details>
<details>
<summary>After</summary>

<img width="1130" alt="Screen Shot 2023-04-09 at 7 58 23 PM" src="https://user-images.githubusercontent.com/63861808/230802512-e1dc3ec2-14fd-454d-9e47-2c8f8c0b14de.png">
</details>


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
