### PR TITLE
 Separate :class:`.Animation` and :class:`.Scene`

### DIFF
--- a/example_scenes/new_test_new.py
+++ b/example_scenes/new_test_new.py
@@ -39,6 +39,7 @@ if __name__ == "__main__":
         win = Window(
             width=1920,
             height=1080,
+            fullscreen=True,
             vsync=True,
             config=Config(double_buffer=True, samples=0),
         )
@@ -151,6 +152,8 @@ if __name__ == "__main__":
                 if not is_finished:
                     if virtual_time >= run_time:
                         animation.finish()
+                        buffer = str(animation.buffer)
+                        print(f"{buffer = }")
                         has_finished = True
                     else:
                         animation.update_mobjects(dt)

--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -16,7 +16,6 @@ from .scene_buffer import SceneBuffer
 
 __all__ = ["Animation", "Wait", "override_animation"]
 
-
 from copy import deepcopy
 from typing import TYPE_CHECKING, Callable, Iterable, Sequence, TypeVar
 
@@ -272,6 +271,15 @@ class Animation:
         """
         for mob in self.get_all_mobjects_to_update():
             mob.update(dt)
+
+    def process_subanimation_buffer(self, buffer: SceneBuffer):
+        """
+        This is used in animations that are proxies around
+        other animations
+        """
+        self.buffer.add(*buffer.to_add)
+        self.buffer.remove(*buffer.to_remove)
+        self.buffer.clear()
 
     def get_all_mobjects_to_update(self) -> list[Mobject]:
         """Get all mobjects to be updated during the animation.

--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -27,7 +27,7 @@ DEFAULT_ANIMATION_RUN_TIME: float = 1.0
 DEFAULT_ANIMATION_LAG_RATIO: float = 0.0
 
 
-class Animation:
+class Animation(AnimationProtocol):
     """An animation.
 
     Animations have a fixed time span.

--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -275,10 +275,12 @@ class Animation:
     def process_subanimation_buffer(self, buffer: SceneBuffer):
         """
         This is used in animations that are proxies around
-        other animations
+        other animations, like :class:`.AnimationGroup`
         """
-        self.buffer.add(*buffer.to_add)
         self.buffer.remove(*buffer.to_remove)
+        for to_replace_pairs in buffer.to_replace:
+            self.buffer.replace(*to_replace_pairs)
+        self.buffer.add(*buffer.to_add)
         self.buffer.clear()
 
     def get_all_mobjects_to_update(self) -> list[Mobject]:

--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -11,15 +11,17 @@ from ..mobject import mobject
 from ..mobject.mobject import Mobject
 from ..mobject.opengl import opengl_mobject
 from ..utils.rate_functions import linear, smooth
+from .protocol import AnimationProtocol
+from .scene_buffer import SceneBuffer
 
 __all__ = ["Animation", "Wait", "override_animation"]
 
 
 from copy import deepcopy
-from typing import TYPE_CHECKING, Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Callable, Iterable, Sequence, TypeVar
 
 if TYPE_CHECKING:
-    from manim.scene.scene import Scene
+    from typing_extensions import Self
 
 
 DEFAULT_ANIMATION_RUN_TIME: float = 1.0
@@ -127,17 +129,17 @@ class Animation:
 
     def __init__(
         self,
-        mobject: Mobject | None,
+        mobject: OpenGLMobject | None,
         lag_ratio: float = DEFAULT_ANIMATION_LAG_RATIO,
         run_time: float = DEFAULT_ANIMATION_RUN_TIME,
         rate_func: Callable[[float], float] = smooth,
         reverse_rate_function: bool = False,
-        name: str = None,
-        remover: bool = False,  # remove a mobject from the screen?
+        name: str | None = None,
+        remover: bool = False,  # remove a mobject from the screen at end of animation
         suspend_mobject_updating: bool = True,
         introducer: bool = False,
         *,
-        _on_finish: Callable[[], None] = lambda _: None,
+        _on_finish: Callable[[SceneBuffer], object] = lambda _: None,
         **kwargs,
     ) -> None:
         self._typecheck_input(mobject)
@@ -149,15 +151,16 @@ class Animation:
         self.introducer: bool = introducer
         self.suspend_mobject_updating: bool = suspend_mobject_updating
         self.lag_ratio: float = lag_ratio
-        self._on_finish: Callable[[Scene], None] = _on_finish
+        self._on_finish = _on_finish
+        self.buffer = SceneBuffer()
         if config["renderer"] == RendererType.OPENGL:
             self.starting_mobject: OpenGLMobject = OpenGLMobject()
             self.mobject: OpenGLMobject = (
                 mobject if mobject is not None else OpenGLMobject()
             )
-        else:
-            self.starting_mobject: Mobject = Mobject()
-            self.mobject: Mobject = mobject if mobject is not None else Mobject()
+        # else:
+        #     self.starting_mobject: Mobject = Mobject()
+        #     self.mobject: Mobject = mobject if mobject is not None else Mobject()
         if kwargs:
             logger.debug("Animation received extra kwargs: %s", kwargs)
 
@@ -169,7 +172,7 @@ class Animation:
                 ),
             )
 
-    def _typecheck_input(self, mobject: Mobject | None) -> None:
+    def _typecheck_input(self, mobject: Mobject | OpenGLMobject | None) -> None:
         if mobject is None:
             logger.debug("Animation with empty mobject")
         elif not isinstance(mobject, (Mobject, OpenGLMobject)):
@@ -213,10 +216,10 @@ class Animation:
             self.mobject.suspend_updating()
         self.interpolate(0)
 
+        if self.is_introducer():
+            self.buffer.add(self.mobject)
+
     def finish(self) -> None:
-        # TODO: begin and finish should require a scene as parameter.
-        # That way Animation.clean_up_from_screen and Scene.add_mobjects_from_animations
-        # could be removed as they fulfill basically the same purpose.
         """Finish the animation.
 
         This method gets called when the animation is over.
@@ -226,43 +229,19 @@ class Animation:
         if self.suspend_mobject_updating and self.mobject is not None:
             self.mobject.resume_updating()
 
-    def clean_up_from_scene(self, scene: Scene) -> None:
-        """Clean up the :class:`~.Scene` after finishing the animation.
-
-        This includes to :meth:`~.Scene.remove` the Animation's
-        :class:`~.Mobject` if the animation is a remover.
-
-        Parameters
-        ----------
-        scene
-            The scene the animation should be cleaned up from.
-        """
-        self._on_finish(scene)
+        self._on_finish(self.buffer)
         if self.is_remover():
-            scene.remove(self.mobject)
-
-    def _setup_scene(self, scene: Scene) -> None:
-        """Setup up the :class:`~.Scene` before starting the animation.
-
-        This includes to :meth:`~.Scene.add` the Animation's
-        :class:`~.Mobject` if the animation is an introducer.
-
-        Parameters
-        ----------
-        scene
-            The scene the animation should be cleaned up from.
-        """
-        if scene is None:
-            return
-        if (
-            self.is_introducer()
-            and self.mobject not in scene.get_mobject_family_members()
-        ):
-            scene.add(self.mobject)
+            self.buffer.remove(self.mobject)
 
     def create_starting_mobject(self) -> Mobject:
         # Keep track of where the mobject starts
         return self.mobject.copy()
+
+    def get_all_animations(self) -> tuple[Animation, ...]:
+        """This method is to implement an animation protocol, and
+        is more useful in places like :class:`.AnimationGroup`
+        """
+        return (self,)
 
     def get_all_mobjects(self) -> Sequence[Mobject]:
         """Get all mobjects involved in the animation.
@@ -305,9 +284,9 @@ class Animation:
         # The surrounding scene typically handles
         # updating of self.mobject.  Besides, in
         # most cases its updating is suspended anyway
-        return list(filter(lambda m: m is not self.mobject, self.get_all_mobjects()))
+        return [m for m in self.get_all_mobjects() if m is not self.mobject]
 
-    def copy(self) -> Animation:
+    def copy(self) -> Self:
         """Create a copy of the animation.
 
         Returns
@@ -422,7 +401,7 @@ class Animation:
     def set_rate_func(
         self,
         rate_func: Callable[[float], float],
-    ) -> Animation:
+    ) -> Self:
         """Set the rate function of the animation.
 
         Parameters
@@ -451,7 +430,7 @@ class Animation:
         """
         return self.rate_func
 
-    def set_name(self, name: str) -> Animation:
+    def set_name(self, name: str) -> Self:
         """Set the name of the animation.
 
         Parameters
@@ -489,7 +468,9 @@ class Animation:
 
 
 def prepare_animation(
-    anim: Animation | mobject._AnimationBuilder,
+    anim: AnimationProtocol
+    | mobject._AnimationBuilder
+    | opengl_mobject._AnimationBuilder,
 ) -> Animation:
     r"""Returns either an unchanged animation, or the animation built
     from a passed animation factory.
@@ -517,10 +498,7 @@ def prepare_animation(
         TypeError: Object 42 cannot be converted to an animation
 
     """
-    if isinstance(anim, mobject._AnimationBuilder):
-        return anim.build()
-
-    if isinstance(anim, opengl_mobject._AnimationBuilder):
+    if isinstance(anim, (mobject._AnimationBuilder, opengl_mobject._AnimationBuilder)):
         return anim.build()
 
     if isinstance(anim, Animation):
@@ -576,7 +554,7 @@ class Wait(Animation):
     def finish(self) -> None:
         pass
 
-    def clean_up_from_scene(self, scene: Scene) -> None:
+    def clean_up_from_scene(self, scene: SceneBuffer) -> None:
         pass
 
     def update_mobjects(self, dt: float) -> None:
@@ -625,7 +603,9 @@ def override_animation(
 
     """
 
-    def decorator(func):
+    _F = TypeVar("_F", bound=Callable)
+
+    def decorator(func: _F) -> _F:
         func._override_animation = animation_class
         return func
 

--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -335,7 +335,7 @@ class Animation:
         alpha: float,
     ) -> Animation:
         # Typically implemented by subclass
-        pass
+        raise NotImplementedError()
 
     def get_sub_alpha(self, alpha: float, index: int, num_submobjects: int) -> float:
         """Get the animation progress of any submobjects subanimation.
@@ -552,9 +552,6 @@ class Wait(Animation):
         pass
 
     def finish(self) -> None:
-        pass
-
-    def clean_up_from_scene(self, scene: SceneBuffer) -> None:
         pass
 
     def update_mobjects(self, dt: float) -> None:

--- a/manim/animation/changing.py
+++ b/manim/animation/changing.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 __all__ = ["AnimatedBoundary", "TracedPath"]
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
-from manim._config import config
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
 from manim.mobject.opengl.opengl_compatibility import ConvertToOpenGL
 from manim.mobject.types.vectorized_mobject import VGroup, VMobject
 from manim.utils.color import (
@@ -61,7 +63,7 @@ class AnimatedBoundary(VGroup):
         ]
         self.add(*self.boundary_copies)
         self.total_time = 0
-        self.add_updater(lambda m, dt: self.update_boundary_copies(dt))
+        self.add_updater(lambda _, dt: self.update_boundary_copies(dt))
 
     def update_boundary_copies(self, dt):
         # Not actual time, but something which passes at
@@ -143,7 +145,9 @@ class TracedPath(VMobject, metaclass=ConvertToOpenGL):
 
     def __init__(
         self,
-        traced_point_func: Callable,
+        traced_point_func: Callable[
+            [], npt.NDArray[npt.float]
+        ],  # TODO: Replace with Callable[[], Point3D]
         stroke_width: float = 2,
         stroke_color: ParsableManimColor | None = WHITE,
         dissipating_time: float | None = None,
@@ -155,7 +159,7 @@ class TracedPath(VMobject, metaclass=ConvertToOpenGL):
         self.time = 1 if self.dissipating_time else None
         self.add_updater(self.update_path)
 
-    def update_path(self, mob, dt):
+    def update_path(self, _mob, dt):
         new_point = self.traced_point_func()
         if not self.has_points():
             self.start_new_path(new_point)

--- a/manim/animation/composition.py
+++ b/manim/animation/composition.py
@@ -99,10 +99,6 @@ class AnimationGroup(Animation):
             self.group.resume_updating()
         self._on_finish(self.buffer)
 
-    def process_subanimation_buffer(self, buffer: SceneBuffer) -> None:
-        self.buffer.add(*buffer.to_add)
-        self.buffer.remove(*buffer.to_remove)
-
     def update_mobjects(self, dt: float) -> None:
         for anim in self.animations:
             anim.update_mobjects(dt)

--- a/manim/animation/creation.py
+++ b/manim/animation/creation.py
@@ -79,6 +79,8 @@ from typing import TYPE_CHECKING, Callable, Iterable, Sequence
 import numpy as np
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from manim.mobject.text.text_mobject import Text
 
 from manim.mobject.opengl.opengl_surface import OpenGLSurface
@@ -92,7 +94,7 @@ from ..constants import TAU
 from ..mobject.mobject import Group, Mobject
 from ..mobject.types.vectorized_mobject import VMobject
 from ..utils.bezier import integer_interpolate
-from ..utils.rate_functions import double_smooth, linear, smooth
+from ..utils.rate_functions import double_smooth, linear
 
 
 class ShowPartial(Animation):
@@ -124,12 +126,13 @@ class ShowPartial(Animation):
         submobject: Mobject,
         starting_submobject: Mobject,
         alpha: float,
-    ) -> None:
+    ) -> Self:
         submobject.pointwise_become_partial(
             starting_submobject, *self._get_bounds(alpha)
         )
+        return self
 
-    def _get_bounds(self, alpha: float) -> None:
+    def _get_bounds(self, alpha: float) -> tuple[float, float]:
         raise NotImplementedError("Please use Create or ShowPassingFlash")
 
 
@@ -318,10 +321,10 @@ class Write(DrawBorderThenFill):
         vmobject: VMobject | OpenGLVMobject,
         rate_func: Callable[[float], float] = linear,
         reverse: bool = False,
+        run_time: float | None = None,
+        lag_ratio: float | None = None,
         **kwargs,
     ) -> None:
-        run_time: float | None = kwargs.pop("run_time", None)
-        lag_ratio: float | None = kwargs.pop("lag_ratio", None)
         run_time, lag_ratio = self._set_default_config_from_length(
             vmobject,
             run_time,

--- a/manim/animation/fading.py
+++ b/manim/animation/fading.py
@@ -80,12 +80,12 @@ class _Fade(Transform):
         self.scale_factor = scale
         super().__init__(mobject, **kwargs)
 
-    def _create_faded_mobject(self, fadeIn: bool) -> Mobject:
+    def _create_faded_mobject(self, fade_in: bool) -> Mobject:
         """Create a faded, shifted and scaled copy of the mobject.
 
         Parameters
         ----------
-        fadeIn
+        fade_in
             Whether the faded mobject is used to fade in.
 
         Returns
@@ -95,7 +95,7 @@ class _Fade(Transform):
         """
         faded_mobject = self.mobject.copy()
         faded_mobject.fade(1)
-        direction_modifier = -1 if fadeIn and not self.point_target else 1
+        direction_modifier = -1 if fade_in and not self.point_target else 1
         faded_mobject.shift(self.shift_vector * direction_modifier)
         faded_mobject.scale(self.scale_factor)
         return faded_mobject
@@ -191,8 +191,8 @@ class FadeOut(_Fade):
         super().__init__(*mobjects, remover=True, **kwargs)
 
     def create_target(self):
-        return self._create_faded_mobject(fadeIn=False)
+        return self._create_faded_mobject(fade_in=False)
 
-    def clean_up_from_scene(self, scene: Scene = None) -> None:
-        super().clean_up_from_scene(scene)
+    def begin(self) -> None:
+        super().begin()
         self.interpolate(0)

--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -31,7 +31,6 @@ __all__ = [
     "Flash",
     "ShowPassingFlash",
     "ShowPassingFlashWithThinningStrokeWidth",
-    "ShowCreationThenFadeOut",
     "ApplyWave",
     "Circumscribe",
     "Wiggle",

--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -37,7 +37,7 @@ __all__ = [
     "Wiggle",
 ]
 
-from typing import Callable, Iterable, Optional, Tuple, Type, Union
+from typing import Callable, Iterable, Optional, Type, Union
 
 import numpy as np
 
@@ -305,7 +305,7 @@ class ShowPassingFlash(ShowPartial):
         self.time_width = time_width
         super().__init__(mobject, remover=True, introducer=True, **kwargs)
 
-    def _get_bounds(self, alpha: float) -> Tuple[float]:
+    def _get_bounds(self, alpha: float) -> tuple[float, float]:
         tw = self.time_width
         upper = interpolate(0, 1 + tw, alpha)
         lower = upper - tw
@@ -313,8 +313,8 @@ class ShowPassingFlash(ShowPartial):
         lower = max(lower, 0)
         return (lower, upper)
 
-    def clean_up_from_scene(self, scene: "Scene") -> None:
-        super().clean_up_from_scene(scene)
+    def finish(self) -> None:
+        super().finish()
         for submob, start in self.get_all_families_zipped():
             submob.pointwise_become_partial(start, 0, 1)
 
@@ -339,16 +339,6 @@ class ShowPassingFlashWithThinningStrokeWidth(AnimationGroup):
                 )
             ),
         )
-
-
-@deprecated(
-    since="v0.15.0",
-    until="v0.16.0",
-    message="Use Create then FadeOut to achieve this effect.",
-)
-class ShowCreationThenFadeOut(Succession):
-    def __init__(self, mobject: "Mobject", remover: bool = True, **kwargs) -> None:
-        super().__init__(Create(mobject), FadeOut(mobject), remover=remover, **kwargs)
 
 
 class ApplyWave(Homotopy):
@@ -469,7 +459,7 @@ class ApplyWave(Homotopy):
             y: float,
             z: float,
             t: float,
-        ) -> Tuple[float, float, float]:
+        ) -> tuple[float, float, float]:
             upper = interpolate(0, 1 + time_width, t)
             lower = upper - time_width
             relative_x = inverse_interpolate(x_min, x_max, x)
@@ -558,6 +548,7 @@ class Wiggle(Animation):
         )
 
 
+# TODO: get rid of this if condition madness
 class Circumscribe(Succession):
     """Draw a temporary line surrounding the mobject.
 

--- a/manim/animation/movement.py
+++ b/manim/animation/movement.py
@@ -18,7 +18,8 @@ from ..animation.animation import Animation
 from ..utils.rate_functions import linear
 
 if TYPE_CHECKING:
-    from ..mobject.mobject import Mobject, VMobject
+    from ..mobject.mobject import Mobject
+    from ..mobject.types.vectorized_mobject import VMobject
 
 
 class Homotopy(Animation):

--- a/manim/animation/protocol.py
+++ b/manim/animation/protocol.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, Sequence
+
+if TYPE_CHECKING:
+    from .animation import Animation
+    from .scene_buffer import SceneBuffer
+
+
+__all__ = ("AnimationProtocol",)
+
+
+class AnimationProtocol(Protocol):
+    buffer: SceneBuffer
+
+    def begin(self) -> None:
+        ...
+
+    def finish(self) -> None:
+        ...
+
+    def get_all_animations(self) -> Sequence[Animation]:
+        ...
+
+    def update_mobjects(self, dt: float) -> None:
+        ...
+
+    def interpolate(self, alpha: float) -> None:
+        ...
+
+    def get_run_time(self) -> float:
+        ...

--- a/manim/animation/scene_buffer.py
+++ b/manim/animation/scene_buffer.py
@@ -1,7 +1,6 @@
-from typing import TYPE_CHECKING, final
+from typing import final
 
-if TYPE_CHECKING:
-    from manim.mobject.opengl.opengl_mobject import OpenGLMobject as Mobject
+from manim.mobject.opengl.opengl_mobject import OpenGLMobject as Mobject
 
 
 __all__ = ["SceneBuffer"]

--- a/manim/animation/scene_buffer.py
+++ b/manim/animation/scene_buffer.py
@@ -22,6 +22,7 @@ class SceneBuffer:
     def __init__(self) -> None:
         self.to_remove: list[Mobject] = []
         self.to_add: list[Mobject] = []
+        self.to_replace: list[tuple[Mobject, ...]] = []
         self.deferred = False
 
     def add(self, *mobs: Mobject) -> None:
@@ -31,6 +32,10 @@ class SceneBuffer:
     def remove(self, *mobs: Mobject) -> None:
         self._check_deferred()
         self.to_remove.extend(mobs)
+
+    def replace(self, mob: Mobject, *replacements: Mobject) -> None:
+        self._check_deferred()
+        self.to_replace.append((mob, *replacements))
 
     def clear(self) -> None:
         self.to_remove.clear()

--- a/manim/animation/scene_buffer.py
+++ b/manim/animation/scene_buffer.py
@@ -2,7 +2,6 @@ from typing import final
 
 from manim.mobject.opengl.opengl_mobject import OpenGLMobject as Mobject
 
-
 __all__ = ["SceneBuffer"]
 
 

--- a/manim/animation/scene_buffer.py
+++ b/manim/animation/scene_buffer.py
@@ -1,0 +1,55 @@
+from typing import TYPE_CHECKING, final
+
+if TYPE_CHECKING:
+    from manim.mobject.opengl.opengl_mobject import OpenGLMobject as Mobject
+
+
+__all__ = ["SceneBuffer"]
+
+
+@final
+class SceneBuffer:
+    """
+    A "buffer" between :class:`.Scene` and :class:`.Animation`
+
+    Operations an animation wants to do on :class:`.Scene` should be
+    done here (eg. :meth:`.Scene.add`, :meth:`.Scene.remove`). The
+    scene will then apply these changes at specific points (namely
+    at the beginning and end of animations)
+
+    It is the scenes job to clear the buffer in between the beginning
+    and end of animations.
+    """
+
+    def __init__(self) -> None:
+        self.to_remove: list[Mobject] = []
+        self.to_add: list[Mobject] = []
+        self.deferred = False
+
+    def add(self, *mobs: Mobject) -> None:
+        self._check_deferred()
+        self.to_add.extend(mobs)
+
+    def remove(self, *mobs: Mobject) -> None:
+        self._check_deferred()
+        self.to_remove.extend(mobs)
+
+    def clear(self) -> None:
+        self.to_remove.clear()
+        self.to_add.clear()
+
+    def deferred_clear(self) -> None:
+        """Clear ``self`` on next operation"""
+        self.deferred = True
+
+    def _check_deferred(self) -> None:
+        if self.deferred:
+            self.clear()
+            self.deferred = False
+
+    def __str__(self) -> str:
+        to_add = self.to_add
+        to_remove = self.to_remove
+        return f"{type(self).__name__}({to_add=}, {to_remove=})"
+
+    __repr__ = __str__

--- a/manim/animation/speedmodifier.py
+++ b/manim/animation/speedmodifier.py
@@ -12,7 +12,6 @@ from manim.utils.simple_functions import get_parameters
 from ..animation.animation import Animation, Wait, prepare_animation
 from ..animation.composition import AnimationGroup
 from ..mobject.mobject import Mobject, Updater, _AnimationBuilder
-from ..scene.scene import Scene
 
 
 class ChangeSpeed(Animation):
@@ -284,9 +283,10 @@ class ChangeSpeed(Animation):
 
     def begin(self) -> None:
         self.anim.begin()
+        self.buffer.add(*self.anim.buffer.to_add)
+        self.buffer.remove(*self.anim.buffer.to_remove)
 
-    def clean_up_from_scene(self, scene: Scene) -> None:
-        self.anim.clean_up_from_scene(scene)
-
-    def _setup_scene(self, scene) -> None:
-        self.anim._setup_scene(scene)
+    def finish(self) -> None:
+        self.anim.finish()
+        self.buffer.add(*self.anim.buffer.to_add)
+        self.buffer.remove(*self.anim.buffer.to_remove)

--- a/manim/animation/speedmodifier.py
+++ b/manim/animation/speedmodifier.py
@@ -277,16 +277,11 @@ class ChangeSpeed(Animation):
     def update_mobjects(self, dt: float) -> None:
         self.anim.update_mobjects(dt)
 
+    def begin(self) -> None:
+        self.anim.begin()
+        self.process_subanimation_buffer(self.anim.buffer)
+
     def finish(self) -> None:
         ChangeSpeed.is_changing_dt = False
         self.anim.finish()
-
-    def begin(self) -> None:
-        self.anim.begin()
-        self.buffer.add(*self.anim.buffer.to_add)
-        self.buffer.remove(*self.anim.buffer.to_remove)
-
-    def finish(self) -> None:
-        self.anim.finish()
-        self.buffer.add(*self.anim.buffer.to_add)
-        self.buffer.remove(*self.anim.buffer.to_remove)
+        self.process_subanimation_buffer(self.anim.buffer)

--- a/manim/animation/transform.py
+++ b/manim/animation/transform.py
@@ -205,10 +205,13 @@ class Transform(Animation):
         # in subclasses
         return self.target_mobject
 
-    def clean_up_from_scene(self, scene: Scene) -> None:
-        super().clean_up_from_scene(scene)
+    def finish(self) -> None:
+        super().finish()
         if self.replace_mobject_with_target_in_scene:
-            scene.replace(self.mobject, self.target_mobject)
+            # Ideally this should stay at the same z-level as
+            # the original mobject, but this is difficult to implement
+            self.buffer.remove(self.mobject)
+            self.buffer.add(self.target_mobject)
 
     def get_all_mobjects(self) -> Sequence[Mobject]:
         return [
@@ -871,11 +874,11 @@ class FadeTransform(Transform):
     def get_all_families_zipped(self):
         return Animation.get_all_families_zipped(self)
 
-    def clean_up_from_scene(self, scene):
-        Animation.clean_up_from_scene(self, scene)
-        scene.remove(self.mobject)
+    def finish(self):
+        Animation.finish(self)  # TODO: is this really needed over super()?
+        self.buffer.remove(self.mobject)
         self.mobject[0].restore()
-        scene.add(self.to_add_on_completion)
+        self.buffer.add(self.to_add_on_completion)
 
 
 class FadeTransformPieces(FadeTransform):

--- a/manim/animation/transform_matching_parts.py
+++ b/manim/animation/transform_matching_parts.py
@@ -19,9 +19,6 @@ from .composition import AnimationGroup
 from .fading import FadeIn, FadeOut
 from .transform import FadeTransformPieces, Transform
 
-if TYPE_CHECKING:
-    from ..scene.scene import Scene
-
 
 class TransformMatchingAbstractBase(AnimationGroup):
     """Abstract base class for transformations that keep track of matching parts.
@@ -153,13 +150,14 @@ class TransformMatchingAbstractBase(AnimationGroup):
             shape_map[key].add(sm)
         return shape_map
 
-    def clean_up_from_scene(self, scene: Scene) -> None:
+    def finish(self) -> None:
+        super().finish()
         # Interpolate all animations back to 0 to ensure source mobjects remain unchanged.
         for anim in self.animations:
             anim.interpolate(0)
-        scene.remove(self.mobject)
-        scene.remove(*self.to_remove)
-        scene.add(self.to_add)
+        self.buffer.remove(self.mobject)
+        self.buffer.remove(*self.to_remove)
+        self.buffer.add(self.to_add)
 
     @staticmethod
     def get_mobject_parts(mobject: Mobject):

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -133,6 +133,7 @@ class Scene:
     def process_buffer(self, buffer: SceneBuffer) -> None:
         self.remove(*buffer.to_remove)
         self.add(*buffer.to_add)
+        buffer.clear()
 
     def run(self) -> None:
         self.virtual_animation_start_time: float = 0

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -688,7 +688,6 @@ class Scene:
             for animation in animation_obj.get_all_animations():
                 animation.begin()
                 self.process_buffer(animation.buffer)
-                animation.buffer.clear()
 
                 # Anything animated that's not already in the
                 # scene gets added to the scene.  Note, for

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -132,6 +132,8 @@ class Scene:
 
     def process_buffer(self, buffer: SceneBuffer) -> None:
         self.remove(*buffer.to_remove)
+        for to_replace_pairs in buffer.to_replace:
+            self.replace(*to_replace_pairs)
         self.add(*buffer.to_add)
         buffer.clear()
 

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -21,25 +21,24 @@ from manim.constants import DEFAULT_WAIT_TIME
 from manim.event_handler import EVENT_DISPATCHER
 from manim.event_handler.event_type import EventType
 from manim.mobject.frame import FullScreenRectangle
-from manim.mobject.mobject import Group, Mobject, Point, _AnimationBuilder
+from manim.mobject.mobject import Group, Point, _AnimationBuilder
+from manim.mobject.opengl.opengl_mobject import OpenGLMobject as Mobject
 from manim.mobject.types.vectorized_mobject import VGroup, VMobject
 from manim.scene.scene_file_writer import SceneFileWriter
 from manim.utils.color import RED
-from manim.utils.family_ops import (
-    extract_mobject_family_members,
-    recursive_mobject_remove,
-)
+from manim.utils.family_ops import extract_mobject_family_members
 from manim.utils.iterables import list_difference_update
 from manim.utils.module_ops import get_module
 
 if TYPE_CHECKING:
-    from typing import Callable, Iterable
+    from typing import Any, Callable, Iterable
 
     from PIL.Image import Image
 
-    from manim.animation.animation import Animation
+    from manim.animation.protocol import AnimationProtocol as Animation
+    from manim.animation.scene_buffer import SceneBuffer
 
-## TODO: these keybindings should be made configureable
+# TODO: these keybindings should be made configureable
 
 PAN_3D_KEY = "d"
 FRAME_SHIFT_KEY = "f"
@@ -130,6 +129,10 @@ class Scene:
 
     def __str__(self) -> str:
         return self.__class__.__name__
+
+    def process_buffer(self, buffer: SceneBuffer) -> None:
+        self.remove(*buffer.to_remove)
+        self.add(*buffer.to_add)
 
     def run(self) -> None:
         self.virtual_animation_start_time: float = 0
@@ -347,7 +350,7 @@ class Scene:
         return any(
             [
                 sm.has_time_based_updater()
-                for mob in self.mobjects()
+                for mob in self.mobjects
                 for sm in mob.get_family()
             ]
         )
@@ -629,7 +632,7 @@ class Scene:
             return times
 
     def get_run_time(self, animations: Iterable[Animation]) -> float:
-        return np.max([animation.get_run_time() for animation in animations])
+        return max([animation.get_run_time() for animation in animations])
 
     def get_animation_time_progression(
         self, animations: Iterable[Animation]
@@ -645,7 +648,7 @@ class Scene:
     def get_wait_time_progression(
         self, duration: float, stop_condition: Callable[[], bool] | None = None
     ) -> list[float] | np.ndarray | ProgressDisplay:
-        kw = {"desc": f"{self.num_plays} Waiting"}
+        kw: dict[str, Any] = {"desc": f"{self.num_plays} Waiting"}
         if stop_condition is not None:
             kw["n_iterations"] = -1  # So it doesn't show % progress
             kw["override_skip_animations"] = True
@@ -680,15 +683,19 @@ class Scene:
         self.camera.refresh_static_mobjects()
 
     def begin_animations(self, animations: Iterable[Animation]) -> None:
-        for animation in animations:
-            animation.begin()
-            # Anything animated that's not already in the
-            # scene gets added to the scene.  Note, for
-            # animated mobjects that are in the family of
-            # those on screen, this can result in a restructuring
-            # of the scene.mobjects list, which is usually desired.
-            if animation.mobject not in self.mobjects:
-                self.add(animation.mobject)
+        for animation_obj in animations:
+            for animation in animation_obj.get_all_animations():
+                animation.begin()
+                self.process_buffer(animation.buffer)
+                animation.buffer.clear()
+
+                # Anything animated that's not already in the
+                # scene gets added to the scene.  Note, for
+                # animated mobjects that are in the family of
+                # those on screen, this can result in a restructuring
+                # of the scene.mobjects list, which is usually desired.
+                if animation.is_introducer and animation.mobject not in self.mobjects:
+                    self.add(animation.mobject)
 
     def progress_through_animations(self, animations: Iterable[Animation]) -> None:
         last_t = 0
@@ -697,7 +704,7 @@ class Scene:
             last_t = t
             for animation in animations:
                 animation.update_mobjects(dt)
-                alpha = t / animation.run_time
+                alpha = t / animation.get_run_time()
                 animation.interpolate(alpha)
             self.update_frame(dt)
             self.emit_frame()
@@ -705,7 +712,8 @@ class Scene:
     def finish_animations(self, animations: Iterable[Animation]) -> None:
         for animation in animations:
             animation.finish()
-            animation.clean_up_from_scene(self)
+            self.process_buffer(animation.buffer)
+
         if self.skip_animations:
             self.update_mobjects(self.get_run_time(animations))
         else:
@@ -721,7 +729,7 @@ class Scene:
         if len(proto_animations) == 0:
             log.warning("Called Scene.play with no animations")
             return
-        animations = list(map(prepare_animation, proto_animations))
+        animations = tuple(map(prepare_animation, proto_animations))
         for anim in animations:
             anim.update_rate_info(run_time, rate_func, lag_ratio)
         self.pre_play()
@@ -986,8 +994,8 @@ class SceneState:
             else:
                 self.mobjects_to_copies[mob] = mob.copy()
 
-    def __eq__(self, state: SceneState):
-        return all(
+    def __eq__(self, state: object) -> bool:
+        return isinstance(state, SceneState) and all(
             (
                 self.time == state.time,
                 self.num_plays == state.num_plays,


### PR DESCRIPTION
## Motivation
* The long term goal of experimental is to render animations in parallel
   * A big part of this is removing the direct usage of `Scene` in an `Animation`.
* Also, it helps to be able to know the bare minimum amount of methods needed to animate something, so I got started with a simple `AnimationProtocol`.
 
## Implementation
**TL;DR**: an `Animation` stores what actions it wants to do to the Scene. During the start of the animation and end of animation, the `Scene` checks those actions and applies them.

**Long Explanation**: attached to each `Animation` object is a `buffer` attribute (of type `SceneBuffer`: you can think of this as an extremely simplified proxy of `Scene` that stores `add` and `remove` operations). Whenever an animation wants to, say add a mobject to the scene they would do `self.buffer.add(Square())`.
For each animation in a `self.play` call, the `Scene` will call the begin method and then "apply the buffer." It is at this time that the adding/removing of mobjects actually happens. Likewise with when the animation finishes.

## TODO
- [X] Implement core `SceneBuffer` stuff
- [x] Fix subclasses
- [x] Finish `AnimationProtocol`

Note: I deleted the branch of #3685 and renamed it to animation-scene. Sorry for the duplicate notifications!