### PR TITLE
Added cubic bézier bounding box calculation to width/height attribute :class:`.VMobject` 

### DIFF
--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -993,7 +993,7 @@ class CubicBezier(VMobject, metaclass=ConvertToOpenGL):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        self.add_cubic_bezier_curve(start_anchor, start_handle, end_handle, end_anchor)
+        self.append_points([start_anchor, start_handle, end_handle, end_anchor])
 
 
 class ArcPolygon(VMobject, metaclass=ConvertToOpenGL):

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -347,6 +347,7 @@ class VMobject(Mobject):
         `list[float]`
             Iterable of the minimum and maximum x and y values and handles.
         """
+        # Adapted from https://nishiohirokazu.blogspot.com/2009/06/how-to-calculate-bezier-curves-bounding.html
         P0, P1, P2, P3 = anchor_start, handle1, handle2, anchor_end
         bounds = [[P0[0], P3[0]], [P0[1], P3[1]]]
 
@@ -410,7 +411,7 @@ class VMobject(Mobject):
             min_y = min(min_y, sub_min_y)
             max_y = max(max_y, sub_max_y)
 
-        return max_y - min_y
+        return max_y - 
 
     def set_stroke(
         self,


### PR DESCRIPTION
## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Widths and heights of :class:`.VMobject` no longer simply use its control points handles to calculate the bounding box.
<!--changelog-end-->
It also removes some dead code related to cubic bezier curves that isn't used in VMobject (simplifying it) and moves some logic specific to the Cubic Bezier out of VMobject.

## Motivation and Explanation: Why and how do your changes improve the library?
Fixes #3619 

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
