### PR TITLE
Complex/number plane axes tips & ticks

### DIFF
--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -123,6 +123,21 @@ class TipableVMobject(VMobject, metaclass=ConvertToOpenGL):
         self.add(tip)
         return self
 
+    # Define new function `add_tip_opposite_end` for allowing user to specify `include_tip` attribute in NumberPlane __init__() method
+    def add_tip_opposite_end(
+        self, tip=None, tip_shape=None, tip_length=None, tip_width=None, at_start=True
+    ):
+        """Adds a tip to the start of the TipableVMobject instance.
+        """
+        if tip is None:
+            tip = self.create_tip(tip_shape, tip_length, tip_width, at_start)
+        else:
+            self.position_tip(tip, at_start)
+        self.reset_endpoints_based_on_tip(tip, at_start)
+        self.asign_tip_attr(tip, at_start)
+        self.add(tip)
+        return self
+
     def create_tip(
         self,
         tip_shape: type[tips.ArrowTip] | None = None,

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -127,8 +127,7 @@ class TipableVMobject(VMobject, metaclass=ConvertToOpenGL):
     def add_tip_opposite_end(
         self, tip=None, tip_shape=None, tip_length=None, tip_width=None, at_start=True
     ):
-        """Adds a tip to the start of the TipableVMobject instance.
-        """
+        """Adds a tip to the start of the TipableVMobject instance."""
         if tip is None:
             tip = self.create_tip(tip_shape, tip_length, tip_width, at_start)
         else:

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -51,6 +51,8 @@ class NumberLine(Line):
         The thickness of the line.
     include_tip
         Whether to add a tip to the end of the line.
+    include_tips
+        Whether to add tips to the start & end of the line.
     tip_width
         The width of the tip.
     tip_height
@@ -148,6 +150,7 @@ class NumberLine(Line):
         stroke_width: float = 2.0,
         # tip
         include_tip: bool = False,
+        include_tips: bool = False,
         tip_width: float = DEFAULT_ARROW_TIP_LENGTH,
         tip_height: float = DEFAULT_ARROW_TIP_LENGTH,
         tip_shape: type[ArrowTip] | None = None,
@@ -199,6 +202,7 @@ class NumberLine(Line):
         self.rotation = rotation
         # tip
         self.include_tip = include_tip
+        self.include_tips = include_tips
         self.tip_width = tip_width
         self.tip_height = tip_height
         # numbers
@@ -229,6 +233,21 @@ class NumberLine(Line):
 
         if self.include_tip:
             self.add_tip(
+                tip_length=self.tip_height,
+                tip_width=self.tip_width,
+                tip_shape=tip_shape,
+            )
+            self.tip.set_stroke(self.stroke_color, self.stroke_width)
+
+        if self.include_tips:
+            self.add_tip(
+                tip_length=self.tip_height,
+                tip_width=self.tip_width,
+                tip_shape=tip_shape,
+            )
+
+            # This function `add_tip_opposite_end` to be defined in arc.py
+            self.add_tip_opposite_end(
                 tip_length=self.tip_height,
                 tip_width=self.tip_width,
                 tip_shape=tip_shape,
@@ -321,9 +340,16 @@ class NumberLine(Line):
         np.ndarray
             A numpy array of floats represnting values along the number line.
         """
+        # set x_min and x_max based on self.include_tip or self.include_tips
         x_min, x_max, x_step = self.x_range
-        if not self.include_tip:
+        if not self.include_tip and not self.include_tips:
             x_max += 1e-6
+        elif not self.include_tip and self.include_tips:
+            x_max -= 1e-6
+            x_min += 1e-6
+        elif self.include_tip and self.include_tips:
+            x_max -= 1e-6
+            x_min += 1e-6
 
         # Handle cases where min and max are both positive or both negative
         if x_min < x_max < 0 or x_max > x_min > 0:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
This commit updates the behavior of NumberPlane and ComplexPlane Mobjects axes tips, by defining a new attribute `include_tips` (note* plural) inside the `axis_config` argument for displaying the leftmost & rightmost tips without distorting/stretching the ticks along the axes.

Note the updated code files number_line.py & arc.py may have some code redundancies
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->

## Further Information and Comments

<!-- If applicable, put further comments for the reviewers here. -->

Works for ComplexPlane, NumberPlane & NumberLine.
No need to define such behavior for Axes, because the ticks are not distorted when including leftmost tip using other "rudimentary" methods

The attribute `include_tips = True` is simple to use.
Avoid using `include_tips=True` in conjunction with `include_tip` (use one or the other) since this will create a double arrow-head on one of the sides of an axis

Below is an illustration of the output using a ComplexPlane Mobject that distorts the ticks along the x- and y-axes. See the code below, with certain parts that can be uncommented to achieve the desired effect:

![Distorted](https://github.com/ManimCommunity/manim/assets/122999532/da449e8a-bfca-4fbc-92ec-8d77fda0a294)

Below is an illustration of the output using a ComplexPlane Mobject with the added attribute `include_tips` showing that the axes ticks are aligned with the NumberPlane grid (lines parallel to the axes)

![ComplexPlaneExample_ManimCE_v0 18 0](https://github.com/ManimCommunity/manim/assets/122999532/22d65533-e43a-4cff-9425-43a838089479)

Here's the code snippet that produces this output:

`

      class ComplexPlaneExample(Scene):

          def construct(self):  

              xrange = [-2,5]
              yrange = [-5,2]          

              plane = ComplexPlane(  
                  x_range=xrange,
                  y_range=yrange,       
                     
                  axis_config={                    
                      # "include_numbers": True,
                      "tip_width": 0.15,
                      "tip_height": 0.15,
                      "include_ticks": True,
                      # "tick_size": 0,                    
                      # "include_numbers": True,
                      # "include_tip": True, # Add a tip to x-axis and y-axis
                      "include_tips": True, # This is the newly defined atrribute
                 }              

             ).add_coordinates()

             self.add(plane)
          
             d1 = Dot(plane.n2p(2 + 1j), color=YELLOW)
             d2 = Dot(plane.n2p(-3 - 2j), color=YELLOW)
          
             label1 = MathTex("2+i").next_to(d1, UR, 0.1)
             label2 = MathTex("-3-2i").next_to(d2, UR, 0.1)
  
             # y_axis = plane.get_axes()[1]
             # y_axis.add_tip(at_start=True, tip_width=0.15, tip_length=0.15)
  
             # x_axis = plane.get_axes()[0]
             # x_axis.add_tip(at_start=True, tip_width=0.15, tip_length=0.15)
          
             self.add(
                 d1,
                 label1,
                 d2,
                 label2,
             )
`

Here's a screenshot of a way to manipulate Axes Mobjects left/right tips which does not work exactly the same for NumberPlane and ComplexPlane Mobjects, which is the motive for this commit:

![AxesTipsDiscord](https://github.com/ManimCommunity/manim/assets/122999532/9e788ae7-c1ec-4df4-adcc-ac5662941e8a)

In the above case, the leftmost tip shape, width and height does not inherit from the rightmost tip, but can easily be manipulated using code below, by toggling some of the comments:

However, this functionality applies only to Axes Mobjects, not NumberPlane and ComplexPlane, thus, the proposed change is very relevant and can hopefully be merged into existing manim CE master

`

            class AxesTips(Scene):

                 def construct(self):

                     axes = Axes(

                         x_range=[-2,5],
                         y_range=[-5,2],            

                        axis_config={
                             "include_numbers": True,
                             "tip_width": 0.15,
                             "tip_height": 0.15,
                             "include_ticks": True,
                             "tick_size": 0.1,
                             "include_numbers": True,
                             # "include_tip": True, # Add a tip to end of  x-axis and end of y-axis
                             "include_tips": True,
                       },

                   )

                # # Add a tip to start of x-axis
                # axes[0].add_tip(at_start=True, tip_width=0.15, tip_length=0.15)
                # # Add a tip to start of y-axis
                # axes[1].add_tip(at_start=True, tip_width=0.15, tip_length=0.15)

               # x_axis_ticks = axes[0].get_tick_marks()
               # print(x_axis_ticks)

              # x_axis_leftmost_tick = axes[0].get_tick_marks()[0]
              # print(x_axis_leftmost_tick)

              # x_axis_ticks -=  x_axis_leftmost_tick
           
              # y_axis_ticks = axes[1].get_tick_marks()
              # print(y_axis_ticks)

             # y_axis_leftmost_tick = axes[1].get_tick_marks()[0]
             # print(y_axis_leftmost_tick)

             # y_axis_ticks -=  y_axis_leftmost_tick
        
        
             # Add Axes object to Scene Object        
             self.add(axes)
`

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
