### PR TITLE
Add Noto fonts install command to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,10 @@ RUN apt-get update -qq \
         wget \
         ghostscript
 
+# adding fonts
+RUN apt-get install --no-install-recommends -y fonts-noto
+RUN fc-cache -fv
+
 # setup a minimal texlive installation
 COPY docker/texlive-profile.txt /tmp/
 ENV PATH=/usr/local/texlive/bin/armhf-linux:/usr/local/texlive/bin/aarch64-linux:/usr/local/texlive/bin/x86_64-linux:$PATH

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,10 +12,9 @@ RUN apt-get update -qq \
         pkg-config \
         make \
         wget \
-        ghostscript
+        ghostscript \
+        fonts-noto
 
-# adding fonts
-RUN apt-get install --no-install-recommends -y fonts-noto
 RUN fc-cache -fv
 
 # setup a minimal texlive installation


### PR DESCRIPTION
## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Added RUN commands in Dockerfile to install Noto Fontfaces (like Noto Sans) and reset font-cache. Fixes #4048 
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
It would be nice if the Noto sans font was added to the built docker image, as it is used in the Interactive Tutorial.
## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
