### PR TITLE
fixed problem with type conversions in Line3D

### DIFF
--- a/manim/mobject/three_d/three_dimensions.py
+++ b/manim/mobject/three_d/three_dimensions.py
@@ -926,6 +926,10 @@ class Line3D(Cylinder):
     ):
         self.thickness = thickness
         self.resolution = (2, resolution) if isinstance(resolution, int) else resolution
+        
+        start = np.array(start,np.float64)
+        end = np.array(end,np.float64)
+        
         self.set_start_and_end_attrs(start, end, **kwargs)
         if color is not None:
             self.set_color(color)

--- a/tests/test_graphical_units/test_threed.py
+++ b/tests/test_graphical_units/test_threed.py
@@ -172,3 +172,10 @@ def test_get_start_and_end_Arrow3d():
     assert np.allclose(
         arrow.get_end(), end, atol=0.01
     ), "end points of Arrow3D do not match"
+
+def test_type_conversion_in_Line3D():
+    start,end = [0,0,0],[1,1,1]
+    line = Line3D(start,end)
+    type_table = [type(item) for item in [*line.get_start(),*line.get_end()]]
+    bool_table = [t == np.float64 for t in type_table]
+    assert all(bool_table), "Types of start and end points are not np.float64"


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
It prevent for passing wrong type of data in Line3D and Arrow3D. 
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

It is inspired by [this](https://discord.com/channels/581738731934056449/1323087855517564958) discord post, where point into Arrow3D has been passed as list of integers instead of floats, which broke subtraction during the Rotation. Right now, data will be automatically converted into the float64 format.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
