### PR TITLE
Fix rectangle grid properties (#3082)

### DIFF
--- a/manim/mobject/geometry/polygram.py
+++ b/manim/mobject/geometry/polygram.py
@@ -625,6 +625,7 @@ class Rectangle(Polygon):
 
         if grid_xstep or grid_ystep:
             from manim.mobject.geometry.line import Line
+
             v = self.get_vertices()
 
         if grid_xstep:
@@ -641,7 +642,7 @@ class Rectangle(Polygon):
                 )
             )
             self.grid_lines.add(grid)
-            
+
         if grid_ystep:
             grid_ystep = abs(grid_ystep)
             count = int(height / grid_ystep)

--- a/manim/mobject/geometry/polygram.py
+++ b/manim/mobject/geometry/polygram.py
@@ -617,10 +617,13 @@ class Rectangle(Polygon):
         super().__init__(UR, UL, DL, DR, color=color, **kwargs)
         self.stretch_to_fit_width(width)
         self.stretch_to_fit_height(height)
-        v = self.get_vertices()
-        if grid_xstep is not None:
+
+        if grid_xstep or grid_ystep:
             from manim.mobject.geometry.line import Line
 
+            v = self.get_vertices()
+
+        if grid_xstep:
             grid_xstep = abs(grid_xstep)
             count = int(width / grid_xstep)
             grid = VGroup(
@@ -634,7 +637,8 @@ class Rectangle(Polygon):
                 )
             )
             self.add(grid)
-        if grid_ystep is not None:
+
+        if grid_ystep:
             grid_ystep = abs(grid_ystep)
             count = int(height / grid_ystep)
             grid = VGroup(


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
* There is no longer an error of imports when trying to create a `Rectangle` with a `y` grid only.


## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Resolve #3082 

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
Changed the conditionals from e.g. `if grid_xstep is not None` to `if grid_xstep` so `grid_xstep=0.0` does not cause a `ZeroDivisionError`


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
