### PR TITLE
feat(lib): add basic VideoMobject class

### DIFF
--- a/docs/source/reference_index/animations.rst
+++ b/docs/source/reference_index/animations.rst
@@ -21,3 +21,4 @@ Animations
    ~animation.transform
    ~animation.transform_matching_parts
    ~animation.updaters
+   ~animation.video

--- a/manim/__init__.py
+++ b/manim/__init__.py
@@ -37,6 +37,7 @@ from .animation.transform import *
 from .animation.transform_matching_parts import *
 from .animation.updaters.mobject_update_utils import *
 from .animation.updaters.update import *
+from .animation.video import *
 from .camera.camera import *
 from .camera.mapping_camera import *
 from .camera.moving_camera import *
@@ -75,6 +76,7 @@ from .mobject.three_d.three_dimensions import *
 from .mobject.types.image_mobject import *
 from .mobject.types.point_cloud_mobject import *
 from .mobject.types.vectorized_mobject import *
+from .mobject.types.video_mobject import *
 from .mobject.value_tracker import *
 from .mobject.vector_field import *
 from .renderer.cairo_renderer import *

--- a/manim/animation/video.py
+++ b/manim/animation/video.py
@@ -1,0 +1,28 @@
+from .animation import Animation
+
+
+class Video(Animation):
+    """
+    Animate a VideoMobject by playing its different frames, in order.
+
+    The actual number of frames played will depend on the interpolation
+    resolution, i.e., the frames per seconds and the animation runtime.
+
+    If the interpolation resolution is too small, some frames may be skipped.
+    """
+
+    def __init__(self, video_mobject, **kwargs):
+        self.video_mobject = video_mobject
+        self.index = 0
+        self.n_frames = len(self.video_mobject)
+        self.dt = 1.0 / self.n_frames
+        super().__init__(video_mobject, **kwargs)
+
+    def interpolate_mobject(self, alpha):
+        index = int(alpha / self.dt) % self.n_frames
+
+        if index != self.index:
+            self.video_mobject.pixel_array = self.video_mobject[index].pixel_array
+            self.index = index
+
+        return self

--- a/manim/mobject/types/__init__.py
+++ b/manim/mobject/types/__init__.py
@@ -9,4 +9,5 @@ Modules
     ~image_mobject
     ~point_cloud_mobject
     ~vectorized_mobject
+    ~video_mobject
 """

--- a/manim/mobject/types/video_mobject.py
+++ b/manim/mobject/types/video_mobject.py
@@ -1,0 +1,55 @@
+"""Mobjects representing animated raster images."""
+
+__all__ = ["VideoMobject"]
+
+from .image_mobject import ImageMobject
+from ...animation.video import Video
+
+
+class VideoMobject(ImageMobject):
+    """Displays a video as a series of images
+    from a numpy array or a file.
+
+    Parameters
+    ----------
+    filenames_or_arrays
+        A sequence of numpy arrays or file names from which each image is loaded.
+
+
+    Example
+    -------
+    .. manim:: RandomNoiseVideo
+
+        class RandomNoiseVideo(Scene):
+            def construct(self):
+                size = (1000, 1000, 3)
+                images = [(255 * np.random.rand(*size)).astype("uint8") for _ in range(100)]
+                video = VideoMobject(images)
+        
+                self.play(GrowFromCenter(video))
+                self.play(video.play(run_time=6.0))
+                self.play(FadeOut(video))
+    """
+
+    def __init__(
+        self,
+        filenames_or_arrays,
+        **kwargs,
+    ):
+        assert len(filenames_or_arrays) > 0, "Cannot create an empty video"
+        self.filenames_or_arrays = filenames_or_arrays
+        self._kwargs = kwargs
+        super().__init__(self.filenames_or_arrays[0], **kwargs)
+
+    def __len__(self):
+        return len(self.filenames_or_arrays)
+
+    def __getitem__(self, index):
+        return ImageMobject(self.filenames_or_arrays[index], **self._kwargs)
+
+    def play(self, **kwargs):
+        """Create an animation that will play video frames."""
+        return Video(self, **kwargs)
+
+
+


### PR DESCRIPTION
Hello, I actually implemented this for a personal need, but I guess other people could enjoy such feature, as in #760.

The current implementation is very minimalist, and may be improved, or tested / better documented.

If OpenCV is added as a dependency, then we could also directly load videos from video files, which could be a nice feature.
