### PR TITLE
Add helpful hints to `VGroup.add()` error message

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -2003,8 +2003,14 @@ class VGroup(VMobject, metaclass=ConvertToOpenGL):
                         (gr-circle_red).animate.shift(RIGHT)
                     )
         """
-        if not all(isinstance(m, (VMobject, OpenGLVMobject)) for m in vmobjects):
-            raise TypeError("All submobjects must be of type VMobject")
+        for m in vmobjects:
+            if not isinstance(m, (VMobject, OpenGLVMobject)):
+                raise TypeError(
+                    f"All submobjects of {self.__class__.__name__} must be of type VMobject. "
+                    f"Got {repr(m)} ({type(m)}) instead. "
+                    "You can try using `Group` instead."
+                )
+
         return super().add(*vmobjects)
 
     def __add__(self, vmobject: VMobject) -> Self:

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -2007,7 +2007,7 @@ class VGroup(VMobject, metaclass=ConvertToOpenGL):
             if not isinstance(m, (VMobject, OpenGLVMobject)):
                 raise TypeError(
                     f"All submobjects of {self.__class__.__name__} must be of type VMobject. "
-                    f"Got {repr(m)} ({type(m)}) instead. "
+                    f"Got {repr(m)} ({type(m).__name__}) instead. "
                     "You can try using `Group` instead."
                 )
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

Changes the error message to explicitly state what was wrong and suggest a solution.

<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

I was confused by the current error message when I was creating a large `VGroup`. The solution is to use `Group` instead as I discovered [here](https://github.com/3b1b/manim/issues/795), but I think that's not obvious to somebody not familiar with Manim internals.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

This is tested by `test_vectorized_mobject.py::test_vgroup_init`.

There are about a dozen other places where error messages could be improved similarly - search for "must be of type" in the codebase. I didn't want to change all of them at once in case there are reviewer objections, but I'm happy to change other similar messages too.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
