### PR TITLE
Fix Indicate docstring typo

### DIFF
--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -131,7 +131,7 @@ class Indicate(Transform):
     color
         The color the mobject temporally takes.
     rate_func
-        The function definig the animation progress at every point in time.
+        The function defining the animation progress at every point in time.
     kwargs
         Additional arguments to be passed to the :class:`~.Succession` constructor
 


### PR DESCRIPTION
Fixed a small typo for the Indicate animation.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
