### PR TITLE
Allow 3DArrows to utilize GrowArrow()

### DIFF
--- a/manim/animation/growing.py
+++ b/manim/animation/growing.py
@@ -37,6 +37,7 @@ import numpy as np
 
 from ..animation.transform import Transform
 from ..constants import PI
+from ..mobject.three_d.three_dimensions import Arrow3D
 from ..utils.paths import spiral_path
 
 if typing.TYPE_CHECKING:
@@ -189,7 +190,10 @@ class GrowArrow(GrowFromPoint):
 
     def create_starting_mobject(self) -> Mobject:
         start_arrow = self.mobject.copy()
-        start_arrow.scale(0, scale_tips=False, about_point=self.point)
+        if isinstance(start_arrow, Arrow3D):
+            start_arrow.scale(0, scale_tips=False, about_point=self.point)
+        else:
+            start_arrow.scale(0, scale_tips=True, about_point=self.point)
         if self.point_color:
             start_arrow.set_color(self.point_color)
         return start_arrow

--- a/manim/animation/growing.py
+++ b/manim/animation/growing.py
@@ -189,7 +189,7 @@ class GrowArrow(GrowFromPoint):
 
     def create_starting_mobject(self) -> Mobject:
         start_arrow = self.mobject.copy()
-        start_arrow.scale(0, scale_tips=True, about_point=self.point)
+        start_arrow.scale(0, scale_tips=False, about_point=self.point)
         if self.point_color:
             start_arrow.set_color(self.point_color)
         return start_arrow

--- a/manim/mobject/three_d/three_dimensions.py
+++ b/manim/mobject/three_d/three_dimensions.py
@@ -1167,7 +1167,7 @@ class Arrow3D(Line3D):
         self.max_thickness_to_length_ratio = max_thickness_to_length_ratio
 
     def position_tip(self, tip: Cone):
-        tip.shift(self.end)
+        tip.shift(-1 * self.end)
 
     def add_tip(self, tip: Cone) -> Self:
         self.position_tip(tip)
@@ -1175,7 +1175,7 @@ class Arrow3D(Line3D):
         return self
 
     def pop_tip(self) -> VGroup:
-        result = result = self.get_group_class()()
+        result = self.get_group_class()()
         result.add(self.cone)
         self.remove(self.cone)
         return result

--- a/manim/mobject/three_d/three_dimensions.py
+++ b/manim/mobject/three_d/three_dimensions.py
@@ -1163,6 +1163,28 @@ class Arrow3D(Line3D):
         self.add(self.cone)
         self.set_color(color)
 
+    def scale(self, factor: float, scale_tips: bool = False, **kwargs) -> Self:
+        if self.get_length() == 0:
+            return self
+
+        if scale_tips:
+            super().scale(factor, **kwargs)
+            return self
+
+        has_tip = self.has_tip()
+        has_start_tip = self.has_start_tip()
+        if has_tip or has_start_tip:
+            old_tips = self.pop_tips()
+
+        super().scale(factor, **kwargs)
+        self._set_stroke_width_from_length()
+
+        if has_tip:
+            self.add_tip(tip=old_tips[0])
+        if has_start_tip:
+            self.add_tip(tip=old_tips[1], at_start=True)
+        return self
+
 
 class Torus(Surface):
     """A torus.


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Adds a `scale` function to the Arrow3D Class in three_dimensions to prevent it from falling back to the default implemented in `mobject` which lacks implementation for handling the scaling of the conical tip of the arrow. Similar to the 2D version, it handles scaling the arrow.
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
Resolves: #3481 
Allows `self.play(GrowArrow(Arrow3D(LEFT, RIGHT)))` 
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
