### PR TITLE
build(ci): change from macos-latest to macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-13, windows-latest]
         python: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:


### PR DESCRIPTION
Hopefully :crossed_fingers: this fixes the MacOS pipeline.
Basically, our setup-ffmpeg action does not support ARM, and `macos-latest` uses Mac 14 which is ARM only.