### PR TITLE
Update Docker base image to python3.12-slim (#3458)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 
 RUN apt-get update -qq \
     && apt-get install --no-install-recommends -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.12-slim
 
 RUN apt-get update -qq \
     && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
## Overview: What does this pull request change?
Simply updating the Docker base image from python 3.8 -> 3.12.

This lets users of the Docker distribution of `manim` take advantage of lots of new Python features (especially type hints).

This should not cause any breaking changes AFAIK.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
