### PR TITLE
Recommend pipx for MacOS users

### DIFF
--- a/docs/source/installation/macos.rst
+++ b/docs/source/installation/macos.rst
@@ -25,7 +25,7 @@ and some required Python packages), run:
 
 .. code-block:: bash
 
-   brew install py3cairo
+   brew install py3cairo pipx
 
 On *Apple Silicon* based machines (i.e., devices with the M1 chip or similar; if
 you are unsure which processor you have check by opening the Apple menu, select
@@ -40,7 +40,7 @@ After all required dependencies are installed, simply run:
 
 .. code-block:: bash
 
-   pip3 install manim
+   pipx install manim
 
 to install Manim.
 


### PR DESCRIPTION
Closes #3656 

Taking inspiration from the [homebrew docs](https://docs.brew.sh/Homebrew-and-Python#pep-668-python312-and-virtual-environments), I changed the installation instructions for macOS to use `pipx`. For most users, this should be enough.