### PR TITLE
Fix incorrect assignment in Mobject.put_start_and_end_on

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1778,10 +1778,7 @@ class Mobject:
         curr_start, curr_end = self.get_start_and_end()
         curr_vect = curr_end - curr_start
         if np.all(curr_vect == 0):
-            # TODO: this looks broken. It makes self.points a Point3D instead
-            # of a Point3D_Array. However, modifying this breaks some tests
-            # where this is currently expected.
-            self.points = np.array(start)
+            self.points = np.array([start])
             return self
         target_vect = np.asarray(end) - np.asarray(start)
         axis = (

--- a/tests/module/mobject/graphing/test_number_line.py
+++ b/tests/module/mobject/graphing/test_number_line.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from manim import DashedLine, NumberLine
+from manim import Line, NumberLine
 from manim.mobject.text.numbers import Integer
 
 
@@ -126,7 +126,8 @@ def test_point_to_number():
 
 
 def test_start_and_end_at_same_point():
-    line = DashedLine(np.zeros(3), np.zeros(3))
-    line.put_start_and_end_on(np.zeros(3), np.array([0, 0, 0]))
+    point = [1.0, 2.0, 3.0]
+    line = Line(point, point)
+    line.put_start_and_end_on(point, point)
 
-    np.testing.assert_array_equal(np.round(np.zeros(3), 4), np.round(line.points, 4))
+    np.testing.assert_array_equal(np.round([point], 4), np.round(line.points, 4))


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
PR #3718 changed the behavior of `Mobject.put_start_and_end_on` when `start == end`, however the assigment to `self.points` was incorrect. The existing code assigned the Point3D directly to `self.points`, that then becomes an array with shape `(3,)`, while instead it should really have shape `(1, 3)`.

This commit fixes the incorrect code and associated test.

<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
