### PR TITLE
fix 360° to 180° in quickstart tutorial

### DIFF
--- a/docs/i18n/gettext/tutorials/quickstart.pot
+++ b/docs/i18n/gettext/tutorials/quickstart.pot
@@ -202,7 +202,7 @@ msgid "This ``Scene`` illustrates the quirks of ``.animate``. When using ``.anim
 msgstr ""
 
 #: ../../source/tutorials/quickstart.rst:344
-msgid "In ``DifferentRotations``, the difference between ``.animate``'s interpretation of rotation and the ``Rotate`` method is far more apparent. The starting and ending states of a ``Mobject`` rotated 360 degrees are the same, so ``.animate`` tries to interpolate two identical objects and the result is the left square. If you find that your own usage of ``.animate`` is causing similar unwanted behavior, consider using conventional animation methods like the right square, which uses ``Rotate``."
+msgid "In ``DifferentRotations``, the difference between ``.animate``'s interpretation of rotation and the ``Rotate`` method is far more apparent. The starting and ending states of a ``Mobject`` rotated 180 degrees are the same, so ``.animate`` tries to interpolate two identical objects and the result is the left square. If you find that your own usage of ``.animate`` is causing similar unwanted behavior, consider using conventional animation methods like the right square, which uses ``Rotate``."
 msgstr ""
 
 #: ../../source/tutorials/quickstart.rst:353

--- a/docs/source/tutorials/quickstart.rst
+++ b/docs/source/tutorials/quickstart.rst
@@ -342,7 +342,7 @@ the corners of the square appear to contract slightly as they move into the posi
 for the first square to transform into the second one.
 
 In ``DifferentRotations``, the difference between ``.animate``'s interpretation of rotation and the
-``Rotate`` method is far more apparent. The starting and ending states of a ``Mobject`` rotated 360 degrees
+``Rotate`` method is far more apparent. The starting and ending states of a ``Mobject`` rotated 180 degrees
 are the same, so ``.animate`` tries to interpolate two identical objects and the result is the left square.
 If you find that your own usage of ``.animate`` is causing similar unwanted behavior, consider
 using conventional animation methods like the right square, which uses ``Rotate``.


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Refer to [Issue 2080](https://github.com/3b1b/manim/issues/2080), fixed wrong degree 360 to 180 in quickstart tutorial of comparing `.animate` and `AnimatedSquareToCircle`


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
