### PR TITLE
Fixing SpiralLn Not Showing First Element

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,19 +1,3 @@
-# This file is automatically picked by pytest
-# while running tests. So, that each test is
-# run on difference temporary directories and avoiding
-# errors.
-
-from __future__ import annotations
-
-try:
-    # https://github.com/moderngl/moderngl/issues/517
-    import readline  # required to prevent a segfault on Python 3.10
-except ModuleNotFoundError:  # windows
-    pass
-
-import cairo
-import moderngl
-
 # If it is running Doctest the current directory
 # is changed because it also tests the config module
 # itself. If it's a normal test then it uses the

--- a/manim/animation/creation.py
+++ b/manim/animation/creation.py
@@ -486,8 +486,8 @@ class SpiralIn(Animation):
             )
             shape.rotate(TAU * alpha, about_point=self.shape_center)
             shape.rotate(-TAU * alpha, about_point=shape.get_center_of_mass())
-            shape.set_fill_opacity(new_fill_opacity)
-            shape.set_stroke_opacity(new_stroke_opacity)
+            shape.set_fill(opacity=new_fill_opacity)
+            shape.set_stroke(opacity=new_stroke_opacity)
 
 
 class ShowIncreasingSubsets(Animation):

--- a/manim/animation/creation.py
+++ b/manim/animation/creation.py
@@ -476,12 +476,18 @@ class SpiralIn(Animation):
         for shape in self.shapes:
             shape.restore()
             shape.save_state()
-            opacity = shape.get_fill_opacity()
-            new_opacity = min(opacity, alpha * opacity / self.fade_in_fraction)
-            shape.shift((shape.final_position - shape.initial_position) * alpha)
+            fill_opacity = shape.get_fill_opacity() or 1
+            stroke_opacity = shape.get_stroke_opacity() or 1
+            new_fill_opacity = min(
+                fill_opacity, alpha * fill_opacity / self.fade_in_fraction
+            )
+            new_stroke_opacity = min(
+                stroke_opacity, alpha * stroke_opacity / self.fade_in_fraction
+            )
             shape.rotate(TAU * alpha, about_point=self.shape_center)
             shape.rotate(-TAU * alpha, about_point=shape.get_center_of_mass())
-            shape.set_opacity(new_opacity)
+            shape.set_fill_opacity(new_fill_opacity)
+            shape.set_stroke_opacity(new_stroke_opacity)
 
 
 class ShowIncreasingSubsets(Animation):


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
This change begins in line 479 of creation.py and ends on line 490.  This change fixes a problem with the opacity related to the element.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
This fixes the opacity issue by splitting the opacity by fill opacity and stroke opacity.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
