### PR TITLE
Fixed `there_and_back_with_pause()` rate function behaviour with different `pause_ratio` values

### DIFF
--- a/manim/utils/rate_functions.py
+++ b/manim/utils/rate_functions.py
@@ -217,7 +217,7 @@ def there_and_back(t: float, inflection: float = 10.0) -> float:
 
 @zero
 def there_and_back_with_pause(t: float, pause_ratio: float = 1.0 / 3) -> float:
-    a = 1.0 / pause_ratio
+    a = 2.0 / (1.0 - pause_ratio)
     if t < 0.5 - pause_ratio / 2:
         return smooth(a * t)
     elif t < 0.5 + pause_ratio / 2:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->

fix the behaviour of `there_and_back_with_pause` when setting `pause_ratio` with other values. 

<!--changelog-start-->

<!--changelog-end-->

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

the picture below shows the bug of `there_and_back_with_pause` (left), and the corrected result (right)

![image](https://github.com/ManimCommunity/manim/assets/52841865/029ddc6b-ddcc-4e5f-bfb9-a9712b69d955)

this picture is generated by the following code:

```python
# In[]
import matplotlib.pyplot as plt
import numpy as np
from matplotlib.axes import Axes


def sigmoid(x: float) -> float:
    return 1.0 / (1 + np.exp(-x))


def smooth(t: float, inflection: float = 10.0) -> float:
    error = sigmoid(-inflection / 2)
    return min(
        max((sigmoid(inflection * (t - 0.5)) - error) / (1 - 2 * error), 0),
        1,
    )


def there_and_back_with_pause(t: float, pause_ratio: float = 1.0 / 3) -> float:
    a = 1.0 / pause_ratio
    if t < 0.5 - pause_ratio / 2:
        return smooth(a * t)
    elif t < 0.5 + pause_ratio / 2:
        return 1
    else:
        return smooth(a - a * t)


def there_and_back_with_pause_corrected(t: float, pause_ratio: float = 1.0 / 3) -> float:
    a = 2.0 / (1.0 - pause_ratio)
    if t < 0.5 - pause_ratio / 2:
        return smooth(a * t)
    elif t < 0.5 + pause_ratio / 2:
        return 1
    else:
        return smooth(a - a * t)


def plot(axes: Axes, func, pause_ratio: float, aspect_eq=True) -> None:
    axes.set_title(f'...{func.__name__[14:]}(t, pause_ratio={pause_ratio:.3f})',
                   fontsize=9)
    axes.set_aspect('equal')
    x = np.linspace(0, 1, 100)
    y = [func(v, pause_ratio=pause_ratio) for v in x]
    axes.scatter(x, y, s=3)


fig = plt.figure(figsize=(10, 10))

plot(fig.add_subplot(4, 2, 1), there_and_back_with_pause, 0.1)
plot(fig.add_subplot(4, 2, 3), there_and_back_with_pause, 1 / 3)
plot(fig.add_subplot(4, 2, 5), there_and_back_with_pause, 0.5)
plot(fig.add_subplot(4, 2, 7), there_and_back_with_pause, 0.8)

plot(fig.add_subplot(4, 2, 2), there_and_back_with_pause_corrected, 0.1)
plot(fig.add_subplot(4, 2, 4), there_and_back_with_pause_corrected, 1 / 3)
plot(fig.add_subplot(4, 2, 6), there_and_back_with_pause_corrected, 0.5)
plot(fig.add_subplot(4, 2, 8), there_and_back_with_pause_corrected, 0.8)

fig.tight_layout()
fig.subplots_adjust(wspace=-0.6)
fig.show()

# %%
```

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
