### PR TITLE
Stop ignoring `manim.plugins` errors in `mypy.ini`

### DIFF
--- a/manim/plugins/__init__.py
+++ b/manim/plugins/__init__.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from manim import config, logger
-
-from .plugins_flags import get_plugins, list_plugins
+from manim._config import config, logger
+from manim.plugins.plugins_flags import get_plugins, list_plugins
 
 __all__ = [
     "get_plugins",

--- a/manim/plugins/plugins_flags.py
+++ b/manim/plugins/plugins_flags.py
@@ -10,7 +10,7 @@ if sys.version_info < (3, 10):
 else:
     from importlib.metadata import entry_points
 
-from manim import console
+from manim._config import console
 
 __all__ = ["list_plugins"]
 
@@ -27,5 +27,5 @@ def list_plugins() -> None:
     console.print("[green bold]Plugins:[/green bold]", justify="left")
 
     plugins = get_plugins()
-    for plugin in plugins:
-        console.print(f" • {plugin}")
+    for plugin_name in plugins:
+        console.print(f" • {plugin_name}")

--- a/mypy.ini
+++ b/mypy.ini
@@ -73,9 +73,6 @@ ignore_errors = True
 [mypy-manim.mobject.geometry.*]
 ignore_errors = False
 
-[mypy-manim.plugins.*]
-ignore_errors = True
-
 [mypy-manim.renderer.*]
 ignore_errors = True
 


### PR DESCRIPTION
Related issue: #3375

`manim.plugins` already has typings. It only needs to have its configuration modified in `mypy.ini`.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
