### PR TITLE
Fix NameError in try... except

### DIFF
--- a/manim/cli/render/commands.py
+++ b/manim/cli/render/commands.py
@@ -142,14 +142,14 @@ def render(
             )
         except Exception:
             logger.debug("Something went wrong: %s", warn_prompt)
-
-        stable = json_data["info"]["version"]
-        if stable != __version__:
-            console.print(
-                f"You are using manim version [red]v{__version__}[/red], but version [green]v{stable}[/green] is available.",
-            )
-            console.print(
-                "You should consider upgrading via [yellow]pip install -U manim[/yellow]",
-            )
+        else:
+            stable = json_data["info"]["version"]
+            if stable != __version__:
+                console.print(
+                    f"You are using manim version [red]v{__version__}[/red], but version [green]v{stable}[/green] is available.",
+                )
+                console.print(
+                    "You should consider upgrading via [yellow]pip install -U manim[/yellow]",
+                )
 
     return args


### PR DESCRIPTION
## Motivation
This came about of some [failing tests with Ubuntu 3.9](https://github.com/ManimCommunity/manim/actions/runs/8653877665/job/23729998298?pr=3678#step:22:89) in the CI.
TL;DR: variable undefined after a `try... except` statement

The previous structure was something like this:
```py
try:
     x = 5 # something that might fail
except Exception:
     logger.debug("Oh no")
# do something with x
```
This has the problem that if an `Exception` occurs, `x` is undefined and we get a `NameError`. Instead it should be something like this:
```py
try:
     x = 5 # something that might fail
except Exception:
     logger.debug("Oh no")
else:
    # do something with x
```
In the case of this PR, this approach is fine because it's not performing any critical actions where failing should terminate the program