### PR TITLE
Fix typing of `Animation`

### DIFF
--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -16,7 +16,7 @@ __all__ = ["Animation", "Wait", "override_animation"]
 
 
 from copy import deepcopy
-from typing import TYPE_CHECKING, Callable, Iterable, Self, Sequence, cast
+from typing import TYPE_CHECKING, Callable, Iterable, Sequence, cast
 
 if TYPE_CHECKING:
     from manim.scene.scene import Scene
@@ -112,7 +112,7 @@ class Animation:
         *args,
         use_override=True,
         **kwargs,
-    ) -> Self:
+    ):
         if isinstance(mobject, Mobject) and use_override:
             func = mobject.animation_override_for(cls)
             if func is not None:
@@ -122,7 +122,7 @@ class Animation:
                     f"{type(mobject).__name__} mobjects. use_override = False can "
                     f" be used as keyword argument to prevent animation overriding.",
                 )
-                return cast(Self, anim)
+                return cast(cls, anim)
         return super().__new__(cls)
 
     def __init__(

--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -16,7 +16,9 @@ __all__ = ["Animation", "Wait", "override_animation"]
 
 
 from copy import deepcopy
-from typing import TYPE_CHECKING, Callable, Iterable, Sequence, cast
+from typing import TYPE_CHECKING, Callable, Iterable, Sequence
+
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     from manim.scene.scene import Scene
@@ -112,7 +114,7 @@ class Animation:
         *args,
         use_override=True,
         **kwargs,
-    ):
+    ) -> Self:
         if isinstance(mobject, Mobject) and use_override:
             func = mobject.animation_override_for(cls)
             if func is not None:
@@ -122,7 +124,7 @@ class Animation:
                     f"{type(mobject).__name__} mobjects. use_override = False can "
                     f" be used as keyword argument to prevent animation overriding.",
                 )
-                return cast(cls, anim)
+                return anim
         return super().__new__(cls)
 
     def __init__(

--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -16,7 +16,7 @@ __all__ = ["Animation", "Wait", "override_animation"]
 
 
 from copy import deepcopy
-from typing import TYPE_CHECKING, Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Callable, Iterable, Self, Sequence, cast
 
 if TYPE_CHECKING:
     from manim.scene.scene import Scene
@@ -112,7 +112,7 @@ class Animation:
         *args,
         use_override=True,
         **kwargs,
-    ):
+    ) -> Self:
         if isinstance(mobject, Mobject) and use_override:
             func = mobject.animation_override_for(cls)
             if func is not None:
@@ -122,7 +122,7 @@ class Animation:
                     f"{type(mobject).__name__} mobjects. use_override = False can "
                     f" be used as keyword argument to prevent animation overriding.",
                 )
-                return anim
+                return cast(Self, anim)
         return super().__new__(cls)
 
     def __init__(

--- a/manim/typing.py
+++ b/manim/typing.py
@@ -561,7 +561,7 @@ Function types
 # Due to current limitations
 # (see https://github.com/python/mypy/issues/14656 / 8263),
 # we don't specify the first argument type (Mobject).
-FunctionOverride: TypeAlias = Callable[..., None]
+FunctionOverride: TypeAlias = Callable
 """Function type returning an :class:`~.Animation` for the specified
 :class:`~.Mobject`.
 """

--- a/manim/typing.py
+++ b/manim/typing.py
@@ -561,6 +561,8 @@ Function types
 # Due to current limitations
 # (see https://github.com/python/mypy/issues/14656 / 8263),
 # we don't specify the first argument type (Mobject).
+# Nor are we able to specify the return type (Animation) since we cannot import
+# that here.
 FunctionOverride: TypeAlias = Callable
 """Function type returning an :class:`~.Animation` for the specified
 :class:`~.Mobject`.


### PR DESCRIPTION
`FunctionOverride` was being typed as returning `None` whereas it in fact returns `Animation`. This was resulting in the result of `Animation(...)` being inferred as `Animation | None` (by Pyright, at least).

This PR addresses this by casting to the true type at the call site in `Animation.__new__()`. It also changes the type to simply be `Callable` seeing as `None` was misleading, and we're also unable to type the arguments correctly.

### How this was tested

In VSCode using Pylance, I confirmed that the return type of `Animation(...)` is `Animation` (not `Animation | None`), and, outside VSCode, that manim could still be used.