### PR TITLE
fix write_subcaption_file error when using opengl renderer

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -725,7 +725,7 @@ class SceneFileWriter:
 
     def write_subcaption_file(self):
         """Writes the subcaption file."""
-        if not config["output_file"]:
+        if config.output_file is None:
             return
         subcaption_file = Path(config.output_file).with_suffix(".srt")
         subcaption_file.write_text(srt.compose(self.subcaptions), encoding="utf-8")

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -725,6 +725,8 @@ class SceneFileWriter:
 
     def write_subcaption_file(self):
         """Writes the subcaption file."""
+        if not config["output_file"]:
+            return
         subcaption_file = Path(config.output_file).with_suffix(".srt")
         subcaption_file.write_text(srt.compose(self.subcaptions), encoding="utf-8")
         logger.info(f"Subcaption file has been written as {subcaption_file}")


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
When config.renderer is `opengl` and subcaptions is not None, the `write_subcaption_file` function will throw
"TypeError: expected str, bytes or os.PathLike object, not NoneType"

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
