### PR TITLE
Improve `Updater` signature checks for substantial speedups, add `UpdaterWrappers` and more `Updater` aliases

### DIFF
--- a/docs/source/reference_index/utilities_misc.rst
+++ b/docs/source/reference_index/utilities_misc.rst
@@ -31,3 +31,4 @@ Module Index
    ~utils.tex_file_writing
    ~utils.tex_templates
    typing
+   ~utils.updaters

--- a/manim/animation/speedmodifier.py
+++ b/manim/animation/speedmodifier.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-import inspect
 import types
 from typing import TYPE_CHECKING, Callable
 
 from numpy import piecewise
 
-from ..animation.animation import Animation, Wait, prepare_animation
-from ..animation.composition import AnimationGroup
-from ..mobject.mobject import Mobject, _AnimationBuilder
-from ..scene.scene import Scene
+from manim.animation.animation import Animation, Wait, prepare_animation
+from manim.animation.composition import AnimationGroup
+from manim.mobject.mobject import Mobject, _AnimationBuilder
+from manim.scene.scene import Scene
+from manim.utils.updaters import MobjectUpdaterWrapper
 
 if TYPE_CHECKING:
-    from ..mobject.mobject import Updater
+    from manim.utils.updaters import MobjectUpdater
 
 __all__ = ["ChangeSpeed"]
 
@@ -235,7 +235,7 @@ class ChangeSpeed(Animation):
     def add_updater(
         cls,
         mobject: Mobject,
-        update_function: Updater,
+        update_function: MobjectUpdater,
         index: int | None = None,
         call_updater: bool = False,
     ):
@@ -264,7 +264,8 @@ class ChangeSpeed(Animation):
         :class:`.ChangeSpeed`
         :meth:`.Mobject.add_updater`
         """
-        if "dt" in inspect.signature(update_function).parameters:
+        wrapper = MobjectUpdaterWrapper(update_function)
+        if wrapper.is_time_based:
             mobject.add_updater(
                 lambda mob, dt: update_function(
                     mob, ChangeSpeed.dt if ChangeSpeed.is_changing_dt else dt

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -6,7 +6,6 @@ __all__ = ["Mobject", "Group", "override_animate"]
 
 
 import copy
-import inspect
 import itertools as it
 import math
 import operator as op
@@ -14,18 +13,17 @@ import random
 import sys
 import types
 import warnings
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from functools import partialmethod, reduce
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Literal
 
 import numpy as np
 
+from manim import config, logger
+from manim.constants import *
 from manim.mobject.opengl.opengl_compatibility import ConvertToOpenGL
-
-from .. import config, logger
-from ..constants import *
-from ..utils.color import (
+from manim.utils.color import (
     BLACK,
     WHITE,
     YELLOW_C,
@@ -34,13 +32,14 @@ from ..utils.color import (
     color_gradient,
     interpolate_color,
 )
-from ..utils.exceptions import MultiAnimationOverrideException
-from ..utils.iterables import list_update, remove_list_redundancies
-from ..utils.paths import straight_path
-from ..utils.space_ops import angle_between_vectors, normalize, rotation_matrix
+from manim.utils.exceptions import MultiAnimationOverrideException
+from manim.utils.iterables import list_update, remove_list_redundancies
+from manim.utils.paths import straight_path
+from manim.utils.space_ops import angle_between_vectors, normalize, rotation_matrix
+from manim.utils.updaters import MobjectUpdaterWrapper
 
 if TYPE_CHECKING:
-    from typing_extensions import Self, TypeAlias
+    from typing_extensions import Self
 
     from manim.typing import (
         FunctionOverride,
@@ -53,12 +52,9 @@ if TYPE_CHECKING:
         Point3D_Array,
         Vector3D,
     )
+    from manim.utils.updaters import MobjectTimeBasedUpdater, MobjectUpdater
 
     from ..animation.animation import Animation
-
-    TimeBasedUpdater: TypeAlias = Callable[["Mobject", float], object]
-    NonTimeBasedUpdater: TypeAlias = Callable[["Mobject"], object]
-    Updater: TypeAlias = NonTimeBasedUpdater | TimeBasedUpdater
 
 
 class Mobject:
@@ -71,6 +67,7 @@ class Mobject:
     Attributes
     ----------
     submobjects : List[:class:`Mobject`]
+
         The contained objects.
     points : :class:`numpy.ndarray`
         The points of the objects.
@@ -96,7 +93,7 @@ class Mobject:
 
     def __init__(
         self,
-        color: ParsableManimColor | list[ParsableManimColor] = WHITE,
+        color: ParsableManimColor | Sequence[ParsableManimColor] = WHITE,
         name: str | None = None,
         dim: int = 3,
         target=None,
@@ -108,7 +105,7 @@ class Mobject:
         self.z_index = z_index
         self.point_hash = None
         self.submobjects = []
-        self.updaters: list[Updater] = []
+        self.updater_wrappers: Sequence[MobjectUpdaterWrapper] = []
         self.updating_suspended = False
         self.color = ManimColor.parse(color)
 
@@ -868,6 +865,10 @@ class Mobject:
 
     # Updating
 
+    @property
+    def updaters(self) -> Sequence[MobjectUpdater]:
+        return self.get_updaters()
+
     def update(self, dt: float = 0, recursive: bool = True) -> Self:
         """Apply all updaters.
 
@@ -894,17 +895,17 @@ class Mobject:
         """
         if self.updating_suspended:
             return self
-        for updater in self.updaters:
-            if "dt" in inspect.signature(updater).parameters:
-                updater(self, dt)
+        for wrapper in self.updater_wrappers:
+            if wrapper.is_time_based:
+                wrapper.updater(self, dt)
             else:
-                updater(self)
+                wrapper.updater(self)
         if recursive:
             for submob in self.submobjects:
                 submob.update(dt, recursive)
         return self
 
-    def get_time_based_updaters(self) -> list[TimeBasedUpdater]:
+    def get_time_based_updaters(self) -> Sequence[MobjectTimeBasedUpdater]:
         """Return all updaters using the ``dt`` parameter.
 
         The updaters use this parameter as the input for difference in time.
@@ -920,11 +921,7 @@ class Mobject:
         :meth:`has_time_based_updater`
 
         """
-        return [
-            updater
-            for updater in self.updaters
-            if "dt" in inspect.signature(updater).parameters
-        ]
+        return [wrapper.updater for wrapper in self.updater_wrappers if t.is_time_based]
 
     def has_time_based_updater(self) -> bool:
         """Test if ``self`` has a time based updater.
@@ -940,11 +937,9 @@ class Mobject:
         :meth:`get_time_based_updaters`
 
         """
-        return any(
-            "dt" in inspect.signature(updater).parameters for updater in self.updaters
-        )
+        return any(wrapper.is_time_based for wrapper in self.updater_wrappers)
 
-    def get_updaters(self) -> list[Updater]:
+    def get_updaters(self) -> Sequence[MobjectUpdater]:
         """Return all updaters.
 
         Returns
@@ -958,14 +953,14 @@ class Mobject:
         :meth:`get_time_based_updaters`
 
         """
-        return self.updaters
+        return [wrapper.updater for wrapper in self.updater_wrappers]
 
-    def get_family_updaters(self) -> list[Updater]:
+    def get_family_updaters(self) -> Sequence[MobjectUpdater]:
         return list(it.chain(*(sm.get_updaters() for sm in self.get_family())))
 
     def add_updater(
         self,
-        update_function: Updater,
+        update_function: MobjectUpdater,
         index: int | None = None,
         call_updater: bool = False,
     ) -> Self:
@@ -1029,20 +1024,19 @@ class Mobject:
         :meth:`remove_updater`
         :class:`~.UpdateFromFunc`
         """
-
+        wrapper = MobjectUpdaterWrapper(update_function)
         if index is None:
-            self.updaters.append(update_function)
+            self.updater_wrappers.append(wrapper)
         else:
-            self.updaters.insert(index, update_function)
+            self.updater_wrappers.insert(index, wrapper)
         if call_updater:
-            parameters = inspect.signature(update_function).parameters
-            if "dt" in parameters:
-                update_function(self, 0)
+            if wrapper.is_time_based:
+                wrapper.updater(self, 0)
             else:
-                update_function(self)
+                wrapper.updater(self)
         return self
 
-    def remove_updater(self, update_function: Updater) -> Self:
+    def remove_updater(self, update_function: MobjectUpdater) -> Self:
         """Remove an updater.
 
         If the same updater is applied multiple times, every instance gets removed.
@@ -1065,8 +1059,11 @@ class Mobject:
         :meth:`get_updaters`
 
         """
-        while update_function in self.updaters:
-            self.updaters.remove(update_function)
+        self.updater_wrappers = [
+            wrapper
+            for wrapper in self.updater_wrappers
+            if wrapper.updater != update_function
+        ]
         return self
 
     def clear_updaters(self, recursive: bool = True) -> Self:
@@ -1089,7 +1086,7 @@ class Mobject:
         :meth:`get_updaters`
 
         """
-        self.updaters = []
+        self.updater_wrappers = []
         if recursive:
             for submob in self.submobjects:
                 submob.clear_updaters()
@@ -1121,8 +1118,7 @@ class Mobject:
         """
 
         self.clear_updaters()
-        for updater in mobject.get_updaters():
-            self.add_updater(updater)
+        self.updater_wrappers = mobject.updater_wrappers.copy()
         return self
 
     def suspend_updating(self, recursive: bool = True) -> Self:

--- a/manim/renderer/shader.py
+++ b/manim/renderer/shader.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
-import inspect
 import re
 import textwrap
+from collections.abc import Sequence
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import moderngl
 import numpy as np
 
-from .. import config
-from ..utils import opengl
+from manim import config
+from manim.utils import opengl
+from manim.utils.updaters import MeshUpdaterWrapper
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from manim.utils.updaters import MeshTimeBasedUpdater, MeshUpdater
 
 SHADER_FOLDER = Path(__file__).parent / "shaders"
 shader_program_cache: dict = {}
@@ -174,76 +181,90 @@ class Object3D:
             current_object = current_object.parent
         return np.linalg.multi_dot(list(reversed(normal_matrices)))[:3, :3]
 
-    def init_updaters(self):
-        self.time_based_updaters = []
-        self.non_time_updaters = []
+    # Updating
+
+    @property
+    def updaters(self) -> Sequence[MeshUpdater]:
+        return self.get_updaters()
+
+    def init_updaters(self) -> None:
+        self.updater_wrappers: Sequence[MeshUpdaterWrapper] = []
         self.has_updaters = False
         self.updating_suspended = False
 
-    def update(self, dt=0):
+    def update(self, dt: float = 0) -> Self:
         if not self.has_updaters or self.updating_suspended:
             return self
-        for updater in self.time_based_updaters:
-            updater(self, dt)
-        for updater in self.non_time_updaters:
-            updater(self)
+        for wrapper in self.updater_wrappers:
+            if wrapper.is_time_based:
+                wrapper.updater(self, dt)
+            else:
+                wrapper.updater(self)
         return self
 
-    def get_time_based_updaters(self):
-        return self.time_based_updaters
+    def get_time_based_updaters(self) -> Sequence[MeshTimeBasedUpdater]:
+        return [
+            wrapper.updater
+            for wrapper in self.updater_wrappers
+            if wrapper.is_time_based
+        ]
 
-    def has_time_based_updater(self):
-        return len(self.time_based_updaters) > 0
+    def has_time_based_updater(self) -> bool:
+        return any(wrapper.is_time_based for wrapper in self.updater_wrappers)
 
-    def get_updaters(self):
-        return self.time_based_updaters + self.non_time_updaters
+    def get_updaters(self) -> Sequence[MeshUpdater]:
+        return [wrapper.updater for wrapper in self.updater_wrappers]
 
-    def add_updater(self, update_function, index=None, call_updater=True):
-        if "dt" in inspect.signature(update_function).parameters:
-            updater_list = self.time_based_updaters
-        else:
-            updater_list = self.non_time_updaters
-
+    def add_updater(
+        self,
+        update_function: MeshUpdater,
+        index: int | None = None,
+        call_updater: bool = False,
+    ) -> Self:
+        wrapper = MeshUpdaterWrapper(update_function)
         if index is None:
-            updater_list.append(update_function)
+            self.updater_wrappers.append(wrapper)
         else:
-            updater_list.insert(index, update_function)
+            self.updater_wrappers.insert(index, wrapper)
 
         self.refresh_has_updater_status()
         if call_updater:
             self.update()
         return self
 
-    def remove_updater(self, update_function):
-        for updater_list in [self.time_based_updaters, self.non_time_updaters]:
-            while update_function in updater_list:
-                updater_list.remove(update_function)
+    def remove_updater(self, update_function: MeshUpdater) -> Self:
+        self.updater_wrappers = [
+            wrapper
+            for wrapper in self.updater_wrappers
+            if wrapper.updater != update_function
+        ]
         self.refresh_has_updater_status()
         return self
 
-    def clear_updaters(self):
-        self.time_based_updaters = []
-        self.non_time_updaters = []
+    def clear_updaters(self, recurse: bool = True) -> Self:
+        self.updater_wrappers = []
         self.refresh_has_updater_status()
+        if recurse:
+            for submob in self.submobjects:
+                submob.clear_updaters()
         return self
 
-    def match_updaters(self, mobject):
+    def match_updaters(self, obj: Object3D) -> Self:
         self.clear_updaters()
-        for updater in mobject.get_updaters():
-            self.add_updater(updater)
+        self.updater_wrappers = obj.updater_wrappers.copy()
         return self
 
-    def suspend_updating(self):
+    def suspend_updating(self) -> Self:
         self.updating_suspended = True
         return self
 
-    def resume_updating(self, call_updater=True):
+    def resume_updating(self, call_updater: bool = True) -> Self:
         self.updating_suspended = False
         if call_updater:
             self.update(dt=0)
         return self
 
-    def refresh_has_updater_status(self):
+    def refresh_has_updater_status(self) -> Self:
         self.has_updaters = len(self.get_updaters()) > 0
         return self
 

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -33,27 +33,29 @@ from tqdm import tqdm
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
+from manim import config, logger
+from manim.animation.animation import Animation, Wait, prepare_animation
+from manim.camera.camera import Camera
+from manim.constants import *
+from manim.gui.gui import configure_pygui
 from manim.mobject.mobject import Mobject
 from manim.mobject.opengl.opengl_mobject import OpenGLPoint
-
-from .. import config, logger
-from ..animation.animation import Animation, Wait, prepare_animation
-from ..camera.camera import Camera
-from ..constants import *
-from ..gui.gui import configure_pygui
-from ..renderer.cairo_renderer import CairoRenderer
-from ..renderer.opengl_renderer import OpenGLRenderer
-from ..renderer.shader import Object3D
-from ..utils import opengl, space_ops
-from ..utils.exceptions import EndSceneEarlyException, RerunSceneException
-from ..utils.family import extract_mobject_family_members
-from ..utils.family_ops import restructure_list_to_exclude_certain_family_members
-from ..utils.file_ops import open_media_file
-from ..utils.iterables import list_difference_update, list_update
+from manim.renderer.cairo_renderer import CairoRenderer
+from manim.renderer.opengl_renderer import OpenGLRenderer
+from manim.renderer.shader import Object3D
+from manim.utils import opengl, space_ops
+from manim.utils.exceptions import EndSceneEarlyException, RerunSceneException
+from manim.utils.family import extract_mobject_family_members
+from manim.utils.family_ops import restructure_list_to_exclude_certain_family_members
+from manim.utils.file_ops import open_media_file
+from manim.utils.iterables import list_difference_update, list_update
+from manim.utils.updaters import MobjectUpdaterWrapper
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Sequence
     from typing import Callable
+
+    from manim.utils.updaters import SceneUpdater
 
 
 class RerunSceneHandler(FileSystemEventHandler):
@@ -124,7 +126,7 @@ class Scene:
         self.camera_target = ORIGIN
         self.widgets = []
         self.dearpygui_imported = dearpygui_imported
-        self.updaters = []
+        self.updaters: Sequence[SceneUpdater] = []
         self.point_lights = []
         self.ambient_light = None
         self.key_to_function_map = {}
@@ -168,12 +170,14 @@ class Scene:
             if k == "camera_class":
                 setattr(result, k, v)
             setattr(result, k, copy.deepcopy(v, clone_from_id))
+        # TODO: where is this attribute even defined?
         result.mobject_updater_lists = []
 
         # Update updaters
         for mobject in self.mobjects:
-            cloned_updaters = []
-            for updater in mobject.updaters:
+            cloned_updater_wrappers = []
+            for wrapper in mobject.updater_wrappers:
+                updater = wrapper.updater
                 # Make the cloned updater use the cloned Mobjects as free variables
                 # rather than the original ones. Analyzing function bytecode with the
                 # dis module will help in understanding this.
@@ -209,11 +213,13 @@ class Scene:
                     updater.__defaults__,
                     tuple(cloned_closure),
                 )
-                cloned_updaters.append(cloned_updater)
+                cloned_updater_wrappers.append(MobjectUpdaterWrapper(cloned_updater))
             mobject_clone = clone_from_id[id(mobject)]
-            mobject_clone.updaters = cloned_updaters
-            if len(cloned_updaters) > 0:
-                result.mobject_updater_lists.append((mobject_clone, cloned_updaters))
+            mobject_clone.updater_wrappers = cloned_updater_wrappers
+            if len(cloned_updater_wrappers) > 0:
+                result.mobject_updater_lists.append(
+                    (mobject_clone, cloned_updater_wrappers)
+                )
         return result
 
     def render(self, preview: bool = False):
@@ -572,7 +578,7 @@ class Scene:
         if not replaced:
             raise ValueError(f"Could not find {old_mobject} in scene")
 
-    def add_updater(self, func: Callable[[float], None]) -> None:
+    def add_updater(self, func: SceneUpdater) -> None:
         """Add an update function to the scene.
 
         The scene updater functions are run every frame,
@@ -603,7 +609,7 @@ class Scene:
         """
         self.updaters.append(func)
 
-    def remove_updater(self, func: Callable[[float], None]) -> None:
+    def remove_updater(self, func: SceneUpdater) -> None:
         """Remove an update function from the scene.
 
         Parameters

--- a/manim/utils/updaters.py
+++ b/manim/utils/updaters.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+    from manim.mobject.mobject import Mobject
+    from manim.opengl.shader import Object3D
+
+
+__all__ = [
+    "MobjectTimeBasedUpdater",
+    "MobjectNonTimeBasedUpdater",
+    "MobjectUpdater",
+    "MeshTimeBasedUpdater",
+    "MeshNonTimeBasedUpdater",
+    "MeshUpdater",
+    "SceneUpdater",
+    "MobjectUpdaterWrapper",
+    "MeshUpdaterWrapper",
+]
+
+
+MobjectTimeBasedUpdater: TypeAlias = Callable[["Mobject", float], "Mobject"]
+MobjectNonTimeBasedUpdater: TypeAlias = Callable[["Mobject"], "Mobject"]
+MobjectUpdater: TypeAlias = MobjectNonTimeBasedUpdater | MobjectTimeBasedUpdater
+
+MeshTimeBasedUpdater: TypeAlias = Callable[["Object3D", float], "Object3D"]
+MeshNonTimeBasedUpdater: TypeAlias = Callable[["Object3D"], "Object3D"]
+MeshUpdater: TypeAlias = MeshNonTimeBasedUpdater | MeshTimeBasedUpdater
+
+SceneUpdater: TypeAlias = Callable[[float], None]
+
+
+class AbstractUpdaterWrapper:
+    """Wraps an :class:`Updater` function, inspects its signature and
+    calculates whether it's time-based or not.
+
+    If it has a single parameter (with no default value), it's considered
+    non-time-based: it doesn't depend on time.
+
+    If it has two parameters (with no default values), it's considered
+    time-based: it depends on time, and the affected Mobject has a change
+    on every frame which depends on the frame's duration dt.
+
+    .. note::
+        It's not mandatory that the parameters are named ``mob`` and ``dt``.
+
+    **Only parameters with no default values are considered in when determining
+    whether the updater is time-based or not.** For example, an updater
+    ``lambda mob, rate=5: ...`` is considered non-time-based since the 2nd
+    parameter ``rate`` has a default value of 5. **This allows for passing
+    functions with more than 2 parameters, as long as the extra parameters have
+    default values.**
+
+    A ``ValueError`` is raised if a function is passed which has 0 or more than
+    2 parameters with no default values.
+
+    When passing an instance method, the first parameter `self` is excluded
+    from the count. When passing a class method, the first parameter `cls` is
+    also excluded.
+
+    .. note ::
+        It is fine to call the 1st parameter ``self`` if the updater is not an
+        instance method: it will still be counted as a parameter. The rule
+        above only applies for instance methods. For example,
+        ``lambda self: self.move_to(square)`` is a valid non-time-based
+        updater, and ``lambda self, dt: self.rotate(dt)`` is time-based.
+
+    .. warning::
+        Do **NOT** name the 1st parameter ``cls`` if the function is not a class
+        method.
+
+    Attributes
+    ----------
+    updater
+        An updater function, whose first parameter is a Mobject and might
+        optionally have a second parameter which should be a float
+        representing a time change dt.
+
+    Raises
+    ------
+    ValueError
+        If an updater is passed with 0 or more than 2 parameters with no
+        default values.
+    """
+
+    __slots__ = ["updater", "is_time_based"]
+
+    def __init__(self, updater: MobjectUpdater | MeshUpdater):
+        self.updater = updater
+
+        signature = inspect.signature(updater)
+        parameters = [str(param) for param in signature.parameters.values()]
+
+        for i, param in enumerate(parameters):
+            # Stop when finding **kwargs or parameters with default values
+            if param.startswith("**") or "=" in param:
+                num_non_default_parameters = i
+                break
+        else:
+            num_non_default_parameters = len(parameters)
+
+        if num_non_default_parameters == 0:
+            self._raise_error(0)
+
+        # If this is a method being called from an instance, exclude the 1st
+        # parameter if it's called "self"
+        if inspect.ismethod(updater) and parameters[0] == "self":
+            num_non_default_parameters -= 1
+        # Exclude the "cls" parameter from class methods
+        if parameters[0] == "cls":
+            num_non_default_parameters -= 1
+
+        # Handle functions containing *args, assuming that all can be passed
+        # a 2nd parameter dt
+        if 1 <= num_non_default_parameters <= 3 and parameters[-1].startswith("*"):
+            num_non_default_parameters = 2
+
+        if num_non_default_parameters == 1:
+            self.is_time_based = False
+        elif num_non_default_parameters == 2:
+            self.is_time_based = True
+        else:
+            self._raise_error(num_non_default_parameters)
+
+    def _raise_error(self, num_non_default_parameters: int):
+        updater_name = self.updater.__code__.co_qualname
+        signature = str(inspect.signature(self.updater))
+        full_name = updater_name + signature
+
+        if num_non_default_parameters == 0:
+            num_non_default_parameters = "no"
+
+        raise ValueError(
+            "An updater function must accept either 1 or 2 parameters without "
+            "default values (not including 'self' or 'cls' for methods), but "
+            f"the function {full_name} has {num_non_default_parameters} such "
+            "parameters."
+        )
+
+
+class MobjectUpdaterWrapper(AbstractUpdaterWrapper):
+    def __init__(self, updater: MobjectUpdater):
+        super().__init__(updater)
+
+
+class MeshUpdaterWrapper(AbstractUpdaterWrapper):
+    def __init__(self, updater: MeshUpdater):
+        super().__init__(updater)

--- a/tests/module/utils/test_updaters.py
+++ b/tests/module/utils/test_updaters.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from manim.constants import RIGHT
+from manim.mobject.geometry.polygram import Square
+from manim.mobject.graph import Graph
+from manim.utils.updaters import MobjectUpdaterWrapper
+
+
+def test_UpdaterWrapper() -> None:
+    square = Square().move_to(RIGHT)
+
+    # Non-time-based updater: 1 parameter with no default value
+    wrapper = MobjectUpdaterWrapper(lambda mob: mob.next_to(square))
+    assert not wrapper.is_time_based
+
+    # Time-based updater: 2 parameters with no default value
+    wrapper = MobjectUpdaterWrapper(lambda mob, dt: mob.rotate(dt))
+    assert wrapper.is_time_based
+
+    # It's not necessary for the 2nd parameter to be called dt
+    wrapper = MobjectUpdaterWrapper(lambda mob, delta_time: mob.rotate(delta_time))
+    assert wrapper.is_time_based
+
+    # An updater can even have more than 2 parameters, as long as they have
+    # default values
+    wrapper = MobjectUpdaterWrapper(lambda mob, dt, rate=2: mob.rotate(rate * dt))
+    assert wrapper.is_time_based
+
+    # An updater cannot have no parameters
+    with pytest.raises(ValueError) as no_parameters_info:
+        wrapper = MobjectUpdaterWrapper(lambda: "Hello world")
+
+    # An updater cannot have more than 2 parameters without a default value
+    with pytest.raises(ValueError) as three_parameters_info:
+        wrapper = MobjectUpdaterWrapper(lambda mob, rate, third: mob.rotate(rate))
+
+    # Only parameters with no default value are considered when determining
+    # whether the updater is time-based or not. If an updater has 2 parameters,
+    # but the 2nd one has a default value, it's considered non-time-based.
+    wrapper = MobjectUpdaterWrapper(lambda mob, other=square: mob.next_to(other))
+    assert not wrapper.is_time_based
+
+    # When using an instance method, the first argument is ignored if it's
+    # called 'self'. This is an attempt to exclude static methods from this
+    # rule.
+    graph = Graph([1, 2], [(1, 2)])
+    wrapper = MobjectUpdaterWrapper(graph.update_edges)  # signature: (self, graph)
+    assert not wrapper.is_time_based  # since only the 'graph' param is counted
+
+    # This doesn't happen when calling the method from the class rather than
+    # from an instance.
+    wrapper = MobjectUpdaterWrapper(Graph.update_edges)  # signature: (self, graph)
+    # 'self' is the 1st, 'graph' is the 2nd, (incorrectly) considered as time
+    assert wrapper.is_time_based
+
+    # In general, if the function is not an instance method, the 1st parameter
+    # is always included, even if it's called "self".
+    wrapper = MobjectUpdaterWrapper(lambda self: self.move_to(square))
+    assert not wrapper.is_time_based
+    wrapper = MobjectUpdaterWrapper(lambda self, dt: self.rotate(dt))
+    assert wrapper.is_time_based


### PR DESCRIPTION
Closes #321

## General description

In the issue described, Leo mentions that calling `inspect.signature()` every time we need to compute whether an `Updater` is time-based or not, takes a considerable amount of time when there are a lot of updaters in a Scene.

Leo proposed that every updater must always have two parameters and made a PR about it, but it was rejected.

Given an updater `func`, my first attempt was accessing `func.__code__.co_varnames` (local variable names in the function code) and slice it from 0 to `func.__code__.co_argcount` (number of positional parameters) to get the names of positional parameters.

However, as JasonGrace commented his concerns about more advanced use cases, I needed something more.

Therefore, in this PR I introduce a `MobjectUpdaterWrapper`, which takes an updater function, saves it in its `.updater` attribute, and uses `inspect.signature()` on it to calculate whether it's time-based or not. It stores the result in its `.is_time_based`, and this computation **only happens once** (when instantiating `MobjectUpdaterWrapper`), rather than every time the updater is called, leading to a substantial speedup when updating Mobjects.

In `MobjectUpdaterWrapper` I also address the concerns raised by JasonGrace, Leo and myself:
- What if the updater function has parameters with default values?
- What if it only has two parameters, but the 2nd one has a default value and is not intended to receive a `dt` value?
- What if the function is a method and its 1st parameter is `self`?
- What if the function _isn't_ a method, but the 1sts parameter is `self` anyways?
- etc.

which is why I decided to make a separate class in the first place: the logic which attempts to address all these concerns is very long and shouldn't bloat the `Mobject.add_updater()` code. Plus, I wanted to replicate the same for `OpenGLMobject` as well.

Because I wanted to make the same changes in `OpenGLMobject`, the best course of action was taking all this code into a different module, specifically `manim.utils.updaters`.

I also noticed that the relatively obscure classes `Object3D` and its subclass `Mesh` also have updaters which work in a very similar fashion, so I added the `MeshUpdater` type alias and the `MeshUpdaterWrapper` class as well.

Finally, `Scene` also has updaters, but very different ones (they always accept a `dt: float` and return `None`), so I also added a `SceneUpdater` type alias.

## Profiling

An example scene with many updaters:
```py
class MovingSquares(Scene):
    def construct(self):
        t = ValueTracker()
        for y in range(4, -5, -2):
            for x in range(-8, 9, 2):
                updater = (lambda x, y: (
                    lambda square, dt: square.move_to([
                        x + np.cos(t.get_value()),
                        y + (1 if x % 4 == 0 else -1) * np.sin(t.get_value()),
                        0,
                    ])
                ))(x, y)
                self.add(Square(1).add_updater(updater))

        self.play(t.animate.set_value(2*TAU), run_time=10, rate_func=linear)
```
Notice how the `inspect.signature()` block completely disappears from the `Mobject.update()` time:

Before | After
--|--
![image](https://github.com/ManimCommunity/manim/assets/49853152/e4d1b0a4-3660-4830-bba0-cc70580491f5) | ![image](https://github.com/ManimCommunity/manim/assets/49853152/9e384565-41c6-4f23-b534-5cf5d90c9f3a) 

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
