### PR TITLE
fix(docs): Remove extra curly bracket in LaTeX math expression

### DIFF
--- a/docs/source/guides/using_text.rst
+++ b/docs/source/guides/using_text.rst
@@ -378,7 +378,7 @@ we have to add it manually.
             myTemplate = TexTemplate()
             myTemplate.add_to_preamble(r"\usepackage{mathrsfs}")
             tex = Tex(
-                r"$\mathscr{H} \rightarrow \mathbb{H}$}",
+                r"$\mathscr{H} \rightarrow \mathbb{H}$",
                 tex_template=myTemplate,
                 font_size=144,
             )


### PR DESCRIPTION
## Overview: What does this pull request change?
Remove extra curly bracket in LaTeX expression in docs.

## Motivation and Explanation: Why and how do your changes improve the library?

## Links to added or changed documentation pages
https://manimce--3389.org.readthedocs.build/en/3389/

## Further Information and Comments
Fix issue #3330

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
