### PR TITLE
Simplify Sector Class by Removing Redundant Parameters

### DIFF
--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -897,17 +897,15 @@ class Sector(AnnularSector):
 
         class ExampleSector(Scene):
             def construct(self):
-                sector = Sector(outer_radius=2, inner_radius=1)
-                sector2 = Sector(outer_radius=2.5, inner_radius=0.8).move_to([-3, 0, 0])
+                sector = Sector(radius=2)
+                sector2 = Sector(radius=2.5, angle=60*DEGREES).move_to([-3, 0, 0])
                 sector.set_color(RED)
                 sector2.set_color(PINK)
                 self.add(sector, sector2)
     """
 
-    def __init__(
-        self, outer_radius: float = 1, inner_radius: float = 0, **kwargs
-    ) -> None:
-        super().__init__(inner_radius=inner_radius, outer_radius=outer_radius, **kwargs)
+    def __init__(self, radius: float = 1, **kwargs) -> None:
+        super().__init__(inner_radius = 0, outer_radius = radius, **kwargs)
 
 
 class Annulus(Circle):

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -905,7 +905,7 @@ class Sector(AnnularSector):
     """
 
     def __init__(self, radius: float = 1, **kwargs) -> None:
-        super().__init__(inner_radius = 0, outer_radius = radius, **kwargs)
+        super().__init__(inner_radius=0, outer_radius=radius, **kwargs)
 
 
 class Annulus(Circle):


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
This pull request refines the `Sector` class by removing the redundant parameters `inner_radius` and `outer_radius`, simplifying the constructor to accept only a single `radius` parameter. The `inner_radius` is now automatically set to `0`, reflecting the true geometric nature of a sector.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Currently, the `Sector` class in Manim inherits parameters, including `inner_radius` and `outer_radius`, from the `AnnularSector` class. 
This makes the `Sector` class exactly the same as the `AnnularSector` class. This is why the examples given in the Manim Documentation for the `Sector` class are examples of `AnnularSector`.

Actually, the `Sector` is conceptually a special case of `AnnularSector` where `inner_radius` should always be `0`. This means that the `Sector` class should only require a single parameter, `radius`, which is then directly passed to `outer_radius` of `AnnularSector`.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
The examples provided in the Manim documentation for the `Sector` class actually depict scenarios that are more representative of the `AnnularSector` class. This highlights the confusion caused by the redundant parameters.

1. Current Documentation Example of `Sector`:
![Screenshot 2024-08-30 214305](https://github.com/user-attachments/assets/6b04ac69-4f54-40c4-8f2c-6a064a0e8f47)
That example is similar to Example of `AnnularSector`:
![Screenshot 2024-08-30 214251](https://github.com/user-attachments/assets/04b77ad8-ec17-4d40-bfcc-da08b4b804f2)

2. Correct Sector Representation
The following image depicts what a Sector should look like when only the `radius` is provided, with `inner_radius` set to 0. It accurately represents a sector, demonstrating how the simplified constructor correctly models this geometric shape.
![Screenshot 2024-08-30 215031](https://github.com/user-attachments/assets/1ea62825-3f37-4c73-9e68-61303239dfd3)


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
