### PR TITLE
Fixing the `get_nth_subpath` function in "opengl_vectorized_mobject.py".

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: python-check-blanket-noqa
         name: Precision flake ignores
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.4.5
     hooks:
       - id: ruff-format
         types: [python]
@@ -68,7 +68,7 @@ repos:
         files: ^manim/
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         files: ^.*\.(py|md|rst)$

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -126,7 +126,7 @@ class SceneFileWriter:
                 self.output_name, config["movie_file_extension"]
             )
 
-            # TODO: /dev/null would be good in case sections_output_dir is used without bein set (doesn't work on Windows), everyone likes defensive programming, right?
+            # TODO: /dev/null would be good in case sections_output_dir is used without being set (doesn't work on Windows), everyone likes defensive programming, right?
             self.sections_output_dir = Path("")
             if config.save_sections:
                 self.sections_output_dir = guarantee_existence(


### PR DESCRIPTION
The `insert_n_curves_to_point_list` function requires the `points` argument to be a numpy array, since it calls the `get_bezier_tuples_from_points` function, which requires `points` to be a numpy array because it has the `return points.reshape((-1, nppc, 3))` statement. Ordinary lists do not have a `reshape` method.

So we need to convert `sp1` and `sp2` to numpy arrays before calling the `insert_n_curves_to_point_list` function.


## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
I fixed the `get_nth_subpath` function, so it will work with the opengl renderer.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
