### PR TITLE
Update dependencies for apple silicon in macos.rst

### DIFF
--- a/docs/source/installation/macos.rst
+++ b/docs/source/installation/macos.rst
@@ -34,7 +34,7 @@ are required, namely:
 
 .. code-block:: bash
 
-   brew install pango scipy
+   brew install pango pkg-config scipy
 
 After all required dependencies are installed, simply run:
 


### PR DESCRIPTION

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Adds `pkg-config` to the list of needed dependencies for apple silicon. 
According to https://pypi.org/project/ManimPango/ manim-pango needs pkg-config

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Running into an error when executing `pip3 install manim` on apple silicon
Adding pkg-config resolved this issue for me.
```
pip3 install manim
Collecting manim
  ...
  Building wheel for manimpango (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building wheel for manimpango (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [41 lines of output]
      ....
      running build_ext
      building 'manimpango.cmanimpango' extension
      creating build/temp.macosx-13-arm64-cpython-311
      creating build/temp.macosx-13-arm64-cpython-311/private
      creating build/temp.macosx-13-arm64-cpython-311/private/var
      creating build/temp.macosx-13-arm64-cpython-311/private/var/folders
      creating build/temp.macosx-13-arm64-cpython-311/private/var/folders/6l
      creating build/temp.macosx-13-arm64-cpython-311/private/var/folders/6l/srywjz3d2rl9dm5xfxtgvy040000gn
      creating build/temp.macosx-13-arm64-cpython-311/private/var/folders/6l/srywjz3d2rl9dm5xfxtgvy040000gn/T
      creating build/temp.macosx-13-arm64-cpython-311/private/var/folders/6l/srywjz3d2rl9dm5xfxtgvy040000gn/T/pip-install-nfcb0_az
      creating build/temp.macosx-13-arm64-cpython-311/private/var/folders/6l/srywjz3d2rl9dm5xfxtgvy040000gn/T/pip-install-nfcb0_az/manimpango_0a111173a7d647f3a66a8906a30bf4e9
      creating build/temp.macosx-13-arm64-cpython-311/private/var/folders/6l/srywjz3d2rl9dm5xfxtgvy040000gn/T/pip-install-nfcb0_az/manimpango_0a111173a7d647f3a66a8906a30bf4e9/manimpango
      clang -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk -I/opt/homebrew/opt/python@3.11/Frameworks/Python.framework/Versions/3.11/include/python3.11 -c /private/var/folders/6l/srywjz3d2rl9dm5xfxtgvy040000gn/T/pip-install-nfcb0_az/manimpango_0a111173a7d647f3a66a8906a30bf4e9/manimpango/cmanimpango.c -o build/temp.macosx-13-arm64-cpython-311/private/var/folders/6l/srywjz3d2rl9dm5xfxtgvy040000gn/T/pip-install-nfcb0_az/manimpango_0a111173a7d647f3a66a8906a30bf4e9/manimpango/cmanimpango.o
      /private/var/folders/6l/srywjz3d2rl9dm5xfxtgvy040000gn/T/pip-install-nfcb0_az/manimpango_0a111173a7d647f3a66a8906a30bf4e9/manimpango/cmanimpango.c:773:10: fatal error: 'cairo.h' file not found
      #include "cairo.h"
               ^~~~~~~~~
      1 error generated.
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for manimpango
Failed to build manimpango
ERROR: Could not build wheels for manimpango, which is required to install pyproject.toml-based projects
```

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
