### PR TITLE
Fix some typehints in mobject.py

### DIFF
--- a/manim/animation/speedmodifier.py
+++ b/manim/animation/speedmodifier.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 import inspect
 import types
-from typing import Callable
+from typing import Callable, TYPE_CHECKING
 
 from numpy import piecewise
 
 from ..animation.animation import Animation, Wait, prepare_animation
 from ..animation.composition import AnimationGroup
-from ..mobject.mobject import Mobject, Updater, _AnimationBuilder
+from ..mobject.mobject import Mobject, _AnimationBuilder
 from ..scene.scene import Scene
+
+if TYPE_CHECKING:
+    from ..mobject.mobject import Updater
 
 __all__ = ["ChangeSpeed"]
 

--- a/manim/animation/speedmodifier.py
+++ b/manim/animation/speedmodifier.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import inspect
 import types
-from typing import Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from numpy import piecewise
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -39,6 +39,8 @@ from ..utils.paths import straight_path
 from ..utils.space_ops import angle_between_vectors, normalize, rotation_matrix
 
 if TYPE_CHECKING:
+    from typing_extensions import Self, TypeAlias
+
     from manim.typing import (
         FunctionOverride,
         Image,
@@ -52,7 +54,6 @@ if TYPE_CHECKING:
     )
 
     from ..animation.animation import Animation
-    from typing_extensions import Self, TypeAlias
 
 TimeBasedUpdater: TypeAlias = Callable[["Mobject", float], object]
 NonTimeBasedUpdater: TypeAlias = Callable[["Mobject"], object]

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -16,10 +16,9 @@ import types
 import warnings
 from functools import partialmethod, reduce
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Iterable, Literal, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, Iterable, Literal
 
 import numpy as np
-from typing_extensions import Self, TypeAlias
 
 from manim.mobject.opengl.opengl_compatibility import ConvertToOpenGL
 
@@ -39,13 +38,6 @@ from ..utils.iterables import list_update, remove_list_redundancies
 from ..utils.paths import straight_path
 from ..utils.space_ops import angle_between_vectors, normalize, rotation_matrix
 
-# TODO: Explain array_attrs
-
-TimeBasedUpdater: TypeAlias = Callable[["Mobject", float], None]
-NonTimeBasedUpdater: TypeAlias = Callable[["Mobject"], None]
-Updater: TypeAlias = Union[NonTimeBasedUpdater, TimeBasedUpdater]
-T = TypeVar("T", bound="Mobject")
-
 if TYPE_CHECKING:
     from manim.typing import (
         FunctionOverride,
@@ -60,6 +52,11 @@ if TYPE_CHECKING:
     )
 
     from ..animation.animation import Animation
+    from typing_extensions import Self, TypeAlias
+
+TimeBasedUpdater: TypeAlias = Callable[["Mobject", float], object]
+NonTimeBasedUpdater: TypeAlias = Callable[["Mobject"], object]
+Updater: TypeAlias = NonTimeBasedUpdater | TimeBasedUpdater
 
 
 class Mobject:
@@ -237,7 +234,7 @@ class Mobject:
             cls.__init__ = cls._original__init__
 
     @property
-    def animate(self: T) -> _AnimationBuilder | T:
+    def animate(self) -> _AnimationBuilder | Self:
         """Used to animate the application of any method of :code:`self`.
 
         Any method called on :code:`animate` is converted to an animation of applying
@@ -2926,7 +2923,7 @@ class Mobject:
         self,
         z_index_value: float,
         family: bool = True,
-    ) -> T:
+    ) -> Self:
         """Sets the :class:`~.Mobject`'s :attr:`z_index` to the value specified in `z_index_value`.
 
         Parameters

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -55,9 +55,9 @@ if TYPE_CHECKING:
 
     from ..animation.animation import Animation
 
-TimeBasedUpdater: TypeAlias = Callable[["Mobject", float], object]
-NonTimeBasedUpdater: TypeAlias = Callable[["Mobject"], object]
-Updater: TypeAlias = NonTimeBasedUpdater | TimeBasedUpdater
+    TimeBasedUpdater: TypeAlias = Callable[["Mobject", float], object]
+    NonTimeBasedUpdater: TypeAlias = Callable[["Mobject"], object]
+    Updater: TypeAlias = NonTimeBasedUpdater | TimeBasedUpdater
 
 
 class Mobject:


### PR DESCRIPTION
* Move `typing_extensions` import under `if TYPE_CHECKING`
* Change from using `def animate(self: T ,...) -> T` to `def animate(self, ...) -> Self` as stated in PEP 673
* Fix incorrect usage of `T` in :meth:`.Mobject.set_z_index`
* Change updater return type to `object`. Since we just [discard the result](https://github.com/ManimCommunity/manim/blob/main/manim/mobject/mobject.py#L849-L852), any return value will do.

Note to reviewer:
Please check if this PR breaks autocomplete for the `.animate` syntax.

It seems there is a problem with the `autoaliasattr_directive`, as the `Updater`s are [no longer being shown](https://manimce--3668.org.readthedocs.build/en/3668/reference/manim.mobject.mobject.Mobject.html). Should be fixed after #3671 