### PR TITLE
Fix scene skipping for `config.upto_animation_number` (`-n` flag in CLI) set to 0 to end after first animation

### DIFF
--- a/manim/renderer/cairo_renderer.py
+++ b/manim/renderer/cairo_renderer.py
@@ -252,13 +252,13 @@ class CairoRenderer:
         if config["save_last_frame"]:
             self.skip_animations = True
         if (
-            config["from_animation_number"]
-            and self.num_plays < config["from_animation_number"]
+            config.from_animation_number > 0
+            and self.num_plays < config.from_animation_number
         ):
             self.skip_animations = True
         if (
-            config["upto_animation_number"]
-            and self.num_plays > config["upto_animation_number"]
+            config.upto_animation_number >= 0
+            and self.num_plays > config.upto_animation_number
         ):
             self.skip_animations = True
             raise EndSceneEarlyException()

--- a/manim/renderer/opengl_renderer.py
+++ b/manim/renderer/opengl_renderer.py
@@ -400,13 +400,13 @@ class OpenGLRenderer:
         if self.file_writer.sections[-1].skip_animations:
             self.skip_animations = True
         if (
-            config["from_animation_number"]
-            and self.num_plays < config["from_animation_number"]
+            config.from_animation_number > 0
+            and self.num_plays < config.from_animation_number
         ):
             self.skip_animations = True
         if (
-            config["upto_animation_number"]
-            and self.num_plays > config["upto_animation_number"]
+            config.upto_animation_number >= 0
+            and self.num_plays > config.upto_animation_number
         ):
             self.skip_animations = True
             raise EndSceneEarlyException()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -260,10 +260,8 @@ def test_from_to_animations_only_first_animation(config):
             self.renderer.update_skipping_status()
             self.after_first_animation = True
             self.play(s.animate.scale(2))
-            
-            
+
     scene = SceneWithTwoAnimations()
     scene.render()
 
     assert scene.after_first_animation is False
-    

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -244,3 +244,26 @@ def test_tex_template_file(tmp_path):
 
     assert Path(custom_config.tex_template_file) == tex_file
     assert custom_config.tex_template.body == "Hello World!"
+
+
+def test_from_to_animations_only_first_animation(config):
+    config: ManimConfig
+    config.from_animation_number = 0
+    config.upto_animation_number = 0
+
+    class SceneWithTwoAnimations(Scene):
+        def construct(self):
+            self.after_first_animation = False
+            s = Square()
+            self.add(s)
+            self.play(s.animate.scale(2))
+            self.renderer.update_skipping_status()
+            self.after_first_animation = True
+            self.play(s.animate.scale(2))
+            
+            
+    scene = SceneWithTwoAnimations()
+    scene.render()
+
+    assert scene.after_first_animation is False
+    


### PR DESCRIPTION
The current check against `config.upto_animation_number` checks whether the value is truthy, when in fact we should check whether it is non-negative.

Fixes #4012.