### PR TITLE
Added missing default_numbers_to_display() in NumberClass

### DIFF
--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -484,6 +484,18 @@ class NumberLine(Line):
             # Align without the minus sign
             num_mob.shift(num_mob[0].width * LEFT / 2)
         return num_mob
+    
+    def default_numbers_to_display(self):
+        leftmost_tick = op.mul(
+            self.tick_frequency, np.ceil(self.x_min / self.tick_size)
+        )
+        numbers = np.arange(
+            np.floor(self.leftmost_tick),
+            np.ceil(self.x_max),
+        )
+        if self.exclude_zero_from_default_numbers:
+            numbers = numbers[numbers != 0]
+        return numbers
 
     def get_number_mobjects(self, *numbers, **kwargs) -> VGroup:
         if len(numbers) == 0:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
I added a default_numbers_to_display function in the NumberLine class.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
To fix issue #2473 - default_numbers_to_display is currently being called by get_number_mobjects in NumberLine without being defined.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
