### PR TITLE
Fix crash due to bad rounding in BarChart when no y_step was provided and the max y value was close to 0

### DIFF
--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -330,7 +330,7 @@ class NumberLine(Line):
             x_max += 1e-6
 
         # Handle cases where min and max are both positive or both negative
-        if x_min < x_max < 0 or x_max > x_min > 0:
+        if x_min < x_max < 0 or x_max > x_min >= 0:
             tick_range = np.arange(x_min, x_max, x_step)
         else:
             start_point = 0

--- a/manim/mobject/graphing/probability.py
+++ b/manim/mobject/graphing/probability.py
@@ -280,7 +280,8 @@ class BarChart(Axes):
             ]
 
         elif len(y_range) == 2:
-            y_range = [*y_range, round(max(self.values) / y_length, 2)]
+            y_step_target = max(self.values) / y_length
+            y_range = [*y_range, round(y_step_target, int(np.ceil(-np.log10(y_step_target))))]
 
         if x_length is None:
             x_length = min(len(self.values), config.frame_width - 2)


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

This PR fixes a bug in BarChart that lead to a crash if the user did not provide the `y_step` (i.e. tick rate, the user provided `y_range=[y_min, y_max]`) **and** the y values were very close to 0 (`round(max(ys), 2)` == 0).

## Motivation and Explanation: Why and how do your changes improve the library?
When the user only provided the minimum and maximum of the y_range, the code for BarChart was deducing the tick rate for the y axis using the following code: 
```python
round(max(self.values) / y_length, 2)
```
However, this returns 0 if the maximum is small, because it is rounded down to zero. This lead to a division by zero in a np.arrange downstream. This issue can be fixed by replacing the `2` by a computed value.

This PR replaces the hard-coded `2` with $\lceil - \log_{10}(x) \rceil$, with $x$ being equal to `max(self.values) / y_length` (unrounded y_step in the original code)

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [x] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [x] If applicable: newly added functions and classes are tested
