### PR TITLE
Fix :attr:`.ManimConfig.format` not updating movie file extension

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -1052,6 +1052,7 @@ class ManimConfig(MutableMapping):
             val,
             [None, "png", "gif", "mp4", "mov", "webm"],
         )
+        self.resolve_movie_file_extension(self.transparent)
         if self.format == "webm":
             logging.getLogger("manim").warning(
                 "Output format set as webm, this can be slower than other formats",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import tempfile
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from manim import WHITE, Scene, Square, Tex, Text, tempconfig
 from manim._config.utils import ManimConfig
@@ -31,6 +32,20 @@ def test_tempconfig(config):
             np.testing.assert_allclose(config[k], v)
         else:
             assert config[k] == v
+
+
+@pytest.mark.parametrize(
+    ("format", "expected_file_extension"),
+    [
+        ("mp4", ".mp4"),
+        ("webm", ".webm"),
+        ("mov", ".mov"),
+        ("gif", ".mp4"),
+    ],
+)
+def test_resolve_file_extensions(config, format, expected_file_extension):
+    config.format = format
+    assert config.movie_file_extension == expected_file_extension
 
 
 class MyScene(Scene):


### PR DESCRIPTION
Closes #3837

## Example of Bug
```pycon
>>> from manim import config
>>> config.movie_file_extension
'.mp4'
>>> config.format = "webm"
>>> config.movie_file_extension
'.mp4'
>>> config.transparent = config.transparent
>>> config.movie_file_extension
'.webm'
```