### PR TITLE
fix(copyright): automate copyright updating for docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 import sys
+from datetime import datetime
 from pathlib import Path
 
 import manim
@@ -25,7 +26,7 @@ sys.path.insert(0, os.path.abspath("."))
 # -- Project information -----------------------------------------------------
 
 project = "Manim"
-copyright = "2020-2022, The Manim Community Dev Team"
+copyright = f"2020-{datetime.now().year}, The Manim Community Dev Team"
 author = "The Manim Community Dev Team"
 
 


### PR DESCRIPTION
The copyright on the docs is from 2022. This PR automates updating of the copyright date via a `datetime` object.

https://manimce--3708.org.readthedocs.build/en/3708/