### PR TITLE
Rename `manim.typing.Image` type aliases to `PixelArray` to avoid conflict with `PIL.Image`

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -44,11 +44,11 @@ if TYPE_CHECKING:
 
     from manim.typing import (
         FunctionOverride,
-        Image,
         ManimFloat,
         ManimInt,
         MappingFunction,
         PathFuncType,
+        PixelArray,
         Point3D,
         Point3D_Array,
         Vector3D,
@@ -825,7 +825,7 @@ class Mobject:
 
     # Displaying
 
-    def get_image(self, camera=None) -> Image:
+    def get_image(self, camera=None) -> PixelArray:
         if camera is None:
             from ..camera.camera import Camera
 

--- a/manim/typing.py
+++ b/manim/typing.py
@@ -77,10 +77,10 @@ __all__ = [
     "FunctionOverride",
     "PathFuncType",
     "MappingFunction",
-    "Image",
-    "GrayscaleImage",
-    "RGBImage",
-    "RGBAImage",
+    "PixelArray",
+    "GrayscalePixelArray",
+    "RGBPixelArray",
+    "RGBAPixelArray",
     "StrPath",
     "StrOrBytesPath",
 ]
@@ -582,7 +582,7 @@ MappingFunction: TypeAlias = Callable[[Point3D], Point3D]
 Image types
 """
 
-Image: TypeAlias = npt.NDArray[ManimInt]
+PixelArray: TypeAlias = npt.NDArray[ManimInt]
 """``shape: (height, width) | (height, width, 3) | (height, width, 4)``
 
 A rasterized image with a height of ``height`` pixels and a width of
@@ -595,21 +595,21 @@ lightness (for greyscale images), an `RGB_Array_Int` or an
 `RGBA_Array_Int`.
 """
 
-GrayscaleImage: TypeAlias = Image
+GrayscalePixelArray: TypeAlias = PixelArray
 """``shape: (height, width)``
 
 A 100% opaque grayscale `Image`, where every pixel value is a
 `ManimInt` indicating its lightness (black -> gray -> white).
 """
 
-RGBImage: TypeAlias = Image
+RGBPixelArray: TypeAlias = PixelArray
 """``shape: (height, width, 3)``
 
 A 100% opaque `Image` in color, where every pixel value is an
 `RGB_Array_Int` object.
 """
 
-RGBAImage: TypeAlias = Image
+RGBAPixelArray: TypeAlias = PixelArray
 """``shape: (height, width, 4)``
 
 An `Image` in color where pixels can be transparent. Every pixel

--- a/manim/typing.py
+++ b/manim/typing.py
@@ -598,21 +598,21 @@ lightness (for greyscale images), an `RGB_Array_Int` or an
 GrayscalePixelArray: TypeAlias = PixelArray
 """``shape: (height, width)``
 
-A 100% opaque grayscale `Image`, where every pixel value is a
+A 100% opaque grayscale `PixelArray`, where every pixel value is a
 `ManimInt` indicating its lightness (black -> gray -> white).
 """
 
 RGBPixelArray: TypeAlias = PixelArray
 """``shape: (height, width, 3)``
 
-A 100% opaque `Image` in color, where every pixel value is an
+A 100% opaque `PixelArray` in color, where every pixel value is an
 `RGB_Array_Int` object.
 """
 
 RGBAPixelArray: TypeAlias = PixelArray
 """``shape: (height, width, 4)``
 
-An `Image` in color where pixels can be transparent. Every pixel
+A `PixelArray` in color where pixels can be transparent. Every pixel
 value is an `RGBA_Array_Int` object.
 """
 


### PR DESCRIPTION
Easy review! We needed to make that change in the experimental branch because we had some conflicts, and I thought, why not implement it in main as well?

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
