### PR TITLE
Allow disabling color inheritance for TeX mobjects

### DIFF
--- a/docs/source/guides/using_text.rst
+++ b/docs/source/guides/using_text.rst
@@ -384,6 +384,52 @@ we have to add it manually.
             )
             self.add(tex)
 
+You can use the ``xcolor`` package to apply colors within TeX, but to do this
+you have to explicitly state that you want to preserve these colors (as the
+default is to override them with whatever the default :class:`~.VMobject`
+color is):
+
+.. manim:: XColor
+    :save_last_frame:
+
+    class XColor(Scene):
+        def construct(self):
+            myTemplate = TexTemplate()
+            myTemplate.add_to_preamble(r"\usepackage{xcolor}")
+            tex = Tex(
+                r"\textcolor{white}{Hello} \textcolor{yellow}{\LaTeX}",
+                tex_template=myTemplate,
+                font_size=144,
+                preserve_colors=True,
+            )
+            self.add(tex)
+
+You can use :func:`manim.mobject.mobject.Mobject.set_default` to make this the
+default:
+
+.. manim:: DefaultTexTemplate
+    :save_last_frame:
+
+    class DefaultTexTemplate(Scene):
+        def construct(self):
+            myTemplate = TexTemplate()
+            myTemplate.add_to_preamble(r"\usepackage{xcolor}")
+            myTemplate.add_to_document(r"\color{white}")
+
+            Tex.set_default(
+                tex_template=myTemplate,
+                preserve_colors=True
+            )
+
+            tex = Tex(
+                r"Hello \textcolor{yellow}{\LaTeX}",
+                font_size=144,
+            )
+            self.add(tex)
+
+            # Restore original defaults, to avoid breaking documentation
+            Tex.set_default()
+
 Substrings and parts
 ====================
 

--- a/manim/mobject/text/tex_mobject.py
+++ b/manim/mobject/text/tex_mobject.py
@@ -62,9 +62,10 @@ class SingleStringMathTex(SVGMobject):
         tex_environment: str = "align*",
         tex_template: TexTemplate | None = None,
         font_size: float = DEFAULT_FONT_SIZE,
+        preserve_colors: bool = False,
         **kwargs,
     ):
-        if kwargs.get("color") is None:
+        if kwargs.get("color") is None and not preserve_colors:
             # makes it so that color isn't explicitly passed for these mobs,
             # and can instead inherit from the parent
             kwargs["color"] = VMobject().color

--- a/manim/mobject/text/tex_mobject.py
+++ b/manim/mobject/text/tex_mobject.py
@@ -44,6 +44,36 @@ tex_string_to_mob_map = {}
 class SingleStringMathTex(SVGMobject):
     """Elementary building block for rendering text with LaTeX.
 
+    Parameters
+    ----------
+    tex_string
+        The TeX source string to render.
+    stroke_width
+        The stroke width of the mobject. If ``None`` (the default),
+        the stroke width values set in the generated SVG file are used.
+    should_center
+        Whether or not the mobject should be centered after
+        being imported.
+    height
+    organize_left_to_right
+    tex_environment
+        The TeX environment to wrap the string in.
+    tex_template
+        The TeX template to use when rendering the string.
+    font_size
+    preserve_colors
+        If ``False`` (the default), the mobject is recolored based on
+        the default :class:`~.VMobject` color.
+        If ``True``, the colors in the TeX document are used.
+
+        .. warning::
+            By default, TeX strings are coloured black, meaning they
+            will be invisible against a black background.
+            If you want to use this option, it is recommended to set
+            a default color in TeX.
+    kwargs
+        Further arguments passed to the parent class.
+
     Tests
     -----
     Check that creating a :class:`~.SingleStringMathTex` object works::

--- a/tests/test_graphical_units/test_tex_mobject.py
+++ b/tests/test_graphical_units/test_tex_mobject.py
@@ -9,12 +9,23 @@ __module_test__ = "tex_mobject"
 @frames_comparison
 def test_color_inheritance(scene):
     """Test that Text and MarkupText correctly inherit colour from
-    their parent class."""
+    their parent class when the preserve_colors argument is unset."""
 
     VMobject.set_default(color=RED)
-    tex = Tex("test color inheritance")
-    mathtex = MathTex("test color inheritance")
-    vgr = VGroup(tex, mathtex).arrange()
+
+    template = config.tex_template.copy()
+    template.add_to_preamble(r"\usepackage{xcolor}")
+
+    text = r"test color \textcolor{green}{inheritance}"
+
+    tex_inherit = Tex(text, tex_template=template)
+    mathtex_inherit = MathTex(text, tex_template=template)
+    tex_preserve = Tex(text, tex_template=template, preserve_colors=True)
+    mathtex_preserve = MathTex(text, tex_template=template, preserve_colors=True)
+
+    vgr = VGroup(tex_inherit, mathtex_inherit, tex_preserve, mathtex_preserve).arrange(
+        DOWN
+    )
     VMobject.set_default()
 
     scene.add(vgr)


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

- Add a `preserve_colors` parameter to `SingleStringMathTex`, allowing the user to disable color inheritance
- Add a Parameters section to `SingleStringMathTex`'s docstring
- Add demos to the _Extra LaTeX Packages_ section of the guide on using text, showing how to use `xcolor` to apply colors to TeX strings

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

This makes it easier to color parts of TeX mobjects; for example users can define custom TeX commands in their template (like `\newcommand{\X}{\ensuremath{\textcolor{cyan}{X}}}` to allow `\X` to produce a cyan math-mode X).
This also avoids issues like #3492, #3548 by allowing TeX itself to apply the colors.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--3643.org.readthedocs.build/en/3643/, where #### represents the PR number. -->

https://manimce--3643.org.readthedocs.build/en/3643/reference/manim.mobject.text.tex_mobject.SingleStringMathTex.html

https://manimce--3643.org.readthedocs.build/en/3643/guides/using_text.html#extra-latex-packages

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

Render of passing test case (upper is inheriting color, lower is preserving it):
![image](https://github.com/ManimCommunity/manim/assets/7029204/6376b48d-20cb-44a7-a85c-728649041f3b)
Note that, without further changes to the preamble / SVG reading, any TeX not explicitly colored is black and thus invisible against the default background.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
