### PR TITLE
Bug fix: Use np.isclose for float equality in number line elongated ticks

### DIFF
--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -277,7 +277,7 @@ class NumberLine(Line):
         via ``self.ticks``."""
         ticks = VGroup()
         elongated_tick_size = self.tick_size * self.longer_tick_multiple
-        elongated_tick_offsets = self.numbers_with_elongated_ticks
+        elongated_tick_offsets = self.numbers_with_elongated_ticks - self.x_min
         for x in self.get_tick_range():
             size = self.tick_size
             if np.any(np.isclose(x - self.x_min, elongated_tick_offsets)):

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -277,9 +277,10 @@ class NumberLine(Line):
         via ``self.ticks``."""
         ticks = VGroup()
         elongated_tick_size = self.tick_size * self.longer_tick_multiple
+        elongated_tick_offsets = self.numbers_with_elongated_ticks
         for x in self.get_tick_range():
             size = self.tick_size
-            if np.any(np.isclose(x, self.numbers_with_elongated_ticks)):
+            if np.any(np.isclose(x - self.x_min, elongated_tick_offsets)):
                 size = elongated_tick_size
             ticks.add(self.get_tick(x, size))
         self.add(ticks)

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -279,7 +279,7 @@ class NumberLine(Line):
         elongated_tick_size = self.tick_size * self.longer_tick_multiple
         for x in self.get_tick_range():
             size = self.tick_size
-            if x in self.numbers_with_elongated_ticks:
+            if np.any(np.isclose(x, self.numbers_with_elongated_ticks)):
                 size = elongated_tick_size
             ticks.add(self.get_tick(x, size))
         self.add(ticks)

--- a/tests/module/mobject/graphing/test_ticks.py
+++ b/tests/module/mobject/graphing/test_ticks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import math
 
 from manim import PI, Axes, NumberLine
 
@@ -11,6 +12,27 @@ def test_duplicate_ticks_removed_for_axes():
     )
     ticks = axis.get_tick_range()
     assert np.unique(ticks).size == ticks.size
+
+
+def test_elongated_ticks_float_equality():
+    nline = NumberLine(
+        x_range=[1 + 1e-5, 1 + 2e-5, 1e-6],
+        numbers_with_elongated_ticks=[
+            1 + 12e-6,
+            1 + 17e-6,
+        ],  # Elongate the 3rd and 8th tick
+        include_ticks=True,
+    )
+
+    tick_heights = set(tick.height for tick in nline.ticks)
+    default_tick_height, elongated_tick_height = min(tick_heights), max(tick_heights)
+
+    assert all(
+        tick.height == elongated_tick_height
+        if ind in [2, 7]
+        else tick.height == default_tick_height
+        for ind, tick in enumerate(nline.ticks)
+    )
 
 
 def test_ticks_not_generated_on_origin_for_axes():

--- a/tests/module/mobject/graphing/test_ticks.py
+++ b/tests/module/mobject/graphing/test_ticks.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import numpy as np
 import math
+
+import numpy as np
 
 from manim import PI, Axes, NumberLine
 
@@ -24,7 +25,7 @@ def test_elongated_ticks_float_equality():
         include_ticks=True,
     )
 
-    tick_heights = set(tick.height for tick in nline.ticks)
+    tick_heights = {tick.height for tick in nline.ticks}
     default_tick_height, elongated_tick_height = min(tick_heights), max(tick_heights)
 
     assert all(

--- a/tests/module/mobject/graphing/test_ticks.py
+++ b/tests/module/mobject/graphing/test_ticks.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import math
-
 import numpy as np
 
 from manim import PI, Axes, NumberLine


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

Resolves #3394 by using `np.isclose` to check for float equality instead of using default float equality, which sometimes is not one might expect (see `0.1 + 0.2 != 0.3` for example).

<!--changelog-end-->


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
