### PR TITLE
Deferred Animation builder to only modify mobjects after the animation is actually played

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2926,7 +2926,9 @@ class _AnimationBuilder:
             )
 
         def update_target(*method_args, **method_kwargs):
-            self.methods.append([method_name, method_args, method_kwargs, has_overridden_animation])
+            self.methods.append(
+                [method_name, method_args, method_kwargs, has_overridden_animation]
+            )
             return self
 
         self.is_chaining = True
@@ -2938,9 +2940,15 @@ class _AnimationBuilder:
         from ..animation.transform import (  # is this to prevent circular import?
             _MethodAnimation,
         )
+
         self.mobject.generate_target()
         new_methods = []
-        for method_name, method_args, method_kwargs, has_overridden_animation in self.methods:
+        for (
+            method_name,
+            method_args,
+            method_kwargs,
+            has_overridden_animation,
+        ) in self.methods:
             method = getattr(self.mobject.target, method_name)
             if has_overridden_animation:
                 self.overridden_animation = method._override_animate(


### PR DESCRIPTION
Passing a flag to `.animate` was a bit too complicated and would destroy the property aspect of it, now we can also use `deferred` as a property.

I split the `_AnimationBuilder` into two subclasses which fulfill their respective roles, whereas `_ImmediateAnimationBuilder` is the usual builder that we know and love and `_DeferredAnimationBuilder` is the new builder which actually is delaying the building of the state until the animation is played. I added an example to the documentation, I am not sure if I should add tests for that or what would be a useful test.

But first i would like to discuss the concept, i linked a documentation page for this.

https://manimce--3502.org.readthedocs.build/en/3502/reference/manim.mobject.mobject.Mobject.html?highlight=deferred#deferredexample

```py
class MinimalExample(Scene):
    def construct(self):
        objects = []
        animations = []
        animations2 = []

        for i in range(10):
            m = Square().set_color(BLUE).set_fill(opacity=0.3).scale(0.5)
            objects.append(m)
            animations.append(ReplacementTransform(m.copy(),m))
            if i % 2 == 0:
                animations2.append(m.animate.set_color(GREEN))
            else:
                animations2.append(FadeOut(m))

        group = VGroup(*objects).arrange_in_grid()
        self.play(*animations, run_time=2)
        self.wait()
        self.play(*animations2, run_time=2)
        self.wait()
        
```


vs.


```py
class Expected(Scene):
    def construct(self):
        objects = []
        animations = []
        animations2 = []
        l1 = []
        l2 = []

        for i in range(10):
            m = Square().set_color(BLUE).set_fill(opacity=0.3).scale(0.5)
            objects.append(m)
            animations.append(ReplacementTransform(m.copy(),m))
            if i % 2 == 0:
                l1.append(m)
            else:
                l2.append(m)

        group = VGroup(*objects).arrange_in_grid()
        self.play(*animations, run_time=2)
        self.wait()
        self.play(*[x.animate.set_color(GREEN) for x in l1],*[FadeOut(x) for x in l2], run_time=2)
        self.wait()```