### PR TITLE
Better updaters for experimental

### DIFF
--- a/example_scenes/test_new_rendering.py
+++ b/example_scenes/test_new_rendering.py
@@ -12,7 +12,9 @@ class Test(Scene):
         st = Star()
         spinny = Line().to_edge(LEFT)
         spinny.add_dt_updater(lambda m, dt: m.rotate(PI / 2 * dt))
-        self.add(spinny)
+        txt = Text("Spinny")
+        txt.add_updater(lambda m: m.next_to(spinny, DOWN))
+        self.add(spinny, txt)
         VGroup(sq, c, st).arrange()
         self.play(
             Succession(

--- a/example_scenes/test_new_rendering.py
+++ b/example_scenes/test_new_rendering.py
@@ -10,6 +10,9 @@ class Test(Scene):
         sq = RegularPolygon(6)
         c = Circle()
         st = Star()
+        spinny = Line().to_edge(LEFT)
+        spinny.add_dt_updater(lambda m, dt: m.rotate(PI / 2 * dt))
+        self.add(spinny)
         VGroup(sq, c, st).arrange()
         self.play(
             Succession(

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -23,12 +23,9 @@ from manim.event_handler import EVENT_DISPATCHER
 from manim.event_handler.event_listener import EventListener
 from manim.event_handler.event_type import EventType
 from manim.mobject.updaters import Updater
-from manim.renderer.shader_wrapper import ShaderWrapper, get_colormap_code
 from manim.utils.bezier import integer_interpolate, interpolate
 from manim.utils.color import *
 from manim.utils.deprecation import deprecated
-
-# from ..utils.iterables import batch_by_property
 from manim.utils.iterables import (
     list_update,
     listify,
@@ -115,9 +112,7 @@ class MobjectStatus:
     points_changed: bool = False
 
 
-# it's generic in its renderer, which is a little bit cursed
-# In the future, it should be replaced with a RendererData protocol
-class OpenGLMobject(Generic[R]):
+class OpenGLMobject:
     """Mathematical Object: base class for objects that can be displayed on screen.
 
     Attributes
@@ -179,7 +174,7 @@ class OpenGLMobject(Generic[R]):
         self.uniforms: dict[str, float | np.ndarray] = {}
 
         # TODO replace with protocol
-        self.renderer_data: R | None = None
+        self.renderer_data: RendererData | None = None
         self.status = MobjectStatus()
 
         self.init_data()
@@ -1444,8 +1439,6 @@ class OpenGLMobject(Generic[R]):
             ):
                 setattr(result, attr, result.family[self.family.index(value)])
             if isinstance(value, np.ndarray):
-                setattr(result, attr, value.copy())
-            if isinstance(value, ShaderWrapper):
                 setattr(result, attr, value.copy())
         return result
 

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -1566,24 +1566,29 @@ class OpenGLMobject:
 
     def add_updater(
         self,
-        update_function: NonTimeUpdater,
+        update_function: NonTimeUpdater | Updater,
         index: int | None = None,
         call_updater: bool = False,
     ) -> Self:
+        if not isinstance(update_function, Updater):
+            update_function = Updater(update_function)
         return self._add_updater(
-            Updater(update_function),
+            update_function,
             index=index,
             call_updater=call_updater,
         )
 
     def add_dt_updater(
         self,
-        update_function: TimeBasedUpdater,
+        update_function: TimeBasedUpdater | Updater,
         index: int | None = None,
         call_updater: bool = False,
     ) -> Self:
+        if not isinstance(update_function, Updater):
+            update_function = Updater(update_function)
+        update_function.needs_dt = True
         return self._add_updater(
-            Updater(update_function, dt=True), index=index, call_updater=call_updater
+            update_function, index=index, call_updater=call_updater
         )
 
     def remove_updater(self, update_function: Updater) -> Self:

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -2021,7 +2021,7 @@ class VMobject(Mobject):
         return self
 
 
-class VGroup(VMobject, metaclass=ConvertToOpenGL):
+class VGroup(OpenGLVMobject):
     """A group of vectorized mobjects.
 
     This can be used to group multiple :class:`~.VMobject` instances together

--- a/manim/mobject/updaters.py
+++ b/manim/mobject/updaters.py
@@ -1,18 +1,70 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from typing_extensions import Concatenate
+
     from manim.mobject.opengl.opengl_mobject import OpenGLMobject
 
+M = TypeVar("M", bound="OpenGLMobject")
 
-@dataclass(frozen=True, slots=True, eq=False)
-class Updater:
-    _updater: Callable[..., object]
-    dt: bool = False
+
+class Updater(Generic[M]):
+    """The internal representation of an updater.
+
+    Note that you can pass a raw instance of this class into the :meth:`.OpenGLMobject.add_updater`
+    and :meth:`.OpenGLMobject.add_dt_updater` methods. This is to allow for decorators in the
+    future such as ``@affects_points`` to return instances of this class.
+
+    Parameters
+    ----------
+        updater: the update function
+        dt: whether the update function requires the time step `dt` as an argument
+
+    Examples
+    --------
+
+        .. code-block:: pycon
+
+            >>> from manim import Updater, Square
+            >>> def update(mob):
+            ...     print("Updating mob")
+            >>> updater = Updater(update)
+            >>> updater(Square(), dt=0)  # still needs dt argument
+            'Updating mob'
+            >>> def dt_update(mob, dt):
+            ...     print("Updating mob with dt")
+            >>> dt_updater = Updater(dt_update, dt=True)
+            >>> dt_updater(Square(), dt=0.1)
+            'Updating mob with dt'
+
+
+        .. code-block:: pycon
+
+            >>> from manim import Updater, Square
+            >>> def update(mob):
+            ...     print("Updating mob")
+            >>> updater = Updater(update)
+            >>> s = Square()
+            >>> s.add_updater(updater)
+            >>> s.update(dt=0)
+            'Updating mob'
+    """
+
+    def __init__(
+        self,
+        updater: Callable[Concatenate[M, ...], object]
+        | Callable[Concatenate[M, float, ...], object],
+        *,
+        dt: bool = False,
+    ) -> None:
+        self._updater = updater
+        self.needs_dt = dt
+        # TODO: add fields such as "affects_points", "affects_color", etc.
+        # so that updater calls can be optimized
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Updater):
@@ -20,10 +72,10 @@ class Updater:
         return self._updater == other
 
     def __hash__(self) -> int:
-        return hash((self._updater, self.dt))
+        return hash((self._updater, self.needs_dt))
 
-    def __call__(self, mob: OpenGLMobject, dt: float) -> None:
-        if self.dt:
+    def __call__(self, mob: M, dt: float) -> None:
+        if self.needs_dt:
             self._updater(mob, dt)
         else:
-            self._updater(mob)
+            self._updater(mob)  # type: ignore

--- a/manim/mobject/updaters.py
+++ b/manim/mobject/updaters.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from manim.mobject.opengl.opengl_mobject import OpenGLMobject
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class Updater:
+    _updater: Callable[..., object]
+    dt: bool = False
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Updater):
+            return self._updater == other._updater
+        return self._updater == other
+
+    def __hash__(self) -> int:
+        return hash((self._updater, self.dt))
+
+    def __call__(self, mob: OpenGLMobject, dt: float) -> None:
+        if self.dt:
+            self._updater(mob, dt)
+        else:
+            self._updater(mob)

--- a/manim/mobject/updaters.py
+++ b/manim/mobject/updaters.py
@@ -29,29 +29,31 @@ class Updater(Generic[M]):
 
         .. code-block:: pycon
 
-            >>> from manim import Updater, Square
+            >>> from manim import Square
+            >>> from manim.mobject.updaters import Updater
             >>> def update(mob):
             ...     print("Updating mob")
             >>> updater = Updater(update)
             >>> updater(Square(), dt=0)  # still needs dt argument
-            'Updating mob'
+            Updating mob
             >>> def dt_update(mob, dt):
             ...     print("Updating mob with dt")
             >>> dt_updater = Updater(dt_update, dt=True)
             >>> dt_updater(Square(), dt=0.1)
-            'Updating mob with dt'
+            Updating mob with dt
 
 
         .. code-block:: pycon
 
-            >>> from manim import Updater, Square
+            >>> from manim import Square
+            >>> from manim.mobject.updaters import Updater
             >>> def update(mob):
             ...     print("Updating mob")
             >>> updater = Updater(update)
             >>> s = Square()
-            >>> s.add_updater(updater)
-            >>> s.update(dt=0)
-            'Updating mob'
+            >>> _ = s.add_updater(updater)
+            >>> _ = s.update(dt=0)
+            Updating mob
     """
 
     def __init__(

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -159,13 +159,6 @@ class Scene:
             mob.has_updaters for mob in self.mobjects
         )
 
-    def has_time_based_updaters(self) -> bool:
-        return any(
-            sm.has_time_based_updater()
-            for mob in self.mobjects
-            for sm in mob.get_family()
-        )
-
     # Related to internal mobject organization
 
     def add(self, *new_mobjects: OpenGLMobject):


### PR DESCRIPTION
Essentially, replace the weird `time_based_updaters` and `non_time_based_updaters` with a new class that wraps a function.
Now, instead of a `dt` parameter, we use `OpenGLMobject.add_dt_updater`.