### PR TITLE
Removed multiple arrow heads with `DashedVMobject`

### DIFF
--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -232,6 +232,11 @@ class TipableVMobject(VMobject, metaclass=ConvertToOpenGL):
     # Getters
 
     def pop_tips(self) -> VGroup:
+        """Removes the tips of the arrow, 
+        if there are no tips to return, does nothing
+        """
+        if not self.has_tip() and not self.has_start_tip():
+            return self.get_group_class()() 
         start, end = self.get_start_and_end()
         result = self.get_group_class()()
         if self.has_tip():

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1966,7 +1966,9 @@ class VMobject(Mobject):
                 0,
                 upper_residue,
             )
-
+        if self.has_tip():
+            if a != 0:
+                self.remove(self.tip)
         return self
 
     def get_subcurve(self, a: float, b: float) -> Self:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
When a DashedVMobject is made, the arrow is duplicated and overlayed for every segment or 'dash'. This change makes it so that only one arrowhead is seen during it all. It solved the issue [#3220](https://github.com/ManimCommunity/manim/issues/3220). Also makes the `TipableVMobject.pop_tips()` function more robust if we enter an object that does not have any tips on either side. 
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

It fixes an issue I found on the issues tab. I think it makes the usage of dashed arrows and vectors easier and more aesthetically pleasing.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
Fixes the issue given here [#3220](https://github.com/ManimCommunity/manim/issues/3220).



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [x] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [x] If applicable: newly added functions and classes are tested
