### PR TITLE
Allow :meth:`.VGroup.add` to use iterables of VMobjects

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -36,10 +36,9 @@ from ..utils.color import (
 )
 from ..utils.exceptions import MultiAnimationOverrideException
 from ..utils.iterables import list_update, remove_list_redundancies
+from ..utils.parameter_parsing import flatten_iterable_parameters
 from ..utils.paths import straight_path
 from ..utils.space_ops import angle_between_vectors, normalize, rotation_matrix
-from ..utils.parameter_parsing import flatten_iterable_parameters
-
 
 # TODO: Explain array_attrs
 
@@ -49,6 +48,8 @@ Updater: TypeAlias = Union[NonTimeBasedUpdater, TimeBasedUpdater]
 T = TypeVar("T", bound="Mobject")
 
 if TYPE_CHECKING:
+    from types import GeneratorType
+
     from manim.typing import (
         FunctionOverride,
         Image,
@@ -61,7 +62,7 @@ if TYPE_CHECKING:
         Vector,
         Vector3,
     )
-    from types import GeneratorType
+
     from ..animation.animation import Animation
 
 
@@ -367,7 +368,9 @@ class Mobject:
         subclasses.
         """
 
-    def add(self, *mobjects: Mobject | Iterable[Mobject] | GeneratorType[Mobject]) -> Self:
+    def add(
+        self, *mobjects: Mobject | Iterable[Mobject] | GeneratorType[Mobject]
+    ) -> Self:
         """Add mobjects as submobjects.
 
         The mobjects are added to :attr:`submobjects`.

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -38,6 +38,8 @@ from ..utils.exceptions import MultiAnimationOverrideException
 from ..utils.iterables import list_update, remove_list_redundancies
 from ..utils.paths import straight_path
 from ..utils.space_ops import angle_between_vectors, normalize, rotation_matrix
+from ..utils.parameter_parsing import flatten_iterable_parameters
+
 
 # TODO: Explain array_attrs
 
@@ -59,7 +61,7 @@ if TYPE_CHECKING:
         Vector,
         Vector3,
     )
-
+    from types import GeneratorType
     from ..animation.animation import Animation
 
 
@@ -365,7 +367,7 @@ class Mobject:
         subclasses.
         """
 
-    def add(self, *mobjects: Mobject) -> Self:
+    def add(self, *mobjects: Mobject | Iterable[Mobject] | GeneratorType[Mobject]) -> Self:
         """Add mobjects as submobjects.
 
         The mobjects are added to :attr:`submobjects`.
@@ -435,6 +437,7 @@ class Mobject:
             [child]
 
         """
+        mobjects = flatten_iterable_parameters(mobjects)
         for m in mobjects:
             if not isinstance(m, Mobject):
                 raise TypeError("All submobjects must be of type Mobject")

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -36,7 +36,6 @@ from ..utils.color import (
 )
 from ..utils.exceptions import MultiAnimationOverrideException
 from ..utils.iterables import list_update, remove_list_redundancies
-from ..utils.parameter_parsing import flatten_iterable_parameters
 from ..utils.paths import straight_path
 from ..utils.space_ops import angle_between_vectors, normalize, rotation_matrix
 
@@ -48,8 +47,6 @@ Updater: TypeAlias = Union[NonTimeBasedUpdater, TimeBasedUpdater]
 T = TypeVar("T", bound="Mobject")
 
 if TYPE_CHECKING:
-    from types import GeneratorType
-
     from manim.typing import (
         FunctionOverride,
         Image,
@@ -59,7 +56,6 @@ if TYPE_CHECKING:
         PathFuncType,
         Point3D,
         Point3D_Array,
-        Vector,
         Vector3,
     )
 
@@ -440,7 +436,6 @@ class Mobject:
             [child]
 
         """
-        mobjects = flatten_iterable_parameters(mobjects)
         for m in mobjects:
             if not isinstance(m, Mobject):
                 raise TypeError("All submobjects must be of type Mobject")

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -49,10 +49,12 @@ from ...utils.bezier import (
 )
 from ...utils.color import BLACK, WHITE, ManimColor, ParsableManimColor
 from ...utils.iterables import make_even, resize_array, stretch_array_to_length, tuplify
-from ...utils.space_ops import rotate_vector, shoelace_direction
 from ...utils.parameter_parsing import flatten_iterable_parameters
+from ...utils.space_ops import rotate_vector, shoelace_direction
 
 if TYPE_CHECKING:
+    from types import GeneratorType
+
     from manim.typing import (
         BezierPoints,
         CubicBezierPoints,
@@ -66,7 +68,6 @@ if TYPE_CHECKING:
         Vector3,
         Zeros,
     )
-    from types import GeneratorType
 
 # TODO
 # - Change cubic curve groups to have 4 points instead of 3
@@ -1937,7 +1938,7 @@ class VGroup(VMobject, metaclass=ConvertToOpenGL):
     def __init__(
         self,
         *vmobjects: VMobject | Iterable[VMobject] | GeneratorType[VMobject],
-        **kwargs
+        **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.add(*vmobjects)

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -2002,8 +2002,7 @@ class VGroup(VMobject, metaclass=ConvertToOpenGL):
         """
         vmobject_classes = (VMobject, OpenGLVMobject)
         vmobjects = flatten_iterable_parameters_excluding_cls(
-            vmobjects,
-            vmobject_classes
+            vmobjects, vmobject_classes
         )
         if not all(isinstance(x, vmobject_classes) for x in vmobjects):
             raise TypeError("All submobjects must be of type VMobject")

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -50,6 +50,7 @@ from ...utils.bezier import (
 from ...utils.color import BLACK, WHITE, ManimColor, ParsableManimColor
 from ...utils.iterables import make_even, resize_array, stretch_array_to_length, tuplify
 from ...utils.space_ops import rotate_vector, shoelace_direction
+from ...utils.parameter_parsing import flatten_iterable_parameters
 
 if TYPE_CHECKING:
     from manim.typing import (
@@ -1998,6 +1999,7 @@ class VGroup(VMobject, metaclass=ConvertToOpenGL):
                         (gr-circle_red).animate.shift(RIGHT)
                     )
         """
+        vmobjects = flatten_iterable_parameters(vmobjects)
         if not all(isinstance(m, (VMobject, OpenGLVMobject)) for m in vmobjects):
             raise TypeError("All submobjects must be of type VMobject")
         return super().add(*vmobjects)

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -49,7 +49,7 @@ from ...utils.bezier import (
 )
 from ...utils.color import BLACK, WHITE, ManimColor, ParsableManimColor
 from ...utils.iterables import make_even, resize_array, stretch_array_to_length, tuplify
-from ...utils.parameter_parsing import flatten_iterable_parameters
+from ...utils.parameter_parsing import flatten_iterable_parameters_excluding_cls
 from ...utils.space_ops import rotate_vector, shoelace_direction
 
 if TYPE_CHECKING:
@@ -2000,8 +2000,12 @@ class VGroup(VMobject, metaclass=ConvertToOpenGL):
                         (gr-circle_red).animate.shift(RIGHT)
                     )
         """
-        vmobjects = flatten_iterable_parameters(vmobjects)
-        if not all(isinstance(m, (VMobject, OpenGLVMobject)) for m in vmobjects):
+        vmobject_classes = (VMobject, OpenGLVMobject)
+        vmobjects = flatten_iterable_parameters_excluding_cls(
+            vmobjects,
+            vmobject_classes
+        )
+        if not all(isinstance(x, vmobject_classes) for x in vmobjects):
             raise TypeError("All submobjects must be of type VMobject")
         return super().add(*vmobjects)
 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -31,8 +31,8 @@ from PIL.Image import Image
 from typing_extensions import Self
 
 from manim.mobject.opengl.opengl_compatibility import ConvertToOpenGL
-from manim.mobject.opengl.opengl_vectorized_mobject import OpenGLVMobject
 from manim.mobject.opengl.opengl_mobject import OpenGLMobject
+from manim.mobject.opengl.opengl_vectorized_mobject import OpenGLVMobject
 from manim.mobject.three_d.three_d_utils import (
     get_3d_vmob_gradient_start_and_end_points,
 )
@@ -2006,7 +2006,7 @@ class VGroup(VMobject, metaclass=ConvertToOpenGL):
             vmobjects,
             vmobject_classes,
             bad_classes=(Mobject, OpenGLMobject),
-            error_message="All submobjects must be of type VMobject, got %(arg)s instead."
+            error_message="All submobjects must be of type VMobject, got %(arg)s instead.",
         )
         return super().add(*vmobjects)
 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -32,6 +32,7 @@ from typing_extensions import Self
 
 from manim.mobject.opengl.opengl_compatibility import ConvertToOpenGL
 from manim.mobject.opengl.opengl_vectorized_mobject import OpenGLVMobject
+from manim.mobject.opengl.opengl_mobject import OpenGLMobject
 from manim.mobject.three_d.three_d_utils import (
     get_3d_vmob_gradient_start_and_end_points,
 )
@@ -2002,10 +2003,11 @@ class VGroup(VMobject, metaclass=ConvertToOpenGL):
         """
         vmobject_classes = (VMobject, OpenGLVMobject)
         vmobjects = flatten_iterable_parameters_excluding_cls(
-            vmobjects, vmobject_classes
+            vmobjects,
+            vmobject_classes,
+            bad_classes=(Mobject, OpenGLMobject),
+            error_message="All submobjects must be of type VMobject, got %(arg)s instead."
         )
-        if not all(isinstance(x, vmobject_classes) for x in vmobjects):
-            raise TypeError("All submobjects must be of type VMobject")
         return super().add(*vmobjects)
 
     def __add__(self, vmobject: VMobject) -> Self:

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
         Vector3,
         Zeros,
     )
+    from types import GeneratorType
 
 # TODO
 # - Change cubic curve groups to have 4 points instead of 3
@@ -1932,7 +1933,11 @@ class VGroup(VMobject, metaclass=ConvertToOpenGL):
 
     """
 
-    def __init__(self, *vmobjects, **kwargs):
+    def __init__(
+        self,
+        *vmobjects: VMobject | Iterable[VMobject] | GeneratorType[VMobject],
+        **kwargs
+    ) -> None:
         super().__init__(**kwargs)
         self.add(*vmobjects)
 

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -30,6 +30,7 @@ def flatten_iterable_parameters(
             flattened_parameters.append(arg)
     return flattened_parameters
 
+
 def flatten_iterable_parameters_excluding_cls(
     args: Iterable[T | Iterable[T] | GeneratorType],
     classes: Iterable[type],
@@ -57,4 +58,3 @@ def flatten_iterable_parameters_excluding_cls(
         else:
             flattened.append(arg)
     return flattened
-

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -29,3 +29,32 @@ def flatten_iterable_parameters(
         else:
             flattened_parameters.append(arg)
     return flattened_parameters
+
+def flatten_iterable_parameters_excluding_cls(
+    args: Iterable[T | Iterable[T] | GeneratorType],
+    classes: Iterable[type],
+) -> list[T]:
+    """Flattens an iterable of parameters into a list of parameters, giving priority to
+    adding certain classes to the flattened list first.
+
+    Parameters
+    ----------
+    args
+        The Iterable of parameters to flatten.
+        [(generator), [], (), ...]
+    classes
+        If ``type(arg) in classes`` the arg will be
+        added to the flattened list without any further
+        processing
+    """
+    flattened = []
+    classes = tuple(classes)
+    for arg in args:
+        if isinstance(arg, classes):
+            flattened.append(arg)
+        elif isinstance(arg, (Iterable, GeneratorType)):
+            flattened.extend(arg)
+        else:
+            flattened.append(arg)
+    return flattened
+

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import GeneratorType
-from typing import Iterable, TypeVar, Any
+from typing import Any, Iterable, TypeVar
 
 T = TypeVar("T")
 
@@ -35,7 +35,7 @@ def flatten_iterable_parameters_excluding_cls(
     args: Iterable[T | Iterable[T] | GeneratorType],
     classes: tuple[type],
     bad_classes: tuple[type[Any]] = (),
-    error_message: str = "Invalid class %(arg)s"
+    error_message: str = "Invalid class %(arg)s",
 ) -> list[T]:
     """Flattens an iterable of parameters into a list of parameters, giving priority to
     adding certain classes to the flattened list first.

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import GeneratorType
-from typing import Iterable, TypeVar
+from typing import Iterable, TypeVar, Any
 
 T = TypeVar("T")
 
@@ -33,7 +33,9 @@ def flatten_iterable_parameters(
 
 def flatten_iterable_parameters_excluding_cls(
     args: Iterable[T | Iterable[T] | GeneratorType],
-    classes: Iterable[type],
+    classes: tuple[type],
+    bad_classes: tuple[type[Any]] = (),
+    error_message: str = "Invalid class %(arg)s"
 ) -> list[T]:
     """Flattens an iterable of parameters into a list of parameters, giving priority to
     adding certain classes to the flattened list first.
@@ -49,11 +51,16 @@ def flatten_iterable_parameters_excluding_cls(
         processing
     """
     flattened = []
-    classes = tuple(classes)
     for arg in args:
         if isinstance(arg, classes):
             flattened.append(arg)
+        elif isinstance(arg, bad_classes):
+            raise TypeError(error_message % {"arg": arg})
         elif isinstance(arg, (Iterable, GeneratorType)):
+            # TODO:
+            # Figure out a way to check if there are any
+            # ``bad_classes`` in arg before extending list
+            # Recursion won't work for large VGroups
             flattened.extend(arg)
         else:
             flattened.append(arg)

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -79,6 +79,11 @@ def test_vgroup_init():
     VGroup()
     VGroup(VMobject())
     VGroup(VMobject(), VMobject())
+    VGroup(
+        VMobject(),
+        [VMobject()]*2,
+        (x for x in [VMobject()])
+    )
     with pytest.raises(TypeError):
         VGroup(Mobject())
     with pytest.raises(TypeError):

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -79,11 +79,7 @@ def test_vgroup_init():
     VGroup()
     VGroup(VMobject())
     VGroup(VMobject(), VMobject())
-    VGroup(
-        VMobject(),
-        [VMobject()]*2,
-        (x for x in [VMobject()])
-    )
+    VGroup(VMobject(), [VMobject()] * 2, (x for x in [VMobject()]))
     with pytest.raises(TypeError):
         VGroup(Mobject())
     with pytest.raises(TypeError):


### PR DESCRIPTION
Closes #3540 

Allows for statements like:
```py
VGroup(
    Square(),
    [Circle()],
    (x.shift(RIGHT) for x in [Star(), Triangle()])
)
```
Also added a test for this.

As MrDiver said, it's annoying to have to unpack iterables with the `*` operator.