### PR TITLE
[EXPERIMENTAL] Improve rendering time by rewriting `STD140BufferFormat._write_padded()`

### DIFF
--- a/manim/renderer/buffers/buffer.py
+++ b/manim/renderer/buffers/buffer.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import math
 
-import numpy as np
 import moderngl as gl
+import numpy as np
 
 
 class STD140BufferFormat:

--- a/manim/renderer/buffers/buffer.py
+++ b/manim/renderer/buffers/buffer.py
@@ -98,14 +98,14 @@ class STD140BufferFormat:
             the same data with 0 or 1 columns of 0s appended
         """
         data = np.asarray(data)
-        if self._paddings[var] or data.ndim == 0:
+        if self._paddings[var] == 0 or data.ndim == 0:
             return data
 
         # Make a new array with extra columns of 0s
         new_shape = list(data.shape)
-        new_shape[-1] += self._paddings[var] 
+        new_shape[-1] += self._paddings[var]
         padded_data = np.zeros(new_shape)
-        padded_data[..., :data.shape[-1]] = data
+        padded_data[..., : data.shape[-1]] = data
         return padded_data
 
     def write(self, data: dict) -> None:

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -8,15 +8,15 @@ from manim import (
     CurvesAsSubmobjects,
     Line,
     Mobject,
+    OpenGLMobject,
     Polygon,
     RegularPolygon,
     Square,
     VDict,
     VGroup,
-    OpenGLMobject,
 )
-from manim.mobject.opengl.opengl_vectorized_mobject import OpenGLVMobject
 from manim.constants import PI
+from manim.mobject.opengl.opengl_vectorized_mobject import OpenGLVMobject
 
 
 def test_vmobject_add():


### PR DESCRIPTION
The original implementation of `STD140BufferFormat._write_padded()` used `np.pad` which is slow. In the given example scene, this method takes almost half of the rendering time.

This new implementation avoids that by creating a new array of zeroes instead. In this way, this method now takes 60x less time, and the total rendering time is almost halved.

Example scene:
```py
class Twist(ThreeDScene):
    def construct(self):
        self.set_camera_orientation(theta=TAU/8, phi=TAU/5)

        def function(u, v):
            x = 8*u - 4
            y = 2*v - 1
            z = 1.0
            angle = TAU/4 * u
            point = (
                np.cos(angle) * np.array([x, y, z])
                + np.sin(angle) * np.array([x, -z, y])
            )
            return point
        
        surface = VGroup(Surface(function, resolution=(20, 5)))
        for i in range(3):
            face_copy = surface[0].copy()
            face_copy.rotate(TAU/4 * (i+1), RIGHT, ORIGIN)
            surface.add(face_copy)

        self.add(surface)

        self.begin_ambient_camera_rotation()
        self.wait(5)
```
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
