### PR TITLE
fixed the use of the LinearTransformationSceneExample in Jupyter notebooks

### DIFF
--- a/manim/mobject/vector_field.py
+++ b/manim/mobject/vector_field.py
@@ -613,7 +613,7 @@ class ArrowVectorField(VectorField):
             The root point of the vector.
 
         """
-        output = np.asarray(self.func(point))
+        output = np.array(self.func(point))
         norm = np.linalg.norm(output)
         if norm != 0:
             output *= self.length_func(norm) / norm

--- a/manim/scene/vector_space_scene.py
+++ b/manim/scene/vector_space_scene.py
@@ -558,11 +558,12 @@ class LinearTransformationScene(VectorScene):
     .. manim:: LinearTransformationSceneExample
 
         class LinearTransformationSceneExample(LinearTransformationScene):
-            def __init__(self):
+            def __init__(self, **kwargs):
                 LinearTransformationScene.__init__(
                     self,
                     show_coordinates=True,
                     leave_ghost_vectors=True,
+                    *kwargs
                 )
 
             def construct(self):


### PR DESCRIPTION
## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
In its current form the `LinearTransformationSceneExample` does not allow any additional `**kwargs` in its `__init__` call, but Jupyter's Manim magic automatically adds a `renderer=` argument.

I just added the `kwarg`-handling which was missing from the example.

## Further Information and Comments
see [LinearTransformationScene doesn't work?](https://discord.com/channels/581738731934056449/1129032761081069588/1129032761081069588) on Discord

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
