### PR TITLE
Set AAC codec for audio in mp4 files, add transcoding utility

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -6,6 +6,7 @@ __all__ = ["SceneFileWriter"]
 
 import json
 import shutil
+from fractions import Fraction
 from pathlib import Path
 from queue import Queue
 from tempfile import NamedTemporaryFile
@@ -54,7 +55,7 @@ def to_av_frame_rate(fps):
         if abs(fps - num / denom) >= epsilon2:
             raise ValueError("invalid frame rate")
 
-    return av.utils.Fraction(num, denom)
+    return Fraction(num, denom)
 
 
 def convert_audio(input_path: Path, output_path: Path, codec_name: str):

--- a/tests/test_scene_rendering/test_file_writer.py
+++ b/tests/test_scene_rendering/test_file_writer.py
@@ -4,8 +4,10 @@ from pathlib import Path
 import av
 import numpy as np
 import pytest
+from av.utils import Fraction
 
 from manim import DR, Circle, Create, Scene, Star, tempconfig
+from manim.scene.scene_file_writer import to_av_frame_rate
 from manim.utils.commands import capture, get_video_metadata
 
 
@@ -175,3 +177,11 @@ def test_unicode_partial_movie(tmpdir, simple_scenes_path):
 
     _, err, exit_code = capture(command)
     assert exit_code == 0, err
+
+
+def test_frame_rates():
+    assert to_av_frame_rate(25) == Fraction(25, 1)
+    assert to_av_frame_rate(24.0) == Fraction(24, 1)
+    assert to_av_frame_rate(23.976) == Fraction(24 * 1000, 1001)
+    assert to_av_frame_rate(23.98) == Fraction(24 * 1000, 1001)
+    assert to_av_frame_rate(59.94) == Fraction(60 * 1000, 1001)

--- a/tests/test_scene_rendering/test_file_writer.py
+++ b/tests/test_scene_rendering/test_file_writer.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import av
 import numpy as np
 import pytest
-from av.utils import Fraction
+from fractions import Fraction
 
 from manim import DR, Circle, Create, Scene, Star, tempconfig
 from manim.scene.scene_file_writer import to_av_frame_rate

--- a/tests/test_scene_rendering/test_file_writer.py
+++ b/tests/test_scene_rendering/test_file_writer.py
@@ -1,10 +1,10 @@
 import sys
+from fractions import Fraction
 from pathlib import Path
 
 import av
 import numpy as np
 import pytest
-from fractions import Fraction
 
 from manim import DR, Circle, Create, Scene, Star, tempconfig
 from manim.scene.scene_file_writer import to_av_frame_rate


### PR DESCRIPTION
When the output format is mp4, pyav seems to reject wav-format audio. Convert to AAC.

Also, certain versions of pyav reject frame rates specified as float. Ensure `frame_rate` has type `Fraction`.