### PR TITLE
Optimized number to point

### DIFF
--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -145,6 +145,12 @@ installed by running:
 
    sudo apt install texlive texlive-latex-extra
 
+For Fedora (see `docs <https://docs.fedoraproject.org/en-US/neurofedora/latex/>`__):
+
+.. code-block:: bash
+
+   sudo dnf install texlive-scheme-full
+
 Should you choose to work with some smaller TeX distribution like
 `TinyTeX <https://yihui.org/tinytex/>`__ , the full list
 of LaTeX packages which Manim interacts with in some way (a subset might

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -23,7 +23,6 @@ from manim.mobject.text.tex_mobject import MathTex, Tex
 from manim.mobject.types.vectorized_mobject import VGroup, VMobject
 from manim.utils.bezier import interpolate
 from manim.utils.config_ops import merge_dicts_recursively
-from manim.utils.space_ops import normalize
 
 
 class NumberLine(Line):
@@ -187,6 +186,8 @@ class NumberLine(Line):
         # turn into a NumPy array to scale by just applying the function
         self.x_range = np.array(x_range, dtype=float)
         self.x_min, self.x_max, self.x_step = scaling.function(self.x_range)
+        self.x_min_no_tips = self.x_min
+        self.x_max_no_tips = self.x_max
         self.length = length
         self.unit_size = unit_size
         # ticks
@@ -263,6 +264,48 @@ class NumberLine(Line):
                     excluding=self.numbers_to_exclude,
                     font_size=self.font_size,
                 )
+
+    def add_tip(
+        self, tip=None, tip_shape=None, tip_length=None, tip_width=None, at_start=False
+    ):
+        """Wrapper for TipableVMobject.add_tip.
+
+        Adds a tip to the NumberLine, and recalculates x_min and x_max
+        from the new line component without its tips, storing the new
+        values in x_min_no_tips and x_max_no_tips.
+        """
+        old_start = self.points[0].copy()
+        old_end = self.points[-1].copy()
+        super().add_tip(tip, tip_shape, tip_length, tip_width, at_start)
+        new_start = self.points[0]
+        new_end = self.points[-1]
+
+        direction = old_end - old_start
+        new_start_proportion = np.dot(new_start - old_start, direction) / np.dot(
+            direction, direction
+        )
+        new_end_proportion = np.dot(new_end - old_start, direction) / np.dot(
+            direction, direction
+        )
+
+        self.x_min_no_tips = self.x_min + new_start_proportion * (
+            self.x_max - self.x_min
+        )
+        self.x_max_no_tips = self.x_min + new_end_proportion * (self.x_max - self.x_min)
+
+        return self
+
+    def pop_tips(self):
+        """Wrapper for TipableVMobject.pop_tips.
+
+        After removing the tips from NumberLine, x_min_no_tips and x_max_no_tips
+        are reset to their original values: x_min and x_max. Then, pop_tips
+        returns the removed tips.
+        """
+        result = super().pop_tips()
+        self.x_min_no_tips = self.x_min
+        self.x_max_no_tips = self.x_max
+        return result
 
     def rotate_about_zero(self, angle: float, axis: Sequence[float] = OUT, **kwargs):
         return self.rotate_about_number(0, angle, axis, **kwargs)
@@ -370,9 +413,11 @@ class NumberLine(Line):
         number = np.asarray(number)
         scalar = number.ndim == 0
         number = self.scaling.inverse_function(number)
-        alphas = (number - self.x_range[0]) / (self.x_range[1] - self.x_range[0])
-        alphas = float(alphas) if scalar else np.vstack(alphas)
-        val = interpolate(self.get_start(), self.get_end(), alphas)
+        alphas = (number - self.x_min_no_tips) / (
+            self.x_max_no_tips - self.x_min_no_tips
+        )
+        alphas = float(alphas) if scalar else alphas.reshape(-1, 1)
+        val = interpolate(self.points[0], self.points[-1], alphas)
         return val
 
     def point_to_number(self, point: Sequence[float]) -> float:
@@ -403,9 +448,10 @@ class NumberLine(Line):
 
         """
         point = np.asarray(point)
-        start, end = self.get_start_and_end()
-        unit_vect = normalize(end - start)
-        proportion = np.dot(point - start, unit_vect) / np.dot(end - start, unit_vect)
+        start = self.points[0]
+        end = self.points[-1]
+        direction = end - start
+        proportion = np.dot(point - start, direction) / np.dot(direction, direction)
         return interpolate(self.x_min, self.x_max, proportion)
 
     def n2p(self, number: float | np.ndarray) -> np.ndarray:

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -452,7 +452,7 @@ class NumberLine(Line):
         end = self.points[-1]
         direction = end - start
         proportion = np.dot(point - start, direction) / np.dot(direction, direction)
-        return interpolate(self.x_min, self.x_max, proportion)
+        return interpolate(self.x_min_no_tips, self.x_max_no_tips, proportion)
 
     def n2p(self, number: float | np.ndarray) -> np.ndarray:
         """Abbreviation for :meth:`~.NumberLine.number_to_point`."""
@@ -463,7 +463,9 @@ class NumberLine(Line):
         return self.point_to_number(point)
 
     def get_unit_size(self) -> float:
-        return self.get_length() / (self.x_range[1] - self.x_range[0])
+        return (self.points[-1] - self.points[0]) / (
+            self.x_max_no_tip - self.x_min_no_tip
+        )
 
     def get_unit_vector(self) -> np.ndarray:
         return super().get_unit_vector() * self.unit_size

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -284,16 +284,14 @@ class NumberLine(Line):
         new_end = self.points[-1]
 
         direction = old_end - old_start
-        new_start_proportion = np.dot(new_start - old_start, direction) / np.dot(
-            direction, direction
-        )
-        new_end_proportion = np.dot(new_end - old_start, direction) / np.dot(
-            direction, direction
-        )
+        length2 = np.dot(direction, direction)
+        new_start_proportion = np.dot(new_start - old_start, direction) / length2
+        new_end_proportion = np.dot(new_end - old_start, direction) / length2
 
-        x_max, x_min, _ = self.x_range_no_tips
-        self.x_range_no_tips[0] = x_min + new_start_proportion * (x_max - x_min)
-        self.x_range_no_tips[1] = x_max + new_start_proportion * (x_max - x_min)
+        range_min, range_max, _ = self.x_range_no_tips
+        diff = range_max - range_min
+        self.x_range_no_tips[0] = range_min + new_start_proportion * diff
+        self.x_range_no_tips[1] = range_min + new_end_proportion * diff
         self.x_min_no_tips, self.x_max_no_tips, _ = self.scaling.function(
             self.x_range_no_tips
         )

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -572,18 +572,18 @@ class NumberLine(Line):
         if label_constructor is None:
             label_constructor = self.label_constructor
 
-        numbers = VGroup()
-        for x in x_values:
-            if x in excluding:
-                continue
-            numbers.add(
+        numbers = VGroup(
+            *[
                 self.get_number_mobject(
                     x,
                     font_size=font_size,
                     label_constructor=label_constructor,
                     **kwargs,
                 )
-            )
+                for x in x_values
+                if x not in excluding
+            ]
+        )
         self.add(numbers)
         self.numbers = numbers
         return self
@@ -628,7 +628,7 @@ class NumberLine(Line):
         if label_constructor is None:
             label_constructor = self.label_constructor
 
-        labels = VGroup()
+        labels = []
         for x, label in dict_values.items():
             # TODO: remove this check and ability to call
             # this method via CoordinateSystem.add_coordinates()
@@ -643,8 +643,9 @@ class NumberLine(Line):
             else:
                 raise AttributeError(f"{label} is not compatible with add_labels.")
             label.next_to(self.number_to_point(x), direction=direction, buff=buff)
-            labels.add(label)
+            labels.append(label)
 
+        labels = VGroup(*labels)
         self.labels = labels
         self.add(labels)
         return self

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -294,7 +294,9 @@ class NumberLine(Line):
         x_max, x_min, _ = self.x_range_no_tips
         self.x_range_no_tips[0] = x_min + new_start_proportion * (x_max - x_min)
         self.x_range_no_tips[1] = x_max + new_start_proportion * (x_max - x_min)
-        self.x_min_no_tips, self.x_max_no_tips, _ = self.x_range_no_tips
+        self.x_min_no_tips, self.x_max_no_tips, _ = self.scaling.function(
+            self.x_range_no_tips
+        )
 
         return self
 

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Callable, Iterable, Sequence
 if TYPE_CHECKING:
     from manim.mobject.geometry.tips import ArrowTip
 
+from math import sqrt
+
 import numpy as np
 
 from manim import config
@@ -463,12 +465,13 @@ class NumberLine(Line):
         return self.point_to_number(point)
 
     def get_unit_size(self) -> float:
+        v = self.get_unit_vector()
+        return sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
+
+    def get_unit_vector(self) -> np.ndarray:
         return (self.points[-1] - self.points[0]) / (
             self.x_max_no_tips - self.x_min_no_tips
         )
-
-    def get_unit_vector(self) -> np.ndarray:
-        return super().get_unit_vector() * self.unit_size
 
     def get_number_mobject(
         self,

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -273,9 +273,10 @@ class NumberLine(Line):
     ):
         """Wrapper for TipableVMobject.add_tip.
 
-        Adds a tip to the NumberLine, and recalculates x_min and x_max
-        from the new line component without its tips, storing the new
-        values in x_min_no_tips and x_max_no_tips.
+        Adds a tip to the NumberLine, and recalculates the range of the portion of
+        the new line component excluding its tips, storing the new range in
+        self.x_range_no_tips. This also calculates a new min and max, and stores
+        their values in self.x_min_no_tips and self.x_max_no_tips.
         """
         old_start = self.points[0].copy()
         old_end = self.points[-1].copy()
@@ -301,9 +302,9 @@ class NumberLine(Line):
     def pop_tips(self):
         """Wrapper for TipableVMobject.pop_tips.
 
-        After removing the tips from NumberLine, x_min_no_tips and x_max_no_tips
-        are reset to their original values: x_min and x_max. Then, pop_tips
-        returns the removed tips.
+        After removing the tips from NumberLine, x_range_no_tips, x_min_no_tips and
+        x_max_no_tips are reset to their original values: x_range, x_min and x_max.
+        Then, pop_tips returns the removed tips.
         """
         result = super().pop_tips()
         self.x_range_no_tips[:] = self.x_range

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -17,7 +17,7 @@ import numpy as np
 from manim import config
 from manim.constants import *
 from manim.mobject.geometry.line import Line
-from manim.mobject.graphing.scale import LinearBase, _ScaleBase
+from manim.mobject.graphing.scale import UnitLinearBase, _ScaleBase
 from manim.mobject.text.numbers import DecimalNumber
 from manim.mobject.text.tex_mobject import MathTex, Tex
 from manim.mobject.types.vectorized_mobject import VGroup, VMobject
@@ -155,7 +155,7 @@ class NumberLine(Line):
         font_size: float = 36,
         label_direction: Sequence[float] = DOWN,
         label_constructor: VMobject = MathTex,
-        scaling: _ScaleBase = LinearBase(),
+        scaling: _ScaleBase = UnitLinearBase(),
         line_to_number_buff: float = MED_SMALL_BUFF,
         decimal_number_config: dict | None = None,
         numbers_to_exclude: Iterable[float] | None = None,
@@ -464,7 +464,7 @@ class NumberLine(Line):
 
     def get_unit_size(self) -> float:
         return (self.points[-1] - self.points[0]) / (
-            self.x_max_no_tip - self.x_min_no_tip
+            self.x_max_no_tips - self.x_min_no_tips
         )
 
     def get_unit_vector(self) -> np.ndarray:

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -188,6 +188,7 @@ class NumberLine(Line):
         # turn into a NumPy array to scale by just applying the function
         self.x_range = np.array(x_range, dtype=float)
         self.x_min, self.x_max, self.x_step = scaling.function(self.x_range)
+        self.x_range_no_tips = self.x_range.copy()
         self.x_min_no_tips = self.x_min
         self.x_max_no_tips = self.x_max
         self.length = length
@@ -290,10 +291,10 @@ class NumberLine(Line):
             direction, direction
         )
 
-        self.x_min_no_tips = self.x_min + new_start_proportion * (
-            self.x_max - self.x_min
-        )
-        self.x_max_no_tips = self.x_min + new_end_proportion * (self.x_max - self.x_min)
+        x_max, x_min, _ = self.x_range_no_tips
+        self.x_range_no_tips[0] = x_min + new_start_proportion * (x_max - x_min)
+        self.x_range_no_tips[1] = x_max + new_start_proportion * (x_max - x_min)
+        self.x_min_no_tips, self.x_max_no_tips, _ = self.x_range_no_tips
 
         return self
 
@@ -305,6 +306,7 @@ class NumberLine(Line):
         returns the removed tips.
         """
         result = super().pop_tips()
+        self.x_range_no_tips[:] = self.x_range
         self.x_min_no_tips = self.x_min
         self.x_max_no_tips = self.x_max
         return result
@@ -412,12 +414,16 @@ class NumberLine(Line):
                    [2., 0., 0.],
                    [3., 0., 0.]])
         """
+        print(self.x_range_no_tips)
+        print(self.x_min_no_tips)
+        print(self.x_max_no_tips)
         number = np.asarray(number)
         scalar = number.ndim == 0
         number = self.scaling.inverse_function(number)
-        alphas = (number - self.x_min_no_tips) / (
-            self.x_max_no_tips - self.x_min_no_tips
-        )
+        print("Number(s):", number)
+        x_min, x_max, _ = self.x_range_no_tips
+        alphas = (number - x_min) / (x_max - x_min)
+        print("Alpha(s): ", alphas)
         alphas = float(alphas) if scalar else alphas.reshape(-1, 1)
         val = interpolate(self.points[0], self.points[-1], alphas)
         return val

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -416,16 +416,11 @@ class NumberLine(Line):
                    [2., 0., 0.],
                    [3., 0., 0.]])
         """
-        print(self.x_range_no_tips)
-        print(self.x_min_no_tips)
-        print(self.x_max_no_tips)
         number = np.asarray(number)
         scalar = number.ndim == 0
         number = self.scaling.inverse_function(number)
-        print("Number(s):", number)
-        x_min, x_max, _ = self.x_range_no_tips
-        alphas = (number - x_min) / (x_max - x_min)
-        print("Alpha(s): ", alphas)
+        range_min, range_max, _ = self.x_range_no_tips
+        alphas = (number - range_min) / (range_max - range_min)
         alphas = float(alphas) if scalar else alphas.reshape(-1, 1)
         val = interpolate(self.points[0], self.points[-1], alphas)
         return val
@@ -477,9 +472,8 @@ class NumberLine(Line):
         return sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
 
     def get_unit_vector(self) -> np.ndarray:
-        return (self.points[-1] - self.points[0]) / (
-            self.x_max_no_tips - self.x_min_no_tips
-        )
+        range_min, range_max, _ = self.x_range_no_tips
+        return (self.points[-1] - self.points[0]) / (range_max - range_min)
 
     def get_number_mobject(
         self,

--- a/manim/mobject/graphing/scale.py
+++ b/manim/mobject/graphing/scale.py
@@ -114,6 +114,33 @@ class LinearBase(_ScaleBase):
         return value / self.scale_factor
 
 
+class UnitLinearBase(LinearBase):
+    def __init__(self):
+        """The default scaling class."""
+
+        super().__init__(scale_factor=1.0)
+
+    def function(self, value: float) -> float:
+        """Multiplies the value by 1.0, i.e. returns the value as is.
+
+        Parameters
+        ----------
+        value
+            Value to be multiplied by the scale factor.
+        """
+        return value
+
+    def inverse_function(self, value: float) -> float:
+        """Inverse of function. Divides the value by 1.0, i.e. returns the value as is.
+
+        Parameters
+        ----------
+        value
+            value to be divided by the scale factor.
+        """
+        return value
+
+
 class LogBase(_ScaleBase):
     def __init__(self, base: float = 10, custom_labels: bool = True):
         """Scale for logarithmic graphs/functions.

--- a/manim/mobject/graphing/scale.py
+++ b/manim/mobject/graphing/scale.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Iterable
 
 import numpy as np
 
-__all__ = ["LogBase", "LinearBase"]
+__all__ = ["LogBase", "LinearBase", "UnitLinearBase"]
 
 from manim.mobject.text.numbers import Integer
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
I've made some changes to `NumberLine` in order to speedup its `number_to_point` method, which is relevant when plotting or updating many graphs in a coordinate system:
- Changed `np.vstack(alphas)` to `alphas.reshape(-1, 1)`, which removes a major bottleneck when using vectorization.
- Recalculated the range of the portion of the line excluding the tips, to use it instead of repeatedly calling `VMobject.get_start` and `VMobject.get_end`, which are the most important bottleneck in general.
- Added a new class `UnitLinearScale` in `bases.py`, with methods `function` and `inverse_function` that return the same value that is passed, for an extra minor speedup.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
This is the code I've been using for testing:
```py
from manim import *

class LaplaceScene(Scene):
    def construct(self):
        axes = Axes(x_range=[-1, 7], y_range=[-1, 4], x_length=16.32, y_length=10.20).add_coordinates()
        s = ValueTracker(0)
    
        def get_min_x(k):
            if k > 3:
                return np.floor(2*np.log(k/3.5)/0.5) / 2 - 0.5
            if k < 0:
                return np.floor(2*np.log(-k/0.5)/0.5) / 2 - 0.5
            return -0.5

        draw_horizontal = lambda k: axes.plot(
            lambda t: k*np.exp(-s.get_value()*t), x_range=[get_min_x(k), 6.5, 0.5],
            stroke_width=1.0, stroke_color=RED_A,
            use_vectorized=True,
        )
        horizontals = {k: draw_horizontal(k) for k in range(-15, 96)}
        del horizontals[0]

        verticals = {
            k: Line(
                axes.c2p(k, -1), axes.c2p(k, 5),
                stroke_width=1.0, stroke_color=BLUE_A,
            )
            for k in range(1, 7)
        }

        draw_func = lambda: axes.plot(
            lambda t: t*np.exp(-s.get_value()*t), x_range=[0, 6.5, 0.5],
            stroke_color=YELLOW,
            use_vectorized=True,
        )
        func = draw_func()

        self.play(
            *[Create(verticals[key]) for key in verticals],
            *[Create(horizontals[key]) for key in horizontals],
            DrawBorderThenFill(axes),
        )
        self.play(Create(func), run_time=2)

        func.add_updater(lambda plot: plot.become(draw_func()))
        for k in horizontals:
            (lambda k: horizontals[k].add_updater(
                lambda line: line.become(draw_horizontal(k))
            ))(k)

        self.play(s.animate.set_value(0.5), run_time=5)

        func.clear_updaters()
        for k in horizontals:
            horizontals[k].clear_updaters()

        self.wait()
        self.play(VGroup(axes, func, *horizontals.values(), *verticals.values()).animate.scale(0.5))
        self.wait()
        
with tempconfig({"preview": True, "quality": "medium_quality", "disable_caching": True}):
    scene = LaplaceScene()
    scene.render()
```

There are 109 ParametricFunctions being updated for 5 seconds, which is costly. A big portion of the runtime is spent on `ParametricFunction.generate_points`, and there are 3 main culprits: `VMobject.make_smooth`, `VMobject.add_points_as_corners`, and `Axes.coords_to_point`. I'm addressing the first 2 of them in other PRs.

![imagen](https://github.com/ManimCommunity/manim/assets/49853152/d7213888-4f80-4099-af90-e815b2d94d62)

In this PR I shall address `Axes.coords_to_point`, or more specifically `NumberLine.number_to_point` (the pale green block which is two blocks below `Axes.coords_to_point`):

![imagen](https://github.com/ManimCommunity/manim/assets/49853152/b9e2dcb7-6435-44aa-96e3-ee3bc7c2eb71)

Here is the original code for `NumberLine.number_to_point`:

```py
def number_to_point(self, number: float | np.ndarray) -> np.ndarray:
        number = np.asarray(number)
        scalar = number.ndim == 0
        number = self.scaling.inverse_function(number)
        alphas = (number - self.x_range[0]) / (self.x_range[1] - self.x_range[0])
        alphas = float(alphas) if scalar else np.vstack(alphas)
        val = interpolate(self.get_start(), self.get_end(), alphas)
        return val
```

### `np.vstack`

**NOTE:** this problem only happened when an array (rather than a single float) is passed to `NumberLine.number_to_line`.

The major bottleneck is `np.vstack(alphas)`. What `np.vstack` does in this case is to transform `alphas` into a column, i.e. if `alphas` was `[0.4, 0.8, 0.1]`, it becomes `[[0.4], [0.8], [0.1]]`.  The thing is, `np.vstack` does a lot of preprocessing behind the curtains, and creates a new array to hold these values. In this case, that preprocessing is not necessary, and we don't actually need to copy the array. A simple view generated with `alphas.reshape(-1, 1)` is sufficient:

```py
        alphas = float(alphas) if scalar else alphas.reshape(-1, 1)
```

And this bottleneck is now gone.

### `TipableVMobject.get_start` and `TipableVMobject.get_end`

In the last line:

```py
        val = interpolate(self.get_start(), self.get_end(), alphas)
```

there are calls to `TipableVMobject`'s methods `get_start` and `get_end`. They check if the line has a tip (calling `has_tip` which does `return hasattr(self, tip) and self.tip in self`, which is expensive) and, if it does, call its `get_start` method, or else call `TipableVMobject.get_start`. They call `VMobject.throw_error_if_no_points`, which is another verification process. All of that is unnecessarily expensive for this case, where we **do** know the `NumberLine` should have points, and there should be a way to get the x range of the line whether it has tips or not without recurring to these expensive calculations, right?

Well, this issue was trickier to solve, because I couldn't just plug in `self.points[0]` and `self.points[-1]` instead of `self.get_start()` and `self.get_end()`. This is because the actual "line" in `NumberLine` becomes shorter when tips are added, and thus the `NumberLine.x_range` attribute does no longer represent the range of the line without the tips, but the range of the full line including the tips. I had to do something more.

To solve this, I overrode `TipableVMobject`'s methods `add_tip` and `pop_tips`, where I calculated the range of the actual portion of the line excluding the tips. For this, I created new attributes for `NumberLine`: `x_range_no_tips`, `x_min_no_tips` and `x_max_no_tips`.

```py
class NumberLine(Line):
    def __init__(self, ...):
        # ...some preprocessing...
        # turn into a NumPy array to scale by just applying the function
        self.x_range = np.array(x_range, dtype=float)
        self.x_min, self.x_max, self.x_step = scaling.function(self.x_range)
        self.x_range_no_tips = self.x_range.copy()
        self.x_min_no_tips = self.x_min
        self.x_max_no_tips = self.x_max
        # ...init some attributes...
        if self.include_tip:
            self.add_tip(
                tip_length=self.tip_height,
                tip_width=self.tip_width,
                tip_shape=tip_shape,
            )
            self.tip.set_stroke(self.stroke_color, self.stroke_width)
        # ...some more processes...

    def add_tip(
        self, tip=None, tip_shape=None, tip_length=None, tip_width=None, at_start=False
    ):
        old_start = self.points[0].copy()
        old_end = self.points[-1].copy()
        super().add_tip(tip, tip_shape, tip_length, tip_width, at_start)
        new_start = self.points[0]
        new_end = self.points[-1]

        direction = old_end - old_start
        length2 = np.dot(direction, direction)
        new_start_proportion = np.dot(new_start - old_start, direction) / length2
        new_end_proportion = np.dot(new_end - old_start, direction) / length2

        range_min, range_max, _ = self.x_range_no_tips
        diff = range_max - range_min
        self.x_range_no_tips[0] = range_min + new_start_proportion * diff
        self.x_range_no_tips[1] = range_min + new_end_proportion * diff
        self.x_min_no_tips, self.x_max_no_tips, _ = self.scaling.function(
            self.x_range_no_tips
        )

        return self

    def pop_tips(self):
        result = super().pop_tips()
        self.x_range_no_tips[:] = self.x_range
        self.x_min_no_tips = self.x_min
        self.x_max_no_tips = self.x_max
        return result
```

With that done, now I can just plug in `self.points[0]` and `self.points[-1]` in `NumberLine.number_to_point`, if I use `x_range_no_tips` instead of `x_range`:

```py
def number_to_point(self, number: float | np.ndarray) -> np.ndarray:
        number = np.asarray(number)
        scalar = number.ndim == 0
        number = self.scaling.inverse_function(number)
        range_min, range_max, _ = self.x_range_no_tips
        alphas = (number - range_min) / (range_max - range_min)
        alphas = float(alphas) if scalar else alphas.reshape(-1, 1)
        val = interpolate(self.points[0], self.points[-1], alphas)
        return val
```

**IMPORTANT NOTE: With those parameters, I also modified some other functions to optimize them: see `point_to_number`, `get_unit_vector` and `get_unit_size`.**

### `NumberLine.scaling.inverse_function` and the adding of `UnitLinearBase`

Finally, there's a very small portion of `NumberLine.number_to_point` (the small paler green block at the right of `NumberLine.number_to_line`) where we call `NumberLine.scaling.inverse_function`. Now, the default base of `NumberLine` is a `LinearBase`, whose default scale factor is 1, and its function and inverse function consist of `return self.scale_factor * value` and `return value / self.scale_factor` respectively. If the default scale factor is 1, this just returns the value itself, but multiplying and dividing by 1 still creates some small overhead.

It is truly a small detail in comparison to the previous two points, but as I wanted to optimize `NumberLine.number_to_point` as much as possible for my use case, I decided to create a new `UnitLinearBase` whose function and inverse function consist solely of returning the same value passed as parameter:

```py
class UnitLinearBase(LinearBase):
    def __init__(self):
        super().__init__(scale_factor=1.0)

    def function(self, value: float) -> float:
        return value

    def inverse_function(self, value: float) -> float:
        return value
```

Then I imported it in `number_line.py` and used it as the default `NumberLine.scaling` attribute. It's around 20x faster than the original "multiply/divide by 1" approach. 

### Results

I managed a speedup of around 3.5x in `NumberLine.number_to_line`! Compare the results:

| Before | After |
|---|---|
| ![imagen](https://github.com/ManimCommunity/manim/assets/49853152/21958b7d-e987-4f47-b412-1f9dc4e40421) | ![imagen](https://github.com/ManimCommunity/manim/assets/49853152/44e64bcf-c6fb-413e-9f2c-97c2760c0ebe) |
| ![imagen](https://github.com/ManimCommunity/manim/assets/49853152/f9ddf5df-12cd-4f42-b45e-b9b0bbaf70fa) | ![imagen](https://github.com/ManimCommunity/manim/assets/49853152/61e86611-ca35-49ca-8d45-a54048370e1f) |

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
