### PR TITLE
Fixed :attr:`.Mobject.animate` type-hint to allow LSP autocomplete

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -238,7 +238,7 @@ class Mobject:
             cls.__init__ = cls._original__init__
 
     @property
-    def animate(self) -> _AnimationBuilder | T:
+    def animate(self: T) -> _AnimationBuilder | T:
         """Used to animate the application of any method of :code:`self`.
 
         Any method called on :code:`animate` is converted to an animation of applying


### PR DESCRIPTION
Pretty self-explanatory. The function definition was missing a `self: T` which meant that LSP's weren't working.

Before:
![image](https://github.com/ManimCommunity/manim/assets/110117391/9caed8ad-e43f-465e-aeb3-8d92118f348c)

After:
![image](https://github.com/ManimCommunity/manim/assets/110117391/bf6a5d99-0d85-4af7-b16b-0c9e3d8aa43f)

