### PR TITLE
Create LabeledRectangle Class

### DIFF
--- a/manim/mobject/geometry/polygram.py
+++ b/manim/mobject/geometry/polygram.py
@@ -662,6 +662,34 @@ class Rectangle(Polygon):
             self.add(self.grid_lines)
 
 
+class LabeledRectangle(Rectangle):
+    """A :class:`Rectangle` containing a label in its center.
+
+    Parameters
+    ----------
+    label
+        The label of the :class:`Rectangle`. This is rendered as :class:`~.MathTex`
+        by default (i.e., when passing a :class:`str`), but other classes
+        representing rendered strings like :class:`~.Text` or :class:`~.Tex`
+        can be passed as well.
+
+    """
+
+    def __init__(
+        self,
+        label: str | SingleStringMathTex | Text | Tex,
+        **kwargs,
+    ) -> None:
+        if isinstance(label, str):
+            rendered_label = MathTex(label, color=BLACK)
+        else:
+            rendered_label = label
+
+        super().__init__(**kwargs)
+        rendered_label.move_to(self.get_center())
+        self.add(rendered_label)
+
+
 class Square(Rectangle):
     """A rectangle with equal side lengths.
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Introduce a new Class in [mobject/geometry/polygram.py](https://github.com/ManimCommunity/manim/blob/77d42d2a46b847b6d5731b4ce254972149c1a426/manim/mobject/geometry/polygram.py#L570)
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
While working with the Graph class I encountered issues with vertexes of type Rectangle, whenever I set labels=True. Thus, I looked at how LabeledDot is defined in arc.py and implemented a Rectangle with support for Label.

Result:
<img src="https://i.imgur.com/IWE5YZT.png">

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
