### PR TITLE
Add support in documentation for type aliases using Python 3.12 `type` definition

### DIFF
--- a/manim/utils/docbuild/module_parsing.py
+++ b/manim/utils/docbuild/module_parsing.py
@@ -175,7 +175,7 @@ def parse_module_attributes() -> tuple[AliasDocsDict, DataDict, TypeVarDict]:
                     alias_name = node.name.id if is_type_alias else node.target.id
                     definition_node = node.value
 
-                    # If the definition is an Union, replace with vertical bar notation.
+                    # If the definition is a Union, replace with vertical bar notation.
                     # Instead of "Union[Type1, Type2]", we'll have "Type1 | Type2".
                     if (
                         type(definition_node) is ast.Subscript


### PR DESCRIPTION
Closes #3772 

I tested it by adding new type aliases and rewriting old ones with the new `type` syntax and it worked fine, in the same way as it does with our `TypeAlias`-annotated assignments. However, I must note that, when attempting to define `type ManimFloat = np.float64`, Manim crashes with a `TypeError: Cannot interpret 'ManimFloat' as a data type`.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
