### PR TITLE
CI: fix caching of cairo

### DIFF
--- a/.github/scripts/ci_build_cairo.py
+++ b/.github/scripts/ci_build_cairo.py
@@ -26,7 +26,7 @@ CAIRO_SHA256_URL = f"{CAIRO_URL}.sha256sum"
 
 VENV_NAME = "meson-venv"
 BUILD_DIR = "build"
-INSTALL_PREFIX = Path(__file__).parent.parent / "third_party" / "cairo"
+INSTALL_PREFIX = Path(__file__).parent.parent.parent / "third_party" / "cairo"
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
I forgot to change the path after moving around the file in https://github.com/ManimCommunity/manim/pull/3416. This made the cache not work and cairo was built each time CI was run.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
