### PR TITLE
Added "tex_bin_dir" config option for specifying a custom TeX binarie…

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -288,6 +288,7 @@ class ManimConfig(MutableMapping):
         "save_pngs",
         "scene_names",
         "show_in_file_browser",
+        "tex_bin_dir",
         "tex_dir",
         "tex_template",
         "tex_template_file",
@@ -614,6 +615,7 @@ class ManimConfig(MutableMapping):
             "background_color",
             "renderer",
             "window_position",
+            "tex_bin_dir",
         ]:
             setattr(self, key, parser["CLI"].get(key, fallback="", raw=True))
 
@@ -834,6 +836,10 @@ class ManimConfig(MutableMapping):
         # Handle --gui_location flag.
         if getattr(args, "gui_location") is not None:
             self.gui_location = args.gui_location
+
+        # Handle --tex_bin_dir flag.
+        if hasattr(args, "tex_bin_dir") and getattr(args, "tex_bin_dir") is not None:
+            self.tex_bin_dir = args.tex_bin_dir
 
         return self
 
@@ -1468,6 +1474,7 @@ class ManimConfig(MutableMapping):
             "input_file",
             "output_file",
             "partial_movie_dir",
+            "tex_bin_dir",
         ]
         if key not in dirs:
             raise KeyError(
@@ -1564,6 +1571,12 @@ class ManimConfig(MutableMapping):
         lambda self: self._d["output_file"],
         lambda self, val: self._set_dir("output_file", val),
         doc="Output file name (-o).",
+    )
+
+    tex_bin_dir = property(
+        lambda self: self._d["tex_bin_dir"],
+        lambda self, val: self._set_dir("tex_bin_dir", val),
+        doc="Path to custom TeX binaries folder.",
     )
 
     scene_names = property(

--- a/manim/cli/checkhealth/checks.py
+++ b/manim/cli/checkhealth/checks.py
@@ -4,6 +4,7 @@ the actual check implementations."""
 from __future__ import annotations
 
 import os
+import pathlib
 import shutil
 import subprocess
 from typing import Callable
@@ -154,7 +155,10 @@ def is_ffmpeg_working():
     ),
 )
 def is_latex_available():
-    path_to_latex = shutil.which("latex")
+    if config.get_dir("tex_bin_dir") is not None:
+        path_to_latex = config.get_dir("tex_bin_dir") / "latex.exe"
+    else:
+        path_to_latex = shutil.which("latex")
     return path_to_latex is not None and os.access(path_to_latex, os.X_OK)
 
 
@@ -169,5 +173,8 @@ def is_latex_available():
     skip_on_failed=[is_latex_available],
 )
 def is_dvisvgm_available():
-    path_to_dvisvgm = shutil.which("dvisvgm")
+    if config.get_dir("tex_bin_dir") is not None:
+        path_to_dvisvgm = config.get_dir("tex_bin_dir") / "dvisvgm.exe"
+    else:
+        path_to_dvisvgm = shutil.which("dvisvgm")
     return path_to_dvisvgm is not None and os.access(path_to_dvisvgm, os.X_OK)

--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -123,9 +123,17 @@ def tex_compilation_command(
     :class:`str`
         Compilation command according to given parameters
     """
+    # If the tex_bin_dir is set, prefix all tex executables with it
+    # Otherwise, default to using the ones on PATH
+    tex_bin_prefix = ""
+    if config.get_dir("tex_bin_dir") is not None:
+        tex_bin_prefix = config.get_dir("tex_bin_dir")
+
     if tex_compiler in {"latex", "pdflatex", "luatex", "lualatex"}:
         commands = [
-            tex_compiler,
+            tex_compiler
+            if tex_bin_prefix == ""
+            else (tex_bin_prefix / tex_compiler).as_posix(),
             "-interaction=batchmode",
             f'-output-format="{output_format[1:]}"',
             "-halt-on-error",
@@ -142,7 +150,9 @@ def tex_compilation_command(
         else:
             raise ValueError("xelatex output is either pdf or xdv")
         commands = [
-            "xelatex",
+            "xelatex"
+            if tex_bin_prefix == ""
+            else (tex_bin_prefix / "xelatex").as_posix(),
             outflag,
             "-interaction=batchmode",
             "-halt-on-error",
@@ -223,10 +233,18 @@ def convert_to_svg(dvi_file: Path, extension: str, page: int = 1):
     :class:`Path`
         Path to generated SVG file.
     """
+    # If the tex_bin_dir is set, prefix all tex executables with it
+    # Otherwise, default to using the ones on PATH
+    tex_bin_prefix = ""
+    if config.get_dir("tex_bin_dir") is not None:
+        tex_bin_prefix = config.get_dir("tex_bin_dir")
+
     result = dvi_file.with_suffix(".svg")
     if not result.exists():
         commands = [
-            "dvisvgm",
+            "dvisvgm"
+            if tex_bin_prefix == ""
+            else (tex_bin_prefix / "dvisvgm").as_posix(),
             "--pdf" if extension == ".pdf" else "",
             "-p " + str(page),
             f'"{dvi_file.as_posix()}"',


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!--changelog-start-->
 - Added new option ``tex_bin_dir`` to ``_config.utils.ManimConfig``
 - Used this new option in ``tex_file_writing.py``, to determine the location of both the TeX compiler and the dvisvgm executable
 - Updated ``manim/cli/checkhealth/checks.py`` to also use this option when determining the presence of LaTeX and dvisvgm
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
This new option allows users to specify a custom directory for the TeX executables, through the ``tex_bin_dir`` config, available both in config files and the CLI. When this option is unset, the executables which are found on the PATH will instead be used.

Having this option allows users to use Manim with a TeX installation which isn't on their PATH, which is usefull, for instance, when there are multiple TeX installations.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
