### PR TITLE
Add LaTeX installation instructions for Fedora

### DIFF
--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -145,6 +145,12 @@ installed by running:
 
    sudo apt install texlive texlive-latex-extra
 
+For Fedora (see `docs <https://docs.fedoraproject.org/en-US/neurofedora/latex/>`__):
+
+.. code-block:: bash
+
+   sudo dnf install texlive-scheme-full
+
 Should you choose to work with some smaller TeX distribution like
 `TinyTeX <https://yihui.org/tinytex/>`__ , the full list
 of LaTeX packages which Manim interacts with in some way (a subset might


### PR DESCRIPTION
## Overview: What does this pull request change?
Adds LaTeX installation instructions for Fedora.

## Links to added or changed documentation pages
https://manimce--####.org.readthedocs.build/en/####/

## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [x] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [x] If applicable: newly added functions and classes are tested
