### PR TITLE
Replaced incorrect mentions of Python 3.7 as the minimally required version

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -59,7 +59,7 @@ in order for Manim to work properly, some additional system
 dependencies need to be installed first. The following pages have
 operating system specific instructions for you to follow.
 
-Manim requires Python version ``3.7`` or above to run.
+Manim requires Python version ``3.8`` or above to run.
 
 .. hint::
 

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -5,7 +5,7 @@ The installation instructions depend on your particular operating
 system and package manager. If you happen to know exactly what you are doing,
 you can also simply ensure that your system has:
 
-- a reasonably recent version of Python 3 (3.7–3.10),
+- a reasonably recent version of Python 3 (3.8 or above),
 - with working Cairo bindings in the form of
   `pycairo <https://cairographics.org/pycairo/>`__,
 - FFmpeg accessible from the command line as ``ffmpeg``,

--- a/docs/source/installation/windows.rst
+++ b/docs/source/installation/windows.rst
@@ -6,7 +6,7 @@ package manager like `Chocolatey <https://chocolatey.org/>`__
 or `Scoop <https://scoop.sh>`__. If you are not afraid of editing
 your System's ``PATH``, a manual installation is also possible.
 In fact, if you already have an existing Python
-installation (3.7-3.10), it might be the easiest way to get
+installation (3.8 or above), it might be the easiest way to get
 everything up and running.
 
 If you choose to use one of the package managers, please follow
@@ -19,7 +19,7 @@ to make one of them available on your system.
 Required Dependencies
 ---------------------
 
-Manim requires a recent version of Python (3.7–3.10) and ``ffmpeg``
+Manim requires a recent version of Python (3.8 or above) and ``ffmpeg``
 in order to work.
 
 Chocolatey
@@ -80,10 +80,10 @@ Manual Installation
 *******************
 
 As mentioned above, Manim needs a reasonably recent version of
-Python 3 (3.7–3.10) and FFmpeg.
+Python 3 (3.8 or above) and FFmpeg.
 
 **Python:** Head over to https://www.python.org, download an installer
-for Python (3.7–3.10), and follow its instructions to get Python
+for a recent version of Python, and follow its instructions to get Python
 installed on your system.
 
 .. note::


### PR DESCRIPTION
See title.