### PR TITLE
Small grammar change to deep_dive doc

### DIFF
--- a/docs/source/guides/deep_dive.rst
+++ b/docs/source/guides/deep_dive.rst
@@ -385,7 +385,7 @@ describing the control points in between ("handles").
 .. hint::
   To learn more about Bézier curves, take a look at the excellent
   online textbook `A Primer on Bézier curves <https://pomax.github.io/bezierinfo/>`__
-  by `Pomax <https://twitter.com/TheRealPomax>`__ -- there is an playground representing
+  by `Pomax <https://twitter.com/TheRealPomax>`__ -- there is a playground representing
   cubic Bézier curves `in §1 <https://pomax.github.io/bezierinfo/#introduction>`__,
   the red and yellow points are "anchors", and the green and blue
   points are "handles".


### PR DESCRIPTION
In manim/docs/source/guides/deep_dive.rst line 388, changed "there is an playground" to "there is a playground".

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
