### PR TITLE
Fix typehint of :attr:`InternalPoint2D_Array`

### DIFF
--- a/manim/typing.py
+++ b/manim/typing.py
@@ -257,9 +257,9 @@ parameter can handle being passed a `Point3D` instead.
 """
 
 InternalPoint2D_Array: TypeAlias = npt.NDArray[PointDType]
-"""``shape: (N, 3)``
+"""``shape: (N, 2)``
 
-An array of `Point2D` objects: ``[[float, float], ...]``.
+An array of `InternalPoint2D` objects: ``[[float, float], ...]``.
 
 .. note::
     This type alias is mostly made available for internal use, and


### PR DESCRIPTION
Fix some typos in the docstring of `InternalPoint2D_Array`