### PR TITLE
Update docker.rst to use bash from the PATH in docker run command

### DIFF
--- a/docs/source/installation/docker.rst
+++ b/docs/source/installation/docker.rst
@@ -45,7 +45,7 @@ modify to your liking. First, run
 
 .. code-block:: sh
 
-   docker run -it --name my-manim-container -v "/full/path/to/your/directory:/manim" manimcommunity/manim /bin/bash
+   docker run -it --name my-manim-container -v "/full/path/to/your/directory:/manim" manimcommunity/manim bash
 
 
 to obtain an interactive shell inside your container allowing you


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
The docker docs use a `docker run` command that runs `/bin/bash`, but it's easier to use `bash` from the `PATH`.
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
[docker.rst](https://manimce--3582.org.readthedocs.build/en/3582/installation/docker.html)
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
I've verified the updated command works.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
