### PR TITLE
Add PEP 749 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,9 +191,6 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
   "F403",
 ]
 
-[tool.ruff.lint.isort]
-required-imports = ["from __future__ import annotations"]
-
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false


### PR DESCRIPTION
Removes the required `from __future__ import annotations` to be compatible with [PEP 749](https://peps.python.org/pep-0749/), which deprecates `from __future__ import annotations`