### PR TITLE
Fix np.float_ to np.float64 while using numpy >= 2.0

### DIFF
--- a/manim/utils/iterables.py
+++ b/manim/utils/iterables.py
@@ -33,7 +33,7 @@ import numpy as np
 
 T = TypeVar("T")
 U = TypeVar("U")
-F = TypeVar("F", np.float_, np.int_)
+F = TypeVar("F", np.float64, np.int_)
 H = TypeVar("H", bound=Hashable)
 
 
@@ -311,8 +311,8 @@ def resize_array(nparray: npt.NDArray[F], length: int) -> npt.NDArray[F]:
 
 
 def resize_preserving_order(
-    nparray: npt.NDArray[np.float_], length: int
-) -> npt.NDArray[np.float_]:
+    nparray: npt.NDArray[np.float64], length: int
+) -> npt.NDArray[np.float64]:
     """Extends/truncates nparray so that ``len(result) == length``.
         The elements of nparray are duplicated to achieve the desired length
         (favours earlier elements).


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
use np.float64 while numpy >= 2.0

<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
