### PR TITLE
Update jupyter.rst

### DIFF
--- a/docs/source/installation/jupyter.rst
+++ b/docs/source/installation/jupyter.rst
@@ -71,7 +71,7 @@ then execute it.
        texlive-latex-recommended texlive-science \
        tipa libpango1.0-dev
    !pip install manim
-   !pip install IPython --upgrade
+   !pip install IPython==8.21.0
 
 You should start to see Colab installing all the dependencies specified
 in these commands. After the execution has completed, you will be prompted


### PR DESCRIPTION
## Overview: What does this pull request change?

Modifies the instructions for running manim on Colab.

Pinpoints `IPython==8.21.0` for Google Colab, because more recent versions are incompatible with their runtime.

## Motivation and Explanation: Why and how do your changes improve the library?

Using `IPython>8.21.0` causes Colab being unable to restart, because Colab depends on traitlets<5.8, but latest versions of IPython install trailets>=5.13.0

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
