### PR TITLE
Replace Pyupgrade with Ruff rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,6 @@ repos:
       - id: end-of-file-fixer
       - id: check-toml
         name: Validate Poetry
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
-    hooks:
-      - id: pyupgrade
-        name: Update code to new python versions
-        args: [--py39-plus]
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/manim/mobject/geometry/boolean_ops.py
+++ b/manim/mobject/geometry/boolean_ops.py
@@ -142,7 +142,7 @@ class _BooleanOps(VMobject, metaclass=ConvertToOpenGL):
                 n1, n2 = self._convert_2d_to_3d_array(points)
                 vmobject.add_quadratic_bezier_curve_to(n1, n2)
             else:
-                raise Exception("Unsupported: %s" % path_verb)
+                raise Exception(f"Unsupported: {path_verb}")
         return vmobject
 
 

--- a/manim/mobject/graphing/scale.py
+++ b/manim/mobject/graphing/scale.py
@@ -182,7 +182,7 @@ class LogBase(_ScaleBase):
         tex_labels = [
             Integer(
                 self.base,
-                unit="^{%s}" % (f"{self.inverse_function(i):.{unit_decimal_places}f}"),
+                unit="^{%s}" % (f"{self.inverse_function(i):.{unit_decimal_places}f}"),  # noqa: UP031
                 **base_config,
             )
             for i in val_range

--- a/manim/mobject/graphing/scale.py
+++ b/manim/mobject/graphing/scale.py
@@ -182,10 +182,8 @@ class LogBase(_ScaleBase):
         tex_labels = [
             Integer(
                 self.base,
-                unit="^{:.{prec}f}".format(
-                    self.inverse_function(i), prec=unit_decimal_places
-                )
-                ** base_config,
+                unit="^{%s}" % (f"{self.inverse_function(i):.{unit_decimal_places}f}"),  # noqa: UP031
+                **base_config,
             )
             for i in val_range
         ]

--- a/manim/mobject/graphing/scale.py
+++ b/manim/mobject/graphing/scale.py
@@ -182,7 +182,7 @@ class LogBase(_ScaleBase):
         tex_labels = [
             Integer(
                 self.base,
-                unit="^{%s}" % (f"{self.inverse_function(i):.{unit_decimal_places}f}"),  # noqa: UP031
+                unit="^{:.{prec}f}".format(self.inverse_function(i), prec=unit_decimal_places)
                 **base_config,
             )
             for i in val_range

--- a/manim/mobject/graphing/scale.py
+++ b/manim/mobject/graphing/scale.py
@@ -182,8 +182,10 @@ class LogBase(_ScaleBase):
         tex_labels = [
             Integer(
                 self.base,
-                unit="^{:.{prec}f}".format(self.inverse_function(i), prec=unit_decimal_places)
-                **base_config,
+                unit="^{:.{prec}f}".format(
+                    self.inverse_function(i), prec=unit_decimal_places
+                )
+                ** base_config,
             )
             for i in val_range
         ]

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -2659,12 +2659,7 @@ class OpenGLMobject:
             glsl_snippet = glsl_snippet.replace(char, "point." + char)
         rgb_list = get_colormap_list(colormap)
         self.set_color_by_code(
-            "color.rgb = float_to_color({}, {}, {}, {});".format(
-                glsl_snippet,
-                float(min_value),
-                float(max_value),
-                get_colormap_code(rgb_list),
-            ),
+            f"color.rgb = float_to_color({glsl_snippet}, {float(min_value)}, {float(max_value)}, {get_colormap_code(rgb_list)});",
         )
         return self
 

--- a/manim/mobject/text/tex_mobject.py
+++ b/manim/mobject/text/tex_mobject.py
@@ -175,8 +175,8 @@ class SingleStringMathTex(SVGMobject):
         tex = self._remove_stray_braces(tex)
 
         for context in ["array"]:
-            begin_in = ("\\begin{%s}" % context) in tex
-            end_in = ("\\end{%s}" % context) in tex
+            begin_in = ("\\begin{%s}" % context) in tex  # noqa: UP031
+            end_in = ("\\end{%s}" % context) in tex  # noqa: UP031
             if begin_in ^ end_in:
                 # Just turn this into a blank string,
                 # which means caller should leave a

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -2308,7 +2308,7 @@ class VDict(VMobject, metaclass=ConvertToOpenGL):
             my_dict.remove("square")
         """
         if key not in self.submob_dict:
-            raise KeyError("The given key '%s' is not present in the VDict" % str(key))
+            raise KeyError(f"The given key '{key!s}' is not present in the VDict")
         super().remove(self.submob_dict[key])
         del self.submob_dict[key]
         return self

--- a/manim/scene/vector_space_scene.py
+++ b/manim/scene/vector_space_scene.py
@@ -297,7 +297,7 @@ class VectorScene(Scene):
         """
         if not isinstance(label, MathTex):
             if len(label) == 1:
-                label = "\\vec{\\textbf{%s}}" % label
+                label = "\\vec{\\textbf{%s}}" % label  # noqa: UP031
             label = MathTex(label)
             if color is None:
                 color = vector.get_color()
@@ -904,9 +904,8 @@ class LinearTransformationScene(VectorScene):
         if new_label:
             label_mob.target_text = new_label
         else:
-            label_mob.target_text = "{}({})".format(
-                transformation_name,
-                label_mob.get_tex_string(),
+            label_mob.target_text = (
+                f"{transformation_name}({label_mob.get_tex_string()})"
             )
         label_mob.vector = vector
         label_mob.kwargs = kwargs

--- a/manim/utils/docbuild/autocolor_directive.py
+++ b/manim/utils/docbuild/autocolor_directive.py
@@ -38,7 +38,7 @@ class ManimColorModuleDocumenter(Directive):
             return [
                 nodes.error(
                     None,
-                    nodes.paragraph(text="Failed to import module '%s'" % module_name),
+                    nodes.paragraph(text=f"Failed to import module '{module_name}'"),
                 )
             ]
 

--- a/manim/utils/docbuild/manim_directive.py
+++ b/manim/utils/docbuild/manim_directive.py
@@ -355,7 +355,7 @@ def _write_rendering_stats(scene_name: str, run_time: str, file_name: str) -> No
             [
                 re.sub(r"^(reference\/)|(manim\.)", "", file_name),
                 scene_name,
-                "%.3f" % run_time,
+                f"{run_time:.3f}",
             ],
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ select = [
   "E",
   "F",
   "I",
+  "UP",
 ]
 
 ignore = [


### PR DESCRIPTION
This PR replaces the pre-commit hook `pyupgrade` with the respective rules in the ruff linter.