### PR TITLE
Fixing labels on the number line for small unit sizes to be not squashed

### DIFF
--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -224,7 +224,12 @@ class NumberLine(Line):
             self.unit_size = self.get_unit_size()
         else:
             self.scale(self.unit_size)
-
+        if self.unit_size < 0.1:
+            self.font_size = 9
+        elif self.unit_size < 0.15:
+            self.font_size = 15
+        elif self.unit_size < 0.3:
+            self.font_size = 18
         self.center()
 
         if self.include_tip:


### PR DESCRIPTION
## Overview: What does this pull request change?
This PR changes the default initialization of the font size of the axes labels to be smaller if the distance between tick marks is too small.

## Motivation and Explanation: Why and how do your changes improve the library?
This change improves the library because it means that people can read the labels on the number line when the distance between tick marks is small, instead of the labels overlapping.
Originally, the labels looked like this for small unit sizes:
![image](https://github.com/ManimCommunity/manim/assets/141789878/edfb6276-da62-4bb3-8a79-a859bfa446d6)

With this change, the default is this:
![image](https://github.com/ManimCommunity/manim/assets/141789878/54cc767d-26c9-4cd6-9fb5-64ab83a51462)

## Further Information and Comments
I could try and create a function to determine the ideal font size to make the labels based on the unit size.
I wonder also if there is a way to reduce the size of the negative signs?
The resolution of the labels does seem to decrease with decreasing size. Could this be fixed somehow?
The default size of the arrows on the ends of the number line does not change depending on the size of the number line. Maybe I could change this too?
See issue #3382 for my comment on the labels being squashed for small unit sizes.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
