### PR TITLE
fix: return value of TexTemplate.add_to...

### DIFF
--- a/manim/utils/tex.py
+++ b/manim/utils/tex.py
@@ -139,6 +139,7 @@ class TexTemplate:
         else:
             self.preamble += "\n" + txt
         self._rebuild()
+        return self
 
     def add_to_document(self, txt: str):
         """Adds txt to the TeX template just after \\begin{document}, e.g. ``\\boldmath``
@@ -150,6 +151,7 @@ class TexTemplate:
         """
         self.post_doc_commands += "\n" + txt + "\n"
         self._rebuild()
+        return self
 
     def get_texcode_for_expression(self, expression: str):
         """Inserts expression verbatim into TeX template.


### PR DESCRIPTION
Unlike similar methods on other objects .add_to_preamble and .add_to_document do not return the TexTemplate object itself. This does not allow for stacking these methods.

Just added the `return self` for both methods

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
- return value of `TexTemplate.add_to_preamble()` -> self
- return value of `TexTemplate.add_to_document()` -> self

## Motivation and Explanation: Why and how do your changes improve the library?
When trying to stack the modification of the preamble during the creation of the template currently Manim will
silently ignore the changes, since a construction like
```python
my_template = TexTemplate().add_to_preamble(r"\usepackage{siunitx}")
```
will return `None` which is a valid value for 
```python
Tex(r"some text", tex_template=my_template)
```

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
