### PR TITLE
Fix use of `Mobject`'s deprecated `get_*()` and `set_*()` methods in Cairo tests

### DIFF
--- a/manim/animation/specialized.py
+++ b/manim/animation/specialized.py
@@ -84,7 +84,7 @@ class Broadcast(LaggedStart):
 
             mob.move_to(self.focal_point)
             mob.save_state()
-            mob.set_width(self.initial_width)
+            mob.set(width=self.initial_width)
 
             if fill_o:
                 mob.set_opacity(self.initial_opacity)

--- a/manim/animation/transform_matching_parts.py
+++ b/manim/animation/transform_matching_parts.py
@@ -225,7 +225,7 @@ class TransformMatchingShapes(TransformMatchingAbstractBase):
     def get_mobject_key(mobject: Mobject) -> int:
         mobject.save_state()
         mobject.center()
-        mobject.set_height(1)
+        mobject.set(height=1)
         result = hash(np.round(mobject.points, 3).tobytes())
         mobject.restore()
         return result

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -475,7 +475,7 @@ class NumberLine(Line):
         num_mob.next_to(self.number_to_point(x), direction=direction, buff=buff)
         if x < 0 and self.label_direction[0] == 0:
             # Align without the minus sign
-            num_mob.shift(num_mob[0].get_width() * LEFT / 2)
+            num_mob.shift(num_mob[0].width * LEFT / 2)
         return num_mob
 
     def get_number_mobjects(self, *numbers, **kwargs) -> VGroup:

--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -441,9 +441,9 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
         if self.should_center:
             self.center()
         if self.svg_height is not None:
-            self.set_height(self.svg_height)
+            self.set(height=self.svg_height)
         if self.svg_width is not None:
-            self.set_width(self.svg_width)
+            self.set(width=self.svg_width)
 
 
 class VMobjectFromSVGPath(VMobject, metaclass=ConvertToOpenGL):

--- a/manim/mobject/text/text_mobject.py
+++ b/manim/mobject/text/text_mobject.py
@@ -352,7 +352,7 @@ class Text(SVGMobject):
                )
                 text6.scale(1.3).shift(DOWN)
                 self.add(text1, text2, text3, text4, text5 , text6)
-                Group(*self.mobjects).arrange(DOWN, buff=.8).set_height(config.frame_height-LARGE_BUFF)
+                Group(*self.mobjects).arrange(DOWN, buff=.8).set(height=config.frame_height-LARGE_BUFF)
 
     .. manim:: TextMoreCustomization
             :save_last_frame:

--- a/manim/mobject/value_tracker.py
+++ b/manim/mobject/value_tracker.py
@@ -71,7 +71,7 @@ class ValueTracker(Mobject, metaclass=ConvertToOpenGL):
 
     def __init__(self, value=0, **kwargs):
         super().__init__(**kwargs)
-        self.set_points(np.zeros((1, 3)))
+        self.set(points=np.zeros((1, 3)))
         self.set_value(value)
 
     def get_value(self) -> float:
@@ -132,7 +132,7 @@ class ValueTracker(Mobject, metaclass=ConvertToOpenGL):
         Turns self into an interpolation between mobject1
         and mobject2.
         """
-        self.set_points(path_func(mobject1.points, mobject2.points, alpha))
+        self.set(points=path_func(mobject1.points, mobject2.points, alpha))
         return self
 
 


### PR DESCRIPTION
Fix deprecation warnings for setters and getters. Most were from `Mobject.set_*`, and I changed them to `Mobject.set(xyz=`. For `Mobject.get_*`, I changed them to `Mobject.xyz`.

Related: #3524 