### PR TITLE
Add `Tuple` to `manim/typing.py`

### DIFF
--- a/manim/typing.py
+++ b/manim/typing.py
@@ -21,7 +21,7 @@
 from __future__ import annotations
 
 from os import PathLike
-from typing import Callable, Union
+from typing import Callable, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt


### PR DESCRIPTION
Fixes https://github.com/ManimCommunity/manim/pull/3719#issuecomment-2081482865

`manim/typing.py`
```diff
- from typing import Callable, Union
+ from typing import Callable, Tuple, Union
```