### PR TITLE
Fix broken link in documentation to Poetry installation instructions

### DIFF
--- a/docs/source/contributing/development.rst
+++ b/docs/source/contributing/development.rst
@@ -62,7 +62,7 @@ For first-time contributors
      managing virtual environments.
 
      If you choose to use Poetry as well, follow `Poetry's installation
-     guidelines <https://python-poetry.org/docs/master/#installation>`__
+     guidelines <https://python-poetry.org/docs/#installing-with-pipx>`__
      to install it on your system, then run ``poetry install`` from
      your cloned repository. Poetry will then install Manim, as well
      as create and enter a virtual environment. You can always re-enter

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -87,8 +87,8 @@ Sharing Your Work
 
 We'd love to hear from you and see your manimations
 `on Twitter <https://twitter.com/manim_community>`_, `Reddit <https://www.reddit.com/r/manim/>`_,
-or `Discord <https://www.manim.community/discord/>`_. If you're using Manim for scientific purposes, 
-instructions on how to cite a particular release can be found
+or `Discord <https://www.manim.community/discord/>`_. If you're using Manim in a scientific
+context, instructions on how to cite a particular release can be found
 `in our README <https://github.com/ManimCommunity/manim/blob/main/README.md>`_.
 
 Index

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -87,7 +87,7 @@ Sharing Your Work
 
 We'd love to hear from you and see your manimations
 `on Twitter <https://twitter.com/manim_community>`_, `Reddit <https://www.reddit.com/r/manim/>`_,
-or `Discord <https://www.manim.community/discord/>`_. If you're using Manim scientific purposes, 
+or `Discord <https://www.manim.community/discord/>`_. If you're using Manim for scientific purposes, 
 instructions on how to cite a particular release can be found
 `in our README <https://github.com/ManimCommunity/manim/blob/main/README.md>`_.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,7 @@ in the right place!
   You can also find information on Manim's docker images and (online)
   notebook environments there.
 - Want to try the library before installing it? Take a look at our
-  interactive online playground at https://try.manim.community in form
+  interactive online playground at https://try.manim.community in the form
   of a Jupyter notebook.
 - In our :doc:`Tutorials <tutorials/index>` section you will find a
   collection of resources that will teach you how to use Manim. In particular,
@@ -71,7 +71,7 @@ Here are some short summaries for all of the sections in this documentation:
   can be found in the :doc:`FAQ </faq/index>` section.
 - The :doc:`Reference Manual </reference>` contains a comprehensive list of all of Manim's
   (documented) modules, classes, and functions. If you are somewhat familiar with Manim's
-  module structure feel free to browse the manual directly. If you are searching for
+  module structure, feel free to browse the manual directly. If you are searching for
   something specific, feel free to use the documentation's search feature in the sidebar.
   Many classes and methods come with their own illustrated examples too!
 - The :doc:`Plugins </plugins>` page documents how to install, write, and distribute
@@ -87,8 +87,8 @@ Sharing Your Work
 
 We'd love to hear from you and see your manimations
 `on Twitter <https://twitter.com/manim_community>`_, `Reddit <https://www.reddit.com/r/manim/>`_,
-or `Discord <https://www.manim.community/discord/>`_. If you're using Manim in a scientific
-context, instructions on how to cite a particular release can be found
+or `Discord <https://www.manim.community/discord/>`_. If you're using Manim scientific purposes, 
+instructions on how to cite a particular release can be found
 `in our README <https://github.com/ManimCommunity/manim/blob/main/README.md>`_.
 
 Index


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
The link (https://python-poetry.org/docs/master/#installation) to the Poetry installation guide provided in the [First Time Contributors Page](https://docs.manim.community/en/latest/contributing/development.html#for-first-time-contributors) is broken. This needs to be updated to https://python-poetry.org/docs/main/#installing-with-pipx as the correct destination.
## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
