### PR TITLE
Fix Vector3 -> Vector3D in contributing docs

### DIFF
--- a/docs/source/contributing/docs/typings.rst
+++ b/docs/source/contributing/docs/typings.rst
@@ -115,8 +115,8 @@ Typing guidelines
    from typing import TYPE_CHECKING
 
    if TYPE_CHECKING:
-       from manim.typing import Vector3
-   # type stuff with Vector3
+       from manim.typing import Vector3D
+   # type stuff with Vector3D
 
 Missing Sections for typehints are:
 -----------------------------------


### PR DESCRIPTION
Following the merge of #3484 a type alias was changed from `Vector3` to `Vector3D`. This change was missed in the typing section of the contributing guide, which this PR fixes.

[typing docs](https://manimce--3639.org.readthedocs.build/en/3639/contributing/docs/typings.html#typing-guidelines)