### PR TITLE
Fix: ``NumberLine`` ``number_to_point`` broken when using ``add_tip``

### DIFF
--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -264,13 +264,13 @@ class TipableVMobject(VMobject, metaclass=ConvertToOpenGL):
 
     def get_end(self) -> Point3D:
         if self.has_tip():
-            return self.tip.get_start()
+            return self.tip.base
         else:
             return super().get_end()
 
     def get_start(self) -> Point3D:
         if self.has_start_tip():
-            return self.start_tip.get_start()
+            return self.start_tip.base
         else:
             return super().get_start()
 

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -9,7 +9,7 @@ __all__ = ["NumberLine", "UnitInterval"]
 
 
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Self
 
 if TYPE_CHECKING:
     from manim.mobject.geometry.tips import ArrowTip
@@ -236,7 +236,6 @@ class NumberLine(Line):
                 tip_width=self.tip_width,
                 tip_shape=tip_shape,
             )
-            self.tip.set_stroke(self.stroke_color, self.stroke_width)
 
         if self.include_ticks:
             self.add_ticks()
@@ -274,6 +273,26 @@ class NumberLine(Line):
         self, number: float, angle: float, axis: Sequence[float] = OUT, **kwargs
     ):
         return self.rotate(angle, axis, about_point=self.n2p(number), **kwargs)
+
+    def add_tip(
+        self,
+        tip: ArrowTip | None = None,
+        tip_shape: type[ArrowTip] | None = None,
+        tip_length: float | None = None,
+        tip_width: float | None = None,
+        at_start: bool = False,
+    ) -> Self:
+        if tip_length is None:
+            tip_length = self.tip_height
+
+        if tip_width is None:
+            tip_width = self.tip_width
+
+        super().add_tip(tip, tip_shape, tip_length, tip_width, at_start)
+
+        self.tip.set_stroke(self.stroke_color, self.stroke_width)
+
+        return self
 
     def add_ticks(self):
         """Adds ticks to the number line. Ticks can be accessed after creation
@@ -325,8 +344,7 @@ class NumberLine(Line):
             A numpy array of floats represnting values along the number line.
         """
         x_min, x_max, x_step = self.x_range
-        if not self.include_tip:
-            x_max += 1e-6
+        x_max += 1e-6
 
         # Handle cases where min and max are both positive or both negative
         if x_min < x_max < 0 or x_max > x_min > 0:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Fixed issue where ``NumberLine``'s ``number_to_point`` method didn't convert from number line value to image position correctly after calling ``add_tip`` after creation.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
``NumberLine``'s ``number_to_point`` method now converts from number line value to image position correctly after calling ``add_tip``.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
No documentation changed.

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
Also fixed was a small issue with the final tick mark of a number line not always appearing when a tip was added.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
