### PR TITLE
Update installation instructions for MacOS (via dedicated brew formula)

### DIFF
--- a/docs/source/installation/macos.rst
+++ b/docs/source/installation/macos.rst
@@ -18,7 +18,7 @@ follow `Homebrew's installation instructions <https://docs.brew.sh/Installation>
 
 
 Installing Manim
----------------------
+----------------
 
 As of July/2024, brew can install Manim including all required dependencies.
 To install Manim:

--- a/docs/source/installation/macos.rst
+++ b/docs/source/installation/macos.rst
@@ -17,46 +17,15 @@ follow `Homebrew's installation instructions <https://docs.brew.sh/Installation>
    (and is recommended to) be installed natively.
 
 
-Required Dependencies
+Installing Manim
 ---------------------
 
-To install all required dependencies for installing Manim (namely: Python,
-and some required Python packages), run:
+As of July/2024, brew can install Manim including all required dependencies.
+To install Manim:
 
 .. code-block:: bash
 
-   brew install py3cairo
-
-On *Apple Silicon* based machines (i.e., devices with the M1 chip or similar; if
-you are unsure which processor you have check by opening the Apple menu, select
-*About This Mac* and check the entry next to *Chip*), some additional dependencies
-are required, namely:
-
-.. code-block:: bash
-
-   brew install pango pkg-config scipy
-
-After all required dependencies are installed, simply run:
-
-.. code-block:: bash
-
-   pip3 install manim
-
-to install Manim.
-
-.. note::
-
-   A frequent source for installation problems is if ``pip3``
-   does not point to the correct Python installation on your system.
-   To check this, run ``pip3 -V``: for macOS Intel, the path should
-   start with ``/usr/local``, and for Apple Silicon with
-   ``/opt/homebrew``. If this is not the case, you either forgot
-   to modify your shell profile (``.zprofile``) during the installation
-   of Homebrew, or did not reload your shell (e.g., by opening a new
-   terminal) after doing so. It is also possible that some other
-   software (like Pycharm) changed the ``PATH`` variable – to fix this,
-   make sure that the Homebrew-related lines in your ``.zprofile`` are
-   at the very end of the file.
+   brew install manim
 
 .. _macos-optional-dependencies:
 


### PR DESCRIPTION
Hello, Manim team, as of July/2024, Homebrew installs Manim and its dependencies. 
Guideline for installing dependencies with brew, and attempt to install using pip3 will no longer work either venv or not. 
Now homebrew team manages python resources as "System-wide" only with Brew installed resources.  
Hence, to give first time installer just leave a single line install command would be the simplest option we have.
