### PR TITLE
Set axis colors for Axes class to passed in values; set default axis color to BLACK if no numbers given

### DIFF
--- a/manim/mobject/graphing/coordinate_systems.py
+++ b/manim/mobject/graphing/coordinate_systems.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, TypeVar, ov
 import numpy as np
 from typing_extensions import Self
 
-from manim import config
+from manim import color, config
 from manim.constants import *
 from manim.mobject.geometry.arc import Circle, Dot
 from manim.mobject.geometry.line import Arrow, DashedLine, Line
@@ -410,7 +410,6 @@ class CoordinateSystem:
         """
 
         self.coordinate_labels = VGroup()
-        # if nothing is passed to axes_numbers, produce axes with default labelling
         if not axes_numbers:
             axes_numbers = [None for _ in range(self.dimension)]
 
@@ -1870,6 +1869,17 @@ class Axes(VGroup, CoordinateSystem, metaclass=ConvertToOpenGL):
             self.axis_config,
             self.y_axis_config,
         )
+
+        if "color" in axis_config:
+            self.axis_config["color"] = axis_config["color"]
+        if "color" in x_axis_config:
+            self.x_axis_config["color"] = x_axis_config["color"]
+        if "color" in y_axis_config:
+            self.y_axis_config["color"] = y_axis_config["color"]
+        if "color" not in self.x_axis_config:
+            self.x_axis_config["color"] = color.BLACK
+        if "color" not in self.y_axis_config:
+            self.y_axis_config["color"] = color.BLACK
 
         # excluding the origin tick removes a tick at the 0-point of the axis
         # This is desired for LinearBase because the 0 point is always the x-axis

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 import numpy as np
 
-from manim import config
+from manim import color, config
 from manim.constants import *
 from manim.mobject.geometry.line import Line
 from manim.mobject.graphing.scale import LinearBase, _ScaleBase
@@ -480,6 +480,14 @@ class NumberLine(Line):
 
     def get_number_mobjects(self, *numbers, **kwargs) -> VGroup:
         if len(numbers) == 0:
+            # Ensure that the color for the labels is set to black
+            self.decimal_number_config["color"] = color.BLACK
+
+            # Now when the configurations are merged, the color will be set to black
+            number_config = merge_dicts_recursively(
+                self.decimal_number_config,
+                number_config,
+            )
             numbers = self.default_numbers_to_display()
         return VGroup([self.get_number_mobject(number, **kwargs) for number in numbers])
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
The first change is in lines 1873-1882 of coordinate_systems.py. The second change is in Ines 484-490 of number_line.py. This pull request attempts to fix that Axes does not respect the parameters passed in, specifically pertaining to color. 
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Resolve #3633 . These changes attempt to fix an issue within the initialization of the Axes class in which the axis_config attributes are not accurately set. To account for color not being displayed as per issue 3633, the changes set the color to the parameters passed in, and also set the default color to BLACK if no numbers are given. 

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
