### PR TITLE
Add typings to `tex_mobject.py` and `numbers.py`

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -14,10 +14,9 @@ import random
 import sys
 import types
 import warnings
-from collections.abc import Iterable
 from functools import partialmethod, reduce
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -40,13 +39,15 @@ from ..utils.paths import straight_path
 from ..utils.space_ops import angle_between_vectors, normalize, rotation_matrix
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from typing import Callable, Literal
+
     from typing_extensions import Self, TypeAlias
 
     from manim.typing import (
         FunctionOverride,
         InternalPoint3D,
         ManimFloat,
-        ManimInt,
         MappingFunction,
         PathFuncType,
         PixelArray,
@@ -100,18 +101,18 @@ class Mobject:
         color: ParsableManimColor | list[ParsableManimColor] = WHITE,
         name: str | None = None,
         dim: int = 3,
-        target=None,
+        target: Mobject | None = None,
         z_index: float = 0,
     ) -> None:
-        self.name = self.__class__.__name__ if name is None else name
-        self.dim = dim
-        self.target = target
-        self.z_index = z_index
+        self.name: str = self.__class__.__name__ if name is None else name
+        self.dim: int = dim
+        self.target: Mobject | None = target
+        self.z_index: float = z_index
         self.point_hash = None
-        self.submobjects = []
+        self.submobjects: Sequence[Mobject] = []
         self.updaters: list[Updater] = []
         self.updating_suspended = False
-        self.color = ManimColor.parse(color)
+        self.color: ManimColor | list[ManimColor] = ManimColor.parse(color)
 
         self.reset_points()
         self.generate_points()
@@ -2291,16 +2292,16 @@ class Mobject:
         """Return the base class of this mobject type."""
         return Mobject
 
-    def split(self) -> list[Self]:
+    def split(self) -> Sequence[Self]:
         result = [self] if len(self.points) > 0 else []
         return result + self.submobjects
 
-    def get_family(self, recurse: bool = True) -> list[Self]:
+    def get_family(self, recurse: bool = True) -> Sequence[Self]:
         sub_families = [x.get_family() for x in self.submobjects]
         all_mobjects = [self] + list(it.chain(*sub_families))
         return remove_list_redundancies(all_mobjects)
 
-    def family_members_with_points(self) -> list[Self]:
+    def family_members_with_points(self) -> Sequence[Self]:
         return [m for m in self.get_family() if m.get_num_points() > 0]
 
     def arrange(
@@ -2576,13 +2577,13 @@ class Mobject:
 
     def sort(
         self,
-        point_to_num_func: Callable[[Point3D], ManimInt] = lambda p: p[0],
-        submob_func: Callable[[Mobject], ManimInt] | None = None,
+        point_to_num_func: Callable[[Point3D], float] = lambda p: p[0],
+        submob_func: Callable[[Mobject], float] | None = None,
     ) -> Self:
         """Sorts the list of :attr:`submobjects` by a function defined by ``submob_func``."""
         if submob_func is None:
 
-            def submob_func(m: Mobject):
+            def submob_func(m: Mobject) -> float:
                 return point_to_num_func(m.get_center())
 
         self.submobjects.sort(key=submob_func)

--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
 
 import numpy as np
@@ -20,6 +21,9 @@ from ..geometry.line import Line
 from ..geometry.polygram import Polygon, Rectangle, RoundedRectangle
 from ..opengl.opengl_compatibility import ConvertToOpenGL
 from ..types.vectorized_mobject import VMobject
+
+if TYPE_CHECKING:
+    from manim.utils.color import ParsableManimColor
 
 __all__ = ["SVGMobject", "VMobjectFromSVGPath"]
 
@@ -98,11 +102,11 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
         should_center: bool = True,
         height: float | None = 2,
         width: float | None = None,
-        color: str | None = None,
+        color: ParsableManimColor | None = None,
         opacity: float | None = None,
-        fill_color: str | None = None,
+        fill_color: ParsableManimColor | None = None,
         fill_opacity: float | None = None,
-        stroke_color: str | None = None,
+        stroke_color: ParsableManimColor | None = None,
         stroke_opacity: float | None = None,
         stroke_width: float | None = None,
         svg_default: dict | None = None,

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -14,8 +14,8 @@ __all__ = [
 
 import itertools as it
 import sys
-from collections.abc import Generator, Hashable, Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, Callable, Literal
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import numpy as np
 from PIL.Image import Image
@@ -48,7 +48,8 @@ from manim.utils.iterables import (
 from manim.utils.space_ops import rotate_vector, shoelace_direction
 
 if TYPE_CHECKING:
-    from typing import Any
+    from collections.abc import Generator, Hashable, Mapping, Sequence
+    from typing import Any, Callable, Literal
 
     import numpy.typing as npt
     from typing_extensions import Self

--- a/manim/mobject/value_tracker.py
+++ b/manim/mobject/value_tracker.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 __all__ = ["ValueTracker", "ComplexValueTracker"]
 
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from manim.mobject.mobject import Mobject
 from manim.mobject.opengl.opengl_compatibility import ConvertToOpenGL
 from manim.utils.paths import straight_path
+
+if TYPE_CHECKING:
+    from typing_extensions import Any
 
 
 class ValueTracker(Mobject, metaclass=ConvertToOpenGL):
@@ -69,7 +74,7 @@ class ValueTracker(Mobject, metaclass=ConvertToOpenGL):
 
     """
 
-    def __init__(self, value=0, **kwargs):
+    def __init__(self, value: float = 0, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.set(points=np.zeros((1, 3)))
         self.set_value(value)

--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -34,7 +34,7 @@ def tex_to_svg_file(
     expression: str,
     environment: str | None = None,
     tex_template: TexTemplate | None = None,
-):
+) -> Path:
     r"""Takes a tex expression and returns the svg version of the compiled tex
 
     Parameters


### PR DESCRIPTION
Important remarks:
- For some reason, MyPy can't determine the type of `VMobject.color`, even when I add typings to `Mobject.color` and `OpenGLMobject.color`. For this reason, I added `# type: ignore [has-type]` comments every time the `.color` attribute was used.
- I added a `TextLike` type alias. I didn't know how to make it a `TypeVar` for a more proper usage in `DecimalNumber._string_to_mob()`, because MyPy always reported a `Type variable TextLike is unbound` error, and I couldn't cover the different possible cases. Any suggestions are welcome.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
