### PR TITLE
Optimized `manim.utils.bezier.is_closed()`

### DIFF
--- a/manim/utils/bezier.py
+++ b/manim/utils/bezier.py
@@ -701,6 +701,46 @@ def is_closed(points: Point3D_Array) -> bool:
         Whether the first and last points of the array are close enough or not
         to be considered the same, thus considering the defined spline as
         closed.
+
+    Examples
+    --------
+    .. code-block:: pycon
+
+        >>> import numpy as np
+        >>> from manim import is_closed
+        >>> is_closed(
+        ...     np.array(
+        ...         [
+        ...             [0, 0, 0],
+        ...             [1, 2, 3],
+        ...             [3, 2, 1],
+        ...             [0, 0, 0],
+        ...         ]
+        ...     )
+        ... )
+        True
+        >>> is_closed(
+        ...     np.array(
+        ...         [
+        ...             [0, 0, 0],
+        ...             [1, 2, 3],
+        ...             [3, 2, 1],
+        ...             [1e-10, 1e-10, 1e-10],
+        ...         ]
+        ...     )
+        ... )
+        True
+        >>> is_closed(
+        ...     np.array(
+        ...         [
+        ...             [0, 0, 0],
+        ...             [1, 2, 3],
+        ...             [3, 2, 1],
+        ...             [1e-2, 1e-2, 1e-2],
+        ...         ]
+        ...     )
+        ... )
+        False
     """
     start, end = points[0], points[-1]
     rtol = 1e-5

--- a/manim/utils/bezier.py
+++ b/manim/utils/bezier.py
@@ -681,7 +681,38 @@ def get_quadratic_approximation_of_cubic(
 
 
 def is_closed(points: Point3D_Array) -> bool:
-    return np.allclose(points[0], points[-1])  # type: ignore
+    """Returns ``True`` if the spline given by ``points`` is closed, by
+    checking if its first and last points are close to each other, or``False``
+    otherwise.
+
+    .. note::
+
+        This function reimplements :meth:`np.allclose`, because repeated
+        calling of :meth:`np.allclose` for only 2 points is inefficient.
+
+    Parameters
+    ----------
+    points
+        An array of points defining a spline.
+
+    Returns
+    -------
+    :class:`bool`
+        Whether the first and last points of the array are close enough or not
+        to be considered the same, thus considering the defined spline as
+        closed.
+    """
+    start, end = points[0], points[-1]
+    rtol = 1e-5
+    atol = 1e-8
+    np.allclose()
+    if abs(end[0] - start[0]) > atol + rtol * start[0]:
+        return False
+    if abs(end[1] - start[1]) > atol + rtol * start[1]:
+        return False
+    if abs(end[2] - start[2]) > atol + rtol * start[2]:
+        return False
+    return True
 
 
 def proportions_along_bezier_curve_for_point(

--- a/manim/utils/bezier.py
+++ b/manim/utils/bezier.py
@@ -705,11 +705,12 @@ def is_closed(points: Point3D_Array) -> bool:
     start, end = points[0], points[-1]
     rtol = 1e-5
     atol = 1e-8
-    if abs(end[0] - start[0]) > atol + rtol * start[0]:
+    tolerance = atol + rtol * start
+    if abs(end[0] - start[0]) > tolerance[0]:
         return False
-    if abs(end[1] - start[1]) > atol + rtol * start[1]:
+    if abs(end[1] - start[1]) > tolerance[1]:
         return False
-    if abs(end[2] - start[2]) > atol + rtol * start[2]:
+    if abs(end[2] - start[2]) > tolerance[2]:
         return False
     return True
 

--- a/manim/utils/bezier.py
+++ b/manim/utils/bezier.py
@@ -705,7 +705,6 @@ def is_closed(points: Point3D_Array) -> bool:
     start, end = points[0], points[-1]
     rtol = 1e-5
     atol = 1e-8
-    np.allclose()
     if abs(end[0] - start[0]) > atol + rtol * start[0]:
         return False
     if abs(end[1] - start[1]) > atol + rtol * start[1]:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Related PRs: #3281, #3767

In `manim.utils.bezier`, in the function `is_closed()`, repeatedly using `np.allclose()` to compare only two 3D points each time is actually very expensive and takes a significant part of the total time of `get_smooth_handle_points()`. **So I rewrote it to simply "compare 1st coords, then compare 2nd coords, then compare 3rd coords", which resulted in a 5x speedup.**

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
