### PR TITLE
Add new method of specifying seed

### DIFF
--- a/manim/_config/logger_utils.py
+++ b/manim/_config/logger_utils.py
@@ -95,6 +95,11 @@ def make_logger(
         keywords=HIGHLIGHTED_KEYWORDS,
     )
 
+    # redirect warnings.warn to logging.warn
+    logging.captureWarnings(True)
+    py_warning = logging.getLogger("py.warnings")
+    py_warning.addHandler(rich_handler)
+
     # finally, the logger
     logger = logging.getLogger("manim")
     logger.addHandler(rich_handler)

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -97,6 +97,15 @@ class Scene:
             def construct(self):
                 self.play(Write(Text("Hello World!")))
 
+    You can specify the seed for random functions inside Manim via :attr:`Scene.random_seed`.
+
+    .. code-block:: python
+
+        class MyScene(Scene):
+            random_seed = 3
+
+            def construct(self): ...
+
     """
 
     random_seed: int | None = None

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -14,6 +14,7 @@ import random
 import threading
 import time
 import types
+import warnings
 from queue import Queue
 
 import srt
@@ -98,17 +99,30 @@ class Scene:
 
     """
 
+    random_seed: int | None = None
+
     def __init__(
         self,
-        renderer=None,
-        camera_class=Camera,
-        always_update_mobjects=False,
-        random_seed=None,
-        skip_animations=False,
+        renderer: OpenGLRenderer | CairoRenderer | None = None,
+        camera_class: type[Camera] = Camera,
+        always_update_mobjects: bool = False,
+        random_seed: int | None = None,
+        skip_animations: bool = False,
     ):
         self.camera_class = camera_class
         self.always_update_mobjects = always_update_mobjects
-        self.random_seed = random_seed
+
+        if random_seed is not None:
+            warnings.warn(
+                "Setting the random seed in the Scene constructor is deprecated. "
+                "Please set the class attribute random_seed instead.",
+                category=FutureWarning,
+                # assuming no scene subclassing, this should refer
+                # to instantiation of the Scene
+                stacklevel=4,
+            )
+            self.random_seed = random_seed
+
         self.skip_animations = skip_animations
 
         self.animations = None

--- a/mypy.ini
+++ b/mypy.ini
@@ -82,6 +82,9 @@ ignore_errors = True
 [mypy-manim.utils.*]
 ignore_errors = True
 
+[mypy-manim.utils.deprecation]
+ignore_errors = False
+
 [mypy-manim.utils.iterables]
 ignore_errors = False
 warn_return_any = False

--- a/tests/module/scene/test_scene.py
+++ b/tests/module/scene/test_scene.py
@@ -101,3 +101,19 @@ def test_replace(dry_run):
     scene.replace(second, beta)
     assert_names(scene.mobjects, ["alpha", "group", "fourth"])
     assert_names(scene.mobjects[1], ["beta", "third"])
+
+
+def test_random_seed():
+    class GoodScene(Scene):
+        random_seed = 3
+
+    class BadScene(Scene):
+        def __init__(self):
+            super().__init__(random_seed=3)
+
+    good = GoodScene()
+    assert good.random_seed == 3
+
+    with pytest.warns(FutureWarning):
+        bad = BadScene()
+    assert bad.random_seed == 3


### PR DESCRIPTION
## Overview: What does this pull request change?
This pull request
- Changes `random_seed` from a `__init__` argument to a class variable, and deprecates the argument in `__init__`
- Typehints `manim.utils.deprecation`
- Configures the python stdlib module `warnings` to use `logging`.


## Motivation and Explanation: Why and how do your changes improve the library?
It's fairly tedious to set the seed via
```py
class MyScene(Scene):
    def __init__(self):
        super().__init__(random_seed=3)
```
It's much nicer to do
```py
class MyScene(Scene):
    random_seed = 3
```

This also is similar to how it works on the xperimental branch.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
