### PR TITLE
Rename parameters and variables conflicting with builtin functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,6 @@ repos:
       - id: flake8
         additional_dependencies:
           [
-            flake8-builtins==1.5.3,
             flake8-docstrings==1.6.0,
             flake8-pytest-style==1.5.0,
             flake8-rst-docstrings==0.2.3,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ sys.path.insert(0, os.path.abspath("."))
 # -- Project information -----------------------------------------------------
 
 project = "Manim"
-copyright = f"2020-{datetime.now().year}, The Manim Community Dev Team"
+copyright = f"2020-{datetime.now().year}, The Manim Community Dev Team"  # noqa: A001
 author = "The Manim Community Dev Team"
 
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2484,10 +2484,10 @@ class Mobject:
             buff_x = buff_y = buff
 
         # Initialize alignments correctly
-        def init_alignments(alignments, num, mapping, name, dir):
+        def init_alignments(alignments, num, mapping, name, dir_):
             if alignments is None:
                 # Use cell_alignment as fallback
-                return [cell_alignment * dir] * num
+                return [cell_alignment * dir_] * num
             if len(alignments) != num:
                 raise ValueError(f"{name}_alignments has a mismatching size.")
             alignments = list(alignments)

--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -264,7 +264,8 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
         """
         result = []
         for shape in svg.elements():
-            if isinstance(shape, se.Group):
+            # can we combine the two continue cases into one?
+            if isinstance(shape, se.Group):  # noqa: SIM114
                 continue
             elif isinstance(shape, se.Path):
                 mob = self.path_to_mobject(shape)

--- a/manim/renderer/opengl_renderer.py
+++ b/manim/renderer/opengl_renderer.py
@@ -63,12 +63,12 @@ class OpenGLCamera(OpenGLMobject):
         if self.orthographic:
             self.projection_matrix = opengl.orthographic_projection_matrix()
             self.unformatted_projection_matrix = opengl.orthographic_projection_matrix(
-                format=False,
+                format_=False,
             )
         else:
             self.projection_matrix = opengl.perspective_projection_matrix()
             self.unformatted_projection_matrix = opengl.perspective_projection_matrix(
-                format=False,
+                format_=False,
             )
 
         if frame_shape is None:

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -308,14 +308,14 @@ class Scene:
     def next_section(
         self,
         name: str = "unnamed",
-        type: str = DefaultSectionType.NORMAL,
+        section_type: str = DefaultSectionType.NORMAL,
         skip_animations: bool = False,
     ) -> None:
         """Create separation here; the last section gets finished and a new one gets created.
         ``skip_animations`` skips the rendering of all animations in this section.
         Refer to :doc:`the documentation</tutorials/output_and_config>` on how to use sections.
         """
-        self.renderer.file_writer.next_section(name, type, skip_animations)
+        self.renderer.file_writer.next_section(name, section_type, skip_animations)
 
     def __str__(self):
         return self.__class__.__name__

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -78,7 +78,7 @@ class SceneFileWriter:
         # first section gets automatically created for convenience
         # if you need the first section to be skipped, add a first section by hand, it will replace this one
         self.next_section(
-            name="autocreated", type=DefaultSectionType.NORMAL, skip_animations=False
+            name="autocreated", type_=DefaultSectionType.NORMAL, skip_animations=False
         )
 
     def init_output_directories(self, scene_name):
@@ -163,7 +163,7 @@ class SceneFileWriter:
         if len(self.sections) and self.sections[-1].is_empty():
             self.sections.pop()
 
-    def next_section(self, name: str, type: str, skip_animations: bool) -> None:
+    def next_section(self, name: str, type_: str, skip_animations: bool) -> None:
         """Create segmentation cut here."""
         self.finish_last_section()
 
@@ -181,7 +181,7 @@ class SceneFileWriter:
 
         self.sections.append(
             Section(
-                type,
+                type_,
                 section_video,
                 name,
                 skip_animations,

--- a/manim/scene/section.py
+++ b/manim/scene/section.py
@@ -34,23 +34,23 @@ class DefaultSectionType(str, Enum):
 
 
 class Section:
-    """A :class:`.Scene` can be segmented into multiple Sections.
+    r"""A :class:`.Scene` can be segmented into multiple Sections.
     Refer to :doc:`the documentation</tutorials/output_and_config>` for more info.
     It consists of multiple animations.
 
     Attributes
     ----------
-    type
-        Can be used by a third party applications to classify different types of sections.
-    video
-        Path to video file with animations belonging to section relative to sections directory.
-        If ``None``, then the section will not be saved.
-    name
-        Human readable, non-unique name for this section.
-    skip_animations
-        Skip rendering the animations in this section when ``True``.
-    partial_movie_files
-        Animations belonging to this section.
+        type\_
+            Can be used by a third party applications to classify different types of sections.
+        video
+            Path to video file with animations belonging to section relative to sections directory.
+            If ``None``, then the section will not be saved.
+        name
+            Human readable, non-unique name for this section.
+        skip_animations
+            Skip rendering the animations in this section when ``True``.
+        partial_movie_files
+            Animations belonging to this section.
 
     See Also
     --------
@@ -59,8 +59,8 @@ class Section:
     :meth:`.OpenGLRenderer.update_skipping_status`
     """
 
-    def __init__(self, type: str, video: str | None, name: str, skip_animations: bool):
-        self.type = type
+    def __init__(self, type_: str, video: str | None, name: str, skip_animations: bool):
+        self.type_ = type_
         # None when not to be saved -> still keeps section alive
         self.video: str | None = video
         self.name = name
@@ -94,7 +94,7 @@ class Section:
         return dict(
             {
                 "name": self.name,
-                "type": self.type,
+                "type": self.type_,
                 "video": self.video,
             },
             **video_metadata,

--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -217,7 +217,7 @@ class ManimColor:
 
     # TODO: Maybe make 8 nibble hex also convertible ?
     @staticmethod
-    def _internal_from_hex_string(hex: str, alpha: float) -> ManimColorInternal:
+    def _internal_from_hex_string(hex_: str, alpha: float) -> ManimColorInternal:
         """Internal function for converting a hex string into the internal representation of a ManimColor.
 
         .. warning::
@@ -238,9 +238,9 @@ class ManimColor:
         ManimColorInternal
             Internal color representation
         """
-        if len(hex) == 6:
-            hex += "00"
-        tmp = int(hex, 16)
+        if len(hex_) == 6:
+            hex_ += "00"
+        tmp = int(hex_, 16)
         return np.asarray(
             (
                 ((tmp >> 24) & 0xFF) / 255,
@@ -590,12 +590,12 @@ class ManimColor:
         return cls(rgba)
 
     @classmethod
-    def from_hex(cls, hex: str, alpha: float = 1.0) -> Self:
+    def from_hex(cls, hex_str: str, alpha: float = 1.0) -> Self:
         """Creates a Manim Color from a hex string, prefixes allowed # and 0x
 
         Parameters
         ----------
-        hex : str
+        hex_str : str
             The hex string to be converted (currently only supports 6 nibbles)
         alpha : float, optional
             alpha value to be used for the hex string, by default 1.0
@@ -605,7 +605,7 @@ class ManimColor:
         ManimColor
             The ManimColor represented by the hex string
         """
-        return cls(hex, alpha)
+        return cls(hex_str, alpha)
 
     @classmethod
     def from_hsv(

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -16,7 +16,7 @@ from decorator import decorate, decorator
 logger = logging.getLogger("manim")
 
 
-def _get_callable_info(callable: Callable) -> tuple[str, str]:
+def _get_callable_info(callable_: Callable, /) -> tuple[str, str]:
     """Returns type and name of a callable.
 
     Parameters
@@ -30,8 +30,8 @@ def _get_callable_info(callable: Callable) -> tuple[str, str]:
         The type and name of the callable. Type can can be one of "class", "method" (for
         functions defined in classes) or "function"). For methods, name is Class.method.
     """
-    what = type(callable).__name__
-    name = callable.__qualname__
+    what = type(callable_).__name__
+    name = callable_.__qualname__
     if what == "function" and "." in name:
         what = "method"
     elif what != "function":

--- a/manim/utils/opengl.py
+++ b/manim/utils/opengl.py
@@ -31,7 +31,7 @@ def orthographic_projection_matrix(
     height=None,
     near=1,
     far=depth + 1,
-    format=True,
+    format_=True,
 ):
     if width is None:
         width = config["frame_width"]
@@ -45,13 +45,15 @@ def orthographic_projection_matrix(
             [0, 0, 0, 1],
         ],
     )
-    if format:
+    if format_:
         return matrix_to_shader_input(projection_matrix)
     else:
         return projection_matrix
 
 
-def perspective_projection_matrix(width=None, height=None, near=2, far=50, format=True):
+def perspective_projection_matrix(
+    width=None, height=None, near=2, far=50, format_=True
+):
     if width is None:
         width = config["frame_width"] / 6
     if height is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,8 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
+  # flake8-builtins
+  "A",
   # unused expression
   "B018",
   # unused variable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers= [
     "Topic :: Scientific/Engineering",
     "Topic :: Multimedia :: Video",
     "Topic :: Multimedia :: Graphics",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -62,9 +61,7 @@ jupyterlab = ["jupyterlab", "notebook"]
 gui = ["dearpygui"]
 
 [tool.poetry.group.dev.dependencies]
-black = ">=23.11,<25.0"
 flake8 = "^6.1.0"
-flake8-builtins = "^2.2.0"
 flake8-docstrings = "^1.7.0"
 furo = "^2023.09.10"
 gitpython = "^3"
@@ -131,6 +128,7 @@ fix = true
 
 [tool.ruff.lint]
 select = [
+  "A",
   "B",
   "C4",
   "E",

--- a/tests/test_scene_rendering/simple_scenes.py
+++ b/tests/test_scene_rendering/simple_scenes.py
@@ -135,7 +135,7 @@ class SceneWithSections(Scene):
         )
         self.wait(2)
 
-        self.next_section(type=PresentationSectionType.SKIP)
+        self.next_section(section_type=PresentationSectionType.SKIP)
         self.wait()
 
         self.next_section(


### PR DESCRIPTION
Migrating from `flake8-builtins` to Ruff.
After this PR and #3881 we should no longer have `flake8` in pre-commit or CI!

As discussed on discord, we opted to break backwards compatibility with this PR. The changes to user code however, should still be minimal, and are listed below.
* `ManimColor.from_hex(hex=...)` to `ManimColor.from_hex(...)` or `ManimColor.from_hex(hex_str=...)`
* `Scene.next_section(type=...)` to `Scene.next_section(section_type=...)`