### PR TITLE
Fix CSV reader adding empty lists in rendering summary

### DIFF
--- a/manim/utils/docbuild/manim_directive.py
+++ b/manim/utils/docbuild/manim_directive.py
@@ -342,7 +342,7 @@ def _log_rendering_times(*args):
             sys.exit()
 
         print("\nRendering Summary\n-----------------\n")
-        
+
         # filter out empty lists caused by csv reader
         data = [row for row in data if row]
 

--- a/manim/utils/docbuild/manim_directive.py
+++ b/manim/utils/docbuild/manim_directive.py
@@ -342,6 +342,9 @@ def _log_rendering_times(*args):
             sys.exit()
 
         print("\nRendering Summary\n-----------------\n")
+        
+        # filter out empty lists caused by csv reader
+        data = [row for row in data if row]
 
         max_file_length = max(len(row[0]) for row in data)
         for key, group in it.groupby(data, key=lambda row: row[0]):


### PR DESCRIPTION
Fixes issue #3311

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Resolves #3311 as was suggested [here](https://github.com/ManimCommunity/manim/issues/3311#issuecomment-1676051987)

What ended up happening was in the line ``list(csv.reader(file))`` the file contained (for whatever reason) two newline characters instead of the expected one. This caused the csv reader to create a new list for it, thus generating the empty list in the issue.



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
