### PR TITLE
Added Two New Classes: LabeledLine and LabeledArrow

### DIFF
--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -369,6 +369,19 @@ class TangentLine(Line):
 #TODO: Find a way to prevent the label in LabeledLine and LabeledArrow from growing in size when the arrow is expanded.
 
 class LabeledLine(Line):
+    """Constructs a line containing a label box somewhere along its length.
+
+    Parameters
+    ----------
+    label: str | Tex | MathTex | Text
+        xxxxxxx
+    label_position: float
+        xxxxxxx
+    font_size: int | float
+        xxxxxx
+    label_color: 
+    
+    """
     def __init__(
         self, 
         label, 
@@ -413,6 +426,9 @@ class LabeledLine(Line):
 
 
 class LabeledArrow(LabeledLine, Arrow):
+    """Constructs an arrow containing a label box somewhere along its length.
+
+    """
     def __init__(
         self, 
         *args,

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -461,54 +461,6 @@ class LabeledLine(Line):
         # self.label_position = label_position
 
 
-<<<<<<< HEAD
-=======
-class LabeledArrow(LabeledLine, Arrow):
-    """Constructs an arrow containing a label box somewhere along its length.
-    This class inherits its label properties from `LabeledLine`, so the main parameters controlling it are the same.
-
-    Parameters
-    ----------
-    label : str | Tex | MathTex | Text
-        Label that will be displayed on the line.
-    label_position : float | optional
-        A ratio in the range [0-1] to indicate the positon of the labelwith respect to the length of the line. Default value is 0.5.
-    font_size : int | float | optional
-        Control font size for the label. This parameter is only used when `label` is of type `str`.
-    label_color: numpy.ndarray | optional
-        The color of the label's text. This parameter is only used when `label` is of type `str`.
-    label_frame : Bool | optional
-        Add a `SurroundingRectangle` frame to the label box.
-    frame_fill_color : numpy.ndarray | optional
-        Background color to fill the label box. If no value is provided, the background color of the canvas will be used.
-    frame_fill_opacity : float | optional
-        Determine the opacity of the label box by passing a value in the range [0-1], where 0 indicates complete transparency and 1 means full opacity.
-
-
-    .. seealso::
-        :class:`LabeledLine`
-
-    Examples
-    --------
-    .. manim:: LabeledArrowExample
-        :save_last_frame:
-
-        class LabeledArrowExample(Scene):
-            def construct(self):
-                l_arrow = LabeledArrow("0.5", start=LEFT*3, end=RIGHT*3 + UP*2, label_position=0.5)
-
-                self.add(l_arrow)
-    """
-
-    def __init__(
-        self,
-        *args,
-        **kwargs,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-
-
->>>>>>> e0a6e205b779d8bd76f58fb8bb06e94b98250623
 class Elbow(VMobject, metaclass=ConvertToOpenGL):
     """Two lines that create a right angle about each other: L-shape.
 

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -366,6 +366,62 @@ class TangentLine(Line):
         self.scale(self.length / self.get_length())
 
 
+#TODO: Find a way to prevent the label in LabeledLine and LabeledArrow from growing in size when the arrow is expanded.
+
+class LabeledLine(Line):
+    def __init__(
+        self, 
+        label, 
+        label_position:float=0.5, 
+        font_size=15,
+        label_color=WHITE,
+        label_frame=True,
+        frame_fill_color=None,
+        frame_fill_opacity=1,
+        *args, 
+        **kwargs,
+    ) -> None:
+        
+        if isinstance(label, str):
+            from manim import MathTex
+
+            rendered_label = MathTex(label, color=label_color, font_size=font_size)
+        else:
+            rendered_label = label
+
+        super().__init__(*args, **kwargs)
+
+        #calculating the vector for the label position
+        line_start, line_end = self.get_start_and_end()
+        new_vec = (line_end - line_start) * label_position
+        label_coords = line_start + new_vec
+
+        #rendered_label.move_to(self.get_vector() * label_position)
+        rendered_label.move_to(label_coords)
+
+        box = BackgroundRectangle(rendered_label, buff=0.05, color=frame_fill_color, fill_opacity=frame_fill_opacity, stroke_width=0.5)
+        self.add(box)
+        
+        if label_frame:
+            box_frame = SurroundingRectangle(rendered_label, buff=0.05, color=label_color, stroke_width=0.5)
+
+            self.add(box_frame)
+            
+        self.add(rendered_label)
+
+        #self.label_position = label_position
+
+
+class LabeledArrow(LabeledLine, Arrow):
+    def __init__(
+        self, 
+        *args,
+        **kwargs,
+    ) -> None:
+        
+        super().__init__(*args, **kwargs)
+
+
 class Elbow(VMobject, metaclass=ConvertToOpenGL):
     """Two lines that create a right angle about each other: L-shape.
 

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -891,12 +891,12 @@ class LabeledArrow(LabeledLine, Arrow):
 
                 self.add(l_arrow)
     """
+
     def __init__(
         self,
         *args,
         **kwargs,
     ) -> None:
-
         super().__init__(*args, **kwargs)
 
 

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -366,21 +366,50 @@ class TangentLine(Line):
         self.scale(self.length / self.get_length())
 
 
-#TODO: Find a way to prevent the label in LabeledLine and LabeledArrow from growing in size when the arrow is expanded.
 
 class LabeledLine(Line):
     """Constructs a line containing a label box somewhere along its length.
 
     Parameters
     ----------
-    label: str | Tex | MathTex | Text
-        xxxxxxx
-    label_position: float
-        xxxxxxx
-    font_size: int | float
-        xxxxxx
-    label_color: 
-    
+    label : str | Tex | MathTex | Text
+        Label that will be displayed on the line.
+    label_position : float | optional
+        A ratio in the range [0-1] to indicate the positon of the labelwith respect to the length of the line. Default value is 0.5.
+    font_size : int | float | optional
+        Control font size for the label. This parameter is only used when `label` is of type `str`.
+    label_color: numpy.ndarray | optional
+        The color of the label's text. This parameter is only used when `label` is of type `str`.
+    label_frame : Bool | optional
+        Add a `SurroundingRectangle` frame to the label box.
+    frame_fill_color : numpy.ndarray | optional
+        Background color to fill the label box. If no value is provided, the background color of the canvas will be used.
+    frame_fill_opacity : float | optional
+        Determine the opacity of the label box by passing a value in the range [0-1], where 0 indicates complete transparency and 1 means full opacity.
+
+    .. seealso::
+        :class:`LabeledArrow`
+
+    Examples
+    --------
+    .. manim:: LabeledLineExample
+        :save_last_frame:
+
+        class LabeledLineExample(Scene):
+            def construct(self):
+                line = LabeledLine(
+                    label          = '0.5', 
+                    label_position = 0.8,
+                    font_size      = 20, 
+                    label_color    = WHITE, 
+                    label_frame    = True, 
+
+                    start=LEFT+DOWN, 
+                    end=RIGHT+UP)
+
+
+                line.set_length(line.get_length() * 2)
+                self.add(line)
     """
     def __init__(
         self, 
@@ -427,7 +456,39 @@ class LabeledLine(Line):
 
 class LabeledArrow(LabeledLine, Arrow):
     """Constructs an arrow containing a label box somewhere along its length.
+    This class inherits its label properties from `LabeledLine`, so the main parameters controlling it are the same. 
+    
+    Parameters
+    ----------
+    label : str | Tex | MathTex | Text
+        Label that will be displayed on the line.
+    label_position : float | optional
+        A ratio in the range [0-1] to indicate the positon of the labelwith respect to the length of the line. Default value is 0.5.
+    font_size : int | float | optional
+        Control font size for the label. This parameter is only used when `label` is of type `str`.
+    label_color: numpy.ndarray | optional
+        The color of the label's text. This parameter is only used when `label` is of type `str`.
+    label_frame : Bool | optional
+        Add a `SurroundingRectangle` frame to the label box.
+    frame_fill_color : numpy.ndarray | optional
+        Background color to fill the label box. If no value is provided, the background color of the canvas will be used.
+    frame_fill_opacity : float | optional
+        Determine the opacity of the label box by passing a value in the range [0-1], where 0 indicates complete transparency and 1 means full opacity.
 
+
+    .. seealso::
+        :class:`LabeledLine`
+
+    Examples
+    --------
+    .. manim:: LabeledArrowExample
+        :save_last_frame:
+
+        class LabeledArrowExample(Scene):
+            def construct(self):
+                l_arrow = LabeledArrow("0.5", start=LEFT*3, end=RIGHT*3 + UP*2, label_position=0.5)
+
+                self.add(l_arrow)
     """
     def __init__(
         self, 

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -454,51 +454,6 @@ class LabeledLine(Line):
         #self.label_position = label_position
 
 
-class LabeledArrow(LabeledLine, Arrow):
-    """Constructs an arrow containing a label box somewhere along its length.
-    This class inherits its label properties from `LabeledLine`, so the main parameters controlling it are the same. 
-    
-    Parameters
-    ----------
-    label : str | Tex | MathTex | Text
-        Label that will be displayed on the line.
-    label_position : float | optional
-        A ratio in the range [0-1] to indicate the positon of the labelwith respect to the length of the line. Default value is 0.5.
-    font_size : int | float | optional
-        Control font size for the label. This parameter is only used when `label` is of type `str`.
-    label_color: numpy.ndarray | optional
-        The color of the label's text. This parameter is only used when `label` is of type `str`.
-    label_frame : Bool | optional
-        Add a `SurroundingRectangle` frame to the label box.
-    frame_fill_color : numpy.ndarray | optional
-        Background color to fill the label box. If no value is provided, the background color of the canvas will be used.
-    frame_fill_opacity : float | optional
-        Determine the opacity of the label box by passing a value in the range [0-1], where 0 indicates complete transparency and 1 means full opacity.
-
-
-    .. seealso::
-        :class:`LabeledLine`
-
-    Examples
-    --------
-    .. manim:: LabeledArrowExample
-        :save_last_frame:
-
-        class LabeledArrowExample(Scene):
-            def construct(self):
-                l_arrow = LabeledArrow("0.5", start=LEFT*3, end=RIGHT*3 + UP*2, label_position=0.5)
-
-                self.add(l_arrow)
-    """
-    def __init__(
-        self, 
-        *args,
-        **kwargs,
-    ) -> None:
-        
-        super().__init__(*args, **kwargs)
-
-
 class Elbow(VMobject, metaclass=ConvertToOpenGL):
     """Two lines that create a right angle about each other: L-shape.
 
@@ -891,6 +846,51 @@ class DoubleArrow(Arrow):
         tip_shape_start = kwargs.pop("tip_shape_start", ArrowTriangleFilledTip)
         super().__init__(*args, **kwargs)
         self.add_tip(at_start=True, tip_shape=tip_shape_start)
+
+
+class LabeledArrow(LabeledLine, Arrow):
+    """Constructs an arrow containing a label box somewhere along its length.
+    This class inherits its label properties from `LabeledLine`, so the main parameters controlling it are the same. 
+    
+    Parameters
+    ----------
+    label : str | Tex | MathTex | Text
+        Label that will be displayed on the line.
+    label_position : float | optional
+        A ratio in the range [0-1] to indicate the positon of the labelwith respect to the length of the line. Default value is 0.5.
+    font_size : int | float | optional
+        Control font size for the label. This parameter is only used when `label` is of type `str`.
+    label_color: numpy.ndarray | optional
+        The color of the label's text. This parameter is only used when `label` is of type `str`.
+    label_frame : Bool | optional
+        Add a `SurroundingRectangle` frame to the label box.
+    frame_fill_color : numpy.ndarray | optional
+        Background color to fill the label box. If no value is provided, the background color of the canvas will be used.
+    frame_fill_opacity : float | optional
+        Determine the opacity of the label box by passing a value in the range [0-1], where 0 indicates complete transparency and 1 means full opacity.
+
+
+    .. seealso::
+        :class:`LabeledLine`
+
+    Examples
+    --------
+    .. manim:: LabeledArrowExample
+        :save_last_frame:
+
+        class LabeledArrowExample(Scene):
+            def construct(self):
+                l_arrow = LabeledArrow("0.5", start=LEFT*3, end=RIGHT*3 + UP*2, label_position=0.5)
+
+                self.add(l_arrow)
+    """
+    def __init__(
+        self, 
+        *args,
+        **kwargs,
+    ) -> None:
+        
+        super().__init__(*args, **kwargs)
 
 
 class Angle(VMobject, metaclass=ConvertToOpenGL):


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
I created two custom classes in the file `manim/mobject/geometry/line.py` with functionality missing from the base code. These classes are `LabeledLine` and `LabeledArrow`. As the names suggest, these objects behave like their original counterparts but also include a label box along the length of the line. There are parameters to control the position of the box, the text, color, fill color, etc. 

I used `LabeledDot` class as a blueprint. At the same time, I tried following the same docstring style as the other classes in the file.

## Motivation and Explanation: Why and how do your changes improve the library?
My main motivation for this change is that I was trying to create a fully-connected feedforward neural network diagram animation. In these types of diagrams, there are directional arrows that go from input nodes to output nodes. I could not find an easy and repeatable way of accomplishing this with the existing classes, so I created my own. 

I mainly cared about having a labeled arrow, but it seemed that a labeled line should also exist, so I created `LabeledLine` first and then made `LabeledArrow` inherit from it.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
