### PR TITLE
Fixed docstring markup in `Rotate`

### DIFF
--- a/manim/animation/rotation.py
+++ b/manim/animation/rotation.py
@@ -59,7 +59,7 @@ class Rotate(Transform):
     about_point
         The rotation center.
     about_edge
-        If ``about_point``is ``None``, this argument specifies
+        If ``about_point`` is ``None``, this argument specifies
         the direction of the bounding box point to be taken as
         the rotation center.
 


### PR DESCRIPTION
Fixes currently broken [docs](https://docs.manim.community/en/stable/reference/manim.animation.rotation.Rotate.html).

![Screenshot from 2024-04-24 06-05-01](https://github.com/ManimCommunity/manim/assets/7880569/bee40bc7-4f18-41ee-a824-b91590352407)
