### PR TITLE
Fix `get_arc_center()` returning reference of point

### DIFF
--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -389,7 +389,7 @@ class Arc(TipableVMobject):
             # For a1 and a2 to lie at the same point arc radius
             # must be zero. Thus arc_center will also lie at
             # that point.
-            return a1
+            return np.copy(a1)
         # Tangent vectors
         t1 = h1 - a1
         t2 = h2 - a2


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Fixes #3572
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

Using given example in #3572,

A reference to the anchor point was being returned by `get_arc_center()` in the case both anchor points of arc are the samee. When the rotation was applied about this point, the following code would move it to origin, apply the rotation and move it back to the original location.

https://github.com/ManimCommunity/manim/blob/3b496ea2e6f1a6ab7829398590b41e17bfbd34c1/manim/mobject/mobject.py#L1369-L1371

But since `about_point` is a reference, in the last line this point is now `ORIGIN`, the object remains at origin.
Fixed by returning a copy of the anchor point.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
