### PR TITLE
Fix: `.to_edge()`'s example demonstration in docs

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1501,6 +1501,7 @@ class Mobject:
                     self.add(tex_top, tex_side)
                     tex_side.to_edge(LEFT)
                     c.to_edge(RIGHT, buff=0)
+                    self.add(c)
 
         """
         return self.align_on_border(edge, buff)

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1498,10 +1498,9 @@ class Mobject:
                     tex_top.to_edge(UP)
                     tex_side = Tex("I am moving to the side!")
                     c = Circle().shift(2*DOWN)
-                    self.add(tex_top, tex_side)
+                    self.add(tex_top, tex_side, c)
                     tex_side.to_edge(LEFT)
                     c.to_edge(RIGHT, buff=0)
-                    self.add(c)
 
         """
         return self.align_on_border(edge, buff)


### PR DESCRIPTION
## Fixed `.to_edge()`'s example demonstration in docs
Added the missing object (`c: Circle`) in the scene demonstrating `.to_edge(RIGHT)` [here](https://docs.manim.community/en/stable/reference/manim.mobject.mobject.Mobject.html#toedgeexample) -
![image](https://github.com/user-attachments/assets/7eded0e6-f620-4f77-9a12-ca65ac4361a5)

## Motivation and Explanation:
The example on [To Edge Example](https://docs.manim.community/en/stable/reference/manim.mobject.mobject.Mobject.html#toedgeexample) demonstrated the use of `.to_edge()` method with three objects, two of them were added (in #3408) to the scene but one was missed. I was just reading through the docs, and was confused for a second looking for the missing circle.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
https://manimce--3958.org.readthedocs.build/en/3958/reference/manim.mobject.mobject.Mobject.html#toedgeexample But this link doesn't seem to work

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] ~~If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section~~
- [ ] ~~If applicable: newly added functions and classes are tested~~
