### PR TITLE
Removed SciPy imports in Manim, making it an indirect dependency

### DIFF
--- a/manim/camera/camera.py
+++ b/manim/camera/camera.py
@@ -15,7 +15,6 @@ from typing import Any, Callable, Iterable
 import cairo
 import numpy as np
 from PIL import Image
-from scipy.spatial.distance import pdist
 
 from .. import config, logger
 from ..constants import *
@@ -973,8 +972,8 @@ class Camera:
         sub_image = Image.fromarray(image_mobject.get_pixel_array(), mode="RGBA")
 
         # Reshape
-        pixel_width = max(int(pdist([ul_coords, ur_coords]).item()), 1)
-        pixel_height = max(int(pdist([ul_coords, dl_coords]).item()), 1)
+        pixel_width = max(1, int(np.linalg.norm(right_vect)))
+        pixel_height = max(1, int(np.linalg.norm(down_vect)))
         sub_image = sub_image.resize(
             (pixel_width, pixel_height),
             resample=image_mobject.resampling_algorithm,


### PR DESCRIPTION
## Overview: What does this pull request change?
I removed all the SciPy imports in Manim, using NumPy functions instead. Thus, Scipy would become just an indirect dependency of NetworkX, used in `Graph` (and by extension `Polyhedron`) for generating the graph layouts which require Scipy.

## Motivation and Explanation: Why and how do your changes improve the library?
### `manim.camera.camera`
`scipy.spatial.distance.pdist`, a function to generate a matrix of pairwise distances between two arrays of points, was imported to calculate... the distance between a **single pair** of points (and then `ndarray.item()` was used to extract the only element in the generated 1x1 matrix as a float). In this scenario, `pdist` is unnecessary and we can just use `np.linalg.norm` on the distance vector between the two requested points... vector which already existed beforehand (`right_vect` and `down_vect`).

### `manim.utils.bezier`
`scipy.linalg.solve_banded` was used in `get_smooth_handle_points` for solving a system of equations to find the required handles for a smooth cubic spline. In PR #3281 I already rewrote that function in a way which doesn't use SciPy, so I just copy-pasted that solution.

### `manim.utils.simple_functions`
The `choose` function called `scipy.special.choose` to calculate combinatorial coefficients. The only place where `choose` was used was in `manim.utils.bezier`, where all the `choose(n, k)` coefficients were requested for all k in [0, n], or sometimes even for all n in [0, num_points], wasting too many intermediate calculations. Therefore, I replaced it with a custom `get_pascal_triangle` function which calculates in a single pass a memo for the entire Pascal triangle with the coefficients up to `choose(n, n)`. Then, I made some slight modifications to the `manim.utils.bezier` functions which used `choose`.

### `manim.utils.space_ops`
`scipy.spatial.transform.Rotation.from_rotvec` was used to calculate a rotation matrix. I replaced it with a custom implementation, explaining all the process in the docstring.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
