### PR TITLE
Add a time property to scene

### DIFF
--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -159,7 +159,7 @@ class Scene:
         return self.renderer.camera
 
     @property
-    def time(self):
+    def time(self) -> float:
         """The time since the start of the scene."""
         return self.renderer.time
 

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -158,6 +158,11 @@ class Scene:
     def camera(self):
         return self.renderer.camera
 
+    @property
+    def time(self):
+        """The time since the start of the scene."""
+        return self.time
+
     def __deepcopy__(self, clone_from_id):
         cls = self.__class__
         result = cls.__new__(cls)
@@ -1083,15 +1088,15 @@ class Scene:
             )
             return
 
-        start_time = self.renderer.time
+        start_time = self.time
         self.renderer.play(self, *args, **kwargs)
-        run_time = self.renderer.time - start_time
+        run_time = self.time - start_time
         if subcaption:
             if subcaption_duration is None:
                 subcaption_duration = run_time
             # The start of the subcaption needs to be offset by the
             # run_time of the animation because it is added after
-            # the animation has already been played (and Scene.renderer.time
+            # the animation has already been played (and Scene.time
             # has already been updated).
             self.add_subcaption(
                 content=subcaption,
@@ -1504,7 +1509,7 @@ class Scene:
         r"""Adds an entry in the corresponding subcaption file
         at the current time stamp.
 
-        The current time stamp is obtained from ``Scene.renderer.time``.
+        The current time stamp is obtained from ``Scene.time``.
 
         Parameters
         ----------
@@ -1541,10 +1546,8 @@ class Scene:
         subtitle = srt.Subtitle(
             index=len(self.renderer.file_writer.subcaptions),
             content=content,
-            start=datetime.timedelta(seconds=float(self.renderer.time + offset)),
-            end=datetime.timedelta(
-                seconds=float(self.renderer.time + offset + duration)
-            ),
+            start=datetime.timedelta(seconds=float(self.time + offset)),
+            end=datetime.timedelta(seconds=float(self.time + offset + duration)),
         )
         self.renderer.file_writer.subcaptions.append(subtitle)
 
@@ -1592,7 +1595,7 @@ class Scene:
         """
         if self.renderer.skip_animations:
             return
-        time = self.renderer.time + time_offset
+        time = self.time + time_offset
         self.renderer.file_writer.add_sound(sound_file, time, gain, **kwargs)
 
     def on_mouse_motion(self, point, d_point):

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -161,7 +161,7 @@ class Scene:
     @property
     def time(self):
         """The time since the start of the scene."""
-        return self.time
+        return self.renderer.time
 
     def __deepcopy__(self, clone_from_id):
         cls = self.__class__

--- a/tests/module/scene/test_scene.py
+++ b/tests/module/scene/test_scene.py
@@ -41,14 +41,14 @@ def test_scene_add_remove(dry_run):
 
 def test_scene_time(dry_run):
     scene = Scene()
-    assert scene.renderer.time == 0
+    assert scene.time == 0
     scene.wait(2)
-    assert scene.renderer.time == 2
+    assert scene.time == 2
     scene.play(FadeIn(Circle()), run_time=0.5)
-    assert pytest.approx(scene.renderer.time) == 2.5
+    assert pytest.approx(scene.time) == 2.5
     scene.renderer._original_skipping_status = True
     scene.play(FadeIn(Square()), run_time=5)  # this animation gets skipped.
-    assert pytest.approx(scene.renderer.time) == 7.5
+    assert pytest.approx(scene.time) == 7.5
 
 
 def test_subcaption(dry_run):

--- a/tests/test_scene_rendering/test_play_logic.py
+++ b/tests/test_scene_rendering/test_play_logic.py
@@ -78,14 +78,14 @@ def test_non_static_wait_detection(using_temp_config, disabling_caching):
 def test_wait_with_stop_condition(using_temp_config, disabling_caching):
     class TestScene(Scene):
         def construct(self):
-            self.wait_until(lambda: self.renderer.time >= 1)
-            assert self.renderer.time >= 1
+            self.wait_until(lambda: self.time >= 1)
+            assert self.time >= 1
             d = Dot()
             d.add_updater(lambda mobj, dt: self.add(Mobject()))
             self.add(d)
             self.play(Wait(run_time=5, stop_condition=lambda: len(self.mobjects) > 5))
             assert len(self.mobjects) > 5
-            assert self.renderer.time < 2
+            assert self.time < 2
 
     scene = TestScene()
     scene.render()


### PR DESCRIPTION
Gives users access to the time passed since the scene started.
This is also easier to maintain compatibility with in experimental, rather than `renderer.time`