### PR TITLE
configure codespell in pyproject

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,4 +72,6 @@ repos:
     hooks:
       - id: codespell
         files: ^.*\.(py|md|rst)$
-        args: ["-L", "medias,nam"]
+        # remove this after minimum python is >=3.11
+        additional_dependencies:
+          - tomli


### PR DESCRIPTION
#3777 added codespell configuration in `pyproject.toml`. This ports it to python versions < 3.11 (see [here](https://github.com/codespell-project/codespell?tab=readme-ov-file#using-a-config-file))