### PR TITLE
Fix squashed axes labels

### DIFF
--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -224,7 +224,12 @@ class NumberLine(Line):
             self.unit_size = self.get_unit_size()
         else:
             self.scale(self.unit_size)
-
+        if self.unit_size < 0.1:
+            self.font_size = 9
+        elif self.unit_size < 0.15:
+            self.font_size = 15
+        elif self.unit_size < 0.3:
+            self.font_size = 18
         self.center()
 
         if self.include_tip:

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -224,12 +224,13 @@ class NumberLine(Line):
             self.unit_size = self.get_unit_size()
         else:
             self.scale(self.unit_size)
-        if self.unit_size < 0.1:
-            self.font_size = 9
-        elif self.unit_size < 0.15:
-            self.font_size = 15
-        elif self.unit_size < 0.3:
-            self.font_size = 18
+        if not self.font_size:
+            if self.unit_size < 0.1:
+                self.font_size = 9
+            elif self.unit_size < 0.15:
+                self.font_size = 15
+            elif self.unit_size < 0.3:
+                self.font_size = 18
         self.center()
 
         if self.include_tip:


### PR DESCRIPTION
## Overview: What does this pull request change?
This pull request changes the default initialization of the font size of the x-axis labels to be smaller if the distance between tick marks is too small.

## Motivation and Explanation: Why and how do your changes improve the library?
This change improves the library because it means that people can read the labels on the number line when the distance between tick marks is small, instead of the labels overlapping.

## Further Information and Comments
Originally, the labels defaulted to this for a small unit size:
![image](https://github.com/ManimCommunity/manim/assets/141789878/6e357029-bdae-496a-b4f8-4b736de0d686)

With the change, the default is this:
![image](https://github.com/ManimCommunity/manim/assets/141789878/dd377209-600a-40dd-a17a-a028ddf139a1)

The resolution of the labels seems to decrease with decreasing font size. Could this be fixed somehow?
See issue #3382 for my comment on the labels being squashed for small unit sizes.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
