### PR TITLE
draft of section group feature

### DIFF
--- a/manim/__init__.py
+++ b/manim/__init__.py
@@ -75,6 +75,7 @@ from .mobject.types.vectorized_mobject import *
 from .mobject.value_tracker import *
 from .mobject.vector_field import *
 from .renderer.cairo_renderer import *
+from .scene.groups import *
 from .scene.moving_camera_scene import *
 from .scene.scene import *
 from .scene.scene_file_writer import *

--- a/manim/scene/groups.py
+++ b/manim/scene/groups.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import types
+from collections.abc import Callable
+from typing import TYPE_CHECKING, ClassVar, Generic, ParamSpec, TypeVar, final, overload
+
+from typing_extensions import Self, TypedDict, Unpack
+
+if TYPE_CHECKING:
+    from .scene import Scene
+
+__all__ = ["group"]
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class SectionGroupData(TypedDict, total=False):
+    """(Public) data for a :class:`.SectionGroup` in a :class:`.Scene`."""
+
+    skip: bool
+    order: int
+
+
+# mark as final because _cls_instance_count doesn't
+# work with inheritance
+@final
+class SectionGroup(Generic[P, T]):
+    """A section in a :class:`.Scene`.
+
+    It holds data about each subsection, and keeps track of the order
+    of the sections via :attr:`~SectionGroup.order`.
+
+    .. warning::
+
+        :attr:`~SectionGroup.func` is effectively a function - it is not
+        bound to the scene, and thus must be called with the first argument
+        as an instance of :class:`.Scene`.
+    """
+
+    _cls_instance_count: ClassVar[int] = 0
+    """How many times the class has been instantiated.
+
+    This is also used for ordering sections, because of the order
+    decorators are called in a class.
+    """
+
+    def __init__(
+        self, func: Callable[P, T], **kwargs: Unpack[SectionGroupData]
+    ) -> None:
+        self.func = func
+
+        self.skip = kwargs.get("skip", False)
+
+        # update the order counter
+        self.order = self._cls_instance_count
+        self.__class__._cls_instance_count += 1
+        if "order" in kwargs:
+            self.order = kwargs["order"]
+
+    def __str__(self) -> str:
+        skip = self.skip
+        order = self.order
+        return f"{self.__class__.__name__}({order=}, {skip=})"
+
+    def __repr__(self) -> str:
+        # return a slightly more verbose repr
+        s = str(self).removesuffix(")")
+        func = self.func
+        return f"{s}, {func=})"
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
+        return self.func(*args, **kwargs)
+
+    def bind(self, instance: Scene) -> Self:
+        """Binds :attr:`func` to the scene instance, making :attr:`func` a method.
+
+        This allows the section to be called without the scene being passed explicitly.
+        """
+        self.func = types.MethodType(self.func, instance)
+        return self
+
+    def __get__(self, instance: Scene, _owner: type[Scene]) -> Self:
+        """Descriptor to bind the section to the scene instance.
+
+        This is called implicitly by python when methods are being bound.
+        """
+        return self  # HELPME use binding
+        return self.bind(instance)
+
+
+@overload
+def group(
+    func: Callable[P, T],
+    **kwargs: Unpack[SectionGroupData],
+) -> SectionGroup[P, T]: ...
+
+
+@overload
+def group(
+    func: None = None,
+    **kwargs: Unpack[SectionGroupData],
+) -> Callable[[Callable[P, T]], SectionGroup[P, T]]: ...
+
+
+def group(
+    func: Callable[P, T] | None = None, **kwargs: Unpack[SectionGroupData]
+) -> SectionGroup[P, T] | Callable[[Callable[P, T]], SectionGroup[P, T]]:
+    r"""Decorator to create a SectionGroup in the scene.
+
+    Example
+    -------
+
+        .. code-block:: python
+
+            class MyScene(Scene):
+                SectionGroups_api = True
+
+                @SectionGroup
+                def first_SectionGroup(self):
+                    pass
+
+                @SectionGroup(skip=True)
+                def second_SectionGroup(self):
+                    pass
+
+    Parameters
+    ----------
+        func : Callable
+            The subsection.
+        skip : bool, optional
+            Whether to skip the section, by default False
+    """
+
+    def wrapper(func: Callable[P, T]) -> SectionGroup[P, T]:
+        return SectionGroup(func, **kwargs)
+
+    return wrapper(func) if func is not None else wrapper

--- a/tests/test_scene_rendering/simple_scenes.py
+++ b/tests/test_scene_rendering/simple_scenes.py
@@ -17,6 +17,8 @@ __all__ = [
     "InteractiveStaticScene",
     "SceneWithSections",
     "ElaborateSceneWithSections",
+    "SceneWithGroupAPI",
+    "SceneWithGroupList",
 ]
 
 
@@ -165,3 +167,39 @@ class ElaborateSceneWithSections(Scene):
         self.next_section("fade out")
         self.play(FadeOut(square))
         self.wait()
+
+
+class SceneWithGroupAPI(Scene):
+    groups_api = True
+
+    def __init__(self):
+        super().__init__()
+
+        self.square = Square()
+        self.circle = Circle()
+
+    @group
+    def transform(self):
+        self.play(TransformFromCopy(self.square, self.circle))
+
+    @group
+    def back_transform(self):
+        self.play(Transform(self.circle, self.square))
+
+
+class SceneWithGroupList(Scene):
+    section_groups = ["transform", "back_transform"]
+
+    def __init__(self):
+        super().__init__()
+
+        self.square = Square()
+        self.circle = Circle()
+
+    @group
+    def back_transform(self):
+        self.play(Transform(self.circle, self.square))
+
+    @group
+    def transform(self):
+        self.play(TransformFromCopy(self.square, self.circle))

--- a/tests/test_scene_rendering/test_sections.py
+++ b/tests/test_scene_rendering/test_sections.py
@@ -8,6 +8,7 @@ from manim import capture
 from tests.assert_utils import assert_dir_exists, assert_dir_not_exists
 
 from ..utils.video_tester import video_comparison
+from .simple_scenes import SceneWithGroupAPI, SceneWithGroupList, SquareToCircle
 
 
 @pytest.mark.slow
@@ -103,3 +104,21 @@ def test_skip_animations(tmp_path, manim_cfg_file, simple_scenes_path):
     ]
     _, err, exit_code = capture(command)
     assert exit_code == 0, err
+
+
+def test_groups_api(tmp_path):
+    find_api_scene = SceneWithGroupAPI()
+    list_api_scene = SceneWithGroupList()
+
+    assert not SquareToCircle().section_groups
+    assert len(list_api_scene.section_groups) == len(find_api_scene.section_groups) == 2
+    assert (
+        list_api_scene.section_groups[0].func.__name__
+        == find_api_scene.section_groups[0].func.__name__
+        == "transform"
+    )
+    assert (
+        list_api_scene.section_groups[1].func.__name__
+        == find_api_scene.section_groups[1].func.__name__
+        == "back_transform"
+    )


### PR DESCRIPTION
## Overview:
Adds a group decorator to Scene that are basically "sections group".

```python
class SceneWithGroupAPI(Scene):
    groups_api = True # groups are read from top to bottom

    def __init__(self):
        super().__init__()

        self.square = Square()
        self.circle = Circle()

    @group
    def transform(self):
        self.play(TransformFromCopy(self.square, self.circle))

    @group
    def back_transform(self):
        self.play(Transform(self.circle, self.square))


class SceneWithGroupList(Scene):
    section_groups = ["transform", "back_transform"] # group order is specified by user (groups may even be repeated)

    def __init__(self):
        super().__init__()

        self.square = Square()
        self.circle = Circle()

    @group
    def back_transform(self):
        self.play(Transform(self.circle, self.square))

    @group
    def transform(self):
        self.play(TransformFromCopy(self.square, self.circle))
```

## Motivation and Explanation: Why and how do your changes improve the library?
For long videos you may want to have 2 levels of granularity for skipping/animation parts of the videos. Sections are the basic building block like a few animations and they are rendered in the same way as before.
You may add groups that behave like "chapters". They are a sequence of sections (you can still put sections inside groups) and the skipping/animation of section groups takes precedence over the individual section skipping/animation.

To make the distinction between sections and section groups the experimental API for sections is used. This way creating section is unchanged and we can gain the flexibility of the experimental API. Actually most of the code for the definition of a ```SectionGroup``` is taken from the experimental ```Section``` object.

## Links to added or changed documentation pages
The documentation must be done but the API is not stabilized. I'll wait for the namming to be correct before documenting.
It should go in the section page I think.

## Additional comments
There is a feature in the SectionGroup object to make it become a full member of the Scene instance that I couldn't make work.
For now section groups must be called like ```group(self)```.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
