### PR TITLE
[EXPERIMENTAL] Change order of statements in `OpenGLVMobject.__init__()` to prevent crashes in subclasses

### DIFF
--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -12,7 +12,7 @@ import sys
 from dataclasses import dataclass
 from functools import partialmethod, wraps
 from math import ceil
-from typing import TYPE_CHECKING, Generic
+from typing import TYPE_CHECKING, Any, Generic
 
 import numpy as np
 from typing_extensions import TypedDict, TypeVar
@@ -145,7 +145,7 @@ class OpenGLMobject:
         is_fixed_orientation: bool = False,
         depth_test: bool = True,
         name: str | None = None,
-        **kwargs,  # just dump
+        **kwargs: Any,  # just dump
     ):
         self.color = color
         self.opacity = opacity

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -103,6 +103,7 @@ class MobjectStatus:
 
 # TODO: add this to the **kwargs of all mobjects that use OpenGLMobject
 class MobjectKwargs(TypedDict, total=False):
+    color: ParsableManimColor | Sequence[ParsableManimColor] | None
     opacity: float
     reflectiveness: float
     shadow: float
@@ -110,7 +111,7 @@ class MobjectKwargs(TypedDict, total=False):
     is_fixed_in_frame: bool
     is_fixed_orientation: bool
     depth_test: bool
-    name: str
+    name: str | None
 
 
 class OpenGLMobject:
@@ -135,7 +136,7 @@ class OpenGLMobject:
     # TypedDict above so that autocomplete works for users
     def __init__(
         self,
-        color=WHITE,
+        color: ParsableManimColor | Sequence[ParsableManimColor] | None = WHITE,
         opacity: float = 1.0,
         reflectiveness: float = 0.0,
         shadow: float = 0.0,

--- a/manim/mobject/opengl/opengl_vectorized_mobject.py
+++ b/manim/mobject/opengl/opengl_vectorized_mobject.py
@@ -62,12 +62,12 @@ DEFAULT_FILL_COLOR = GREY_C
 class VMobjectKwargs(MobjectKwargs, total=False):
     color: ParsableManimColor | Sequence[ParsableManimColor] | None
     fill_color: ParsableManimColor | Sequence[ParsableManimColor] | None
-    fill_opacity: float
+    fill_opacity: float | None
     stroke_color: ParsableManimColor | Sequence[ParsableManimColor] | None
-    stroke_opacity: float
+    stroke_opacity: float | None
     stroke_width: float
     draw_stroke_behind_fill: bool
-    background_image_file: str
+    background_image_file: str | None
     long_lines: bool
     joint_type: LineJointType
     flat_stroke: bool

--- a/manim/mobject/opengl/opengl_vectorized_mobject.py
+++ b/manim/mobject/opengl/opengl_vectorized_mobject.py
@@ -60,10 +60,10 @@ DEFAULT_FILL_COLOR = GREY_C
 
 # TODO: add this to the **kwargs of all mobjects that use OpenGLVMobject
 class VMobjectKwargs(MobjectKwargs, total=False):
-    color: ParsableManimColor | list[ParsableManimColor]
-    fill_color: ParsableManimColor | list[ParsableManimColor]
+    color: ParsableManimColor | Sequence[ParsableManimColor] | None
+    fill_color: ParsableManimColor | Sequence[ParsableManimColor] | None
     fill_opacity: float
-    stroke_color: ParsableManimColor | list[ParsableManimColor]
+    stroke_color: ParsableManimColor | Sequence[ParsableManimColor] | None
     stroke_opacity: float
     stroke_width: float
     draw_stroke_behind_fill: bool
@@ -71,6 +71,8 @@ class VMobjectKwargs(MobjectKwargs, total=False):
     long_lines: bool
     joint_type: LineJointType
     flat_stroke: bool
+    shade_in_3d: bool
+    checkerboard_colors: bool  # TODO: remove
 
 
 class OpenGLVMobject(OpenGLMobject):
@@ -95,17 +97,10 @@ class OpenGLVMobject(OpenGLMobject):
         long_lines: bool = False,
         joint_type: LineJointType = LineJointType.AUTO,
         flat_stroke: bool = False,
-        shade_in_3d=False,  # TODO: Can be ignored for now but we should think about using some sort of shader to introduce lighting after deferred rendering has completed
-        checkerboard_colors=False,  # ignore,
+        shade_in_3d: bool = False,  # TODO: Can be ignored for now but we should think about using some sort of shader to introduce lighting after deferred rendering has completed
+        checkerboard_colors: bool = False,  # ignore,
         **kwargs: Unpack[MobjectKwargs],
     ):
-        super().__init__(**kwargs)
-        if fill_color is None:
-            fill_color = self.color
-        if stroke_color is None:
-            stroke_color = self.color
-        self.set_fill(color=fill_color, opacity=fill_opacity)
-        self.set_stroke(color=stroke_color, opacity=stroke_opacity)
         self.stroke_width = listify(stroke_width)
         self.draw_stroke_behind_fill = draw_stroke_behind_fill
         self.background_image_file = background_image_file
@@ -115,6 +110,14 @@ class OpenGLVMobject(OpenGLMobject):
 
         self.needs_new_triangulation = True
         self.triangulation = np.zeros(0, dtype="i4")
+
+        super().__init__(**kwargs)
+        if fill_color is None:
+            fill_color = self.color
+        if stroke_color is None:
+            stroke_color = self.color
+        self.set_fill(color=fill_color, opacity=fill_opacity)
+        self.set_stroke(color=stroke_color, width=stroke_width, opacity=stroke_opacity)
 
         # self.refresh_unit_normal()
 


### PR DESCRIPTION
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
