### PR TITLE
Make combination of video + audio streams more robust; fix incompatibility with `pyav >= 13.0.0`

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -774,7 +774,9 @@ class SceneFileWriter:
                             rate=audio_stream.codec_context.sample_rate,
                         )
                     else:
-                        output_audio_stream = output_container.add_stream(template=audio_stream)
+                        output_audio_stream = output_container.add_stream(
+                            template=audio_stream
+                        )
                     output_audio_streams.append(output_audio_stream)
 
                 for packet in video_input.demux(video_stream):


### PR DESCRIPTION
This rewrites the remuxing and combination of the video + audio streams that have been produced throughout `Scene.render`, which is happening in the `SceneFileWriter.combine_to_movie` method. The rewritten version now works (at least locally) for `pyav >= 12.0.0`, while the previous version apparently only worked for `pyav >= 12.0.0, pyav < 13.0.0`.

As the RTD render images apparently predominantly had a more recent release of pyav, this is what broke the docbuilld for recent builds.

The rewritten version
- differs from the old one primarily in the way how audio streams are added to the final output container. In cases where we target `mp4` output, instantiating the stream directly from the stream given in the auxiliary audio file broke rendering, so now we instantiate it by passing codec name and sample rate explicitly.
- additionally supports cases where audio files with multiple audio channels are created.