### PR TITLE
Tex selective cleanup

### DIFF
--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -67,7 +67,7 @@ def tex_to_svg_file(
     )
     svg_file = convert_to_svg(dvi_file, tex_template.output_format)
     if not config["no_latex_cleanup"]:
-        delete_nonsvg_files( jobname = dvi_file.stem )
+        delete_nonsvg_files(jobname=dvi_file.stem)
     return svg_file
 
 
@@ -258,8 +258,7 @@ def convert_to_svg(dvi_file: Path, extension: str, page: int = 1):
     return result
 
 
-def delete_nonsvg_files(additional_endings: Iterable[str] = (),
-                        jobname = None ) -> None:
+def delete_nonsvg_files(additional_endings: Iterable[str] = (), jobname=None) -> None:
     """Deletes every file that does not have a suffix in ``(".svg", ".tex", *additional_endings)``
     If the optional parameter jobname is specified, only files with stem `jobname`  will be deleted,
     preserving any nonrelated files.
@@ -282,6 +281,7 @@ def delete_nonsvg_files(additional_endings: Iterable[str] = (),
         for f in tex_dir.iterdir():
             if f.stem == jobname and f.suffix not in file_suffix_whitelist:
                 f.unlink()
+
 
 def print_all_tex_errors(log_file: Path, tex_compiler: str, tex_file: Path) -> None:
     if not log_file.exists():

--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -261,11 +261,15 @@ def convert_to_svg(dvi_file: Path, extension: str, page: int = 1):
 def delete_nonsvg_files(additional_endings: Iterable[str] = (),
                         jobname = None ) -> None:
     """Deletes every file that does not have a suffix in ``(".svg", ".tex", *additional_endings)``
+    If the optional parameter jobname is specified, only files with stem `jobname`  will be deleted,
+    preserving any nonrelated files.
 
     Parameters
     ----------
     additional_endings
         Additional endings to whitelist
+    jobname
+        Jobname of the latex job for which the nonsvg files need to be deleted
     """
     tex_dir = config.get_dir("tex_dir")
     file_suffix_whitelist = {".svg", ".tex", *additional_endings}

--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -67,7 +67,7 @@ def tex_to_svg_file(
     )
     svg_file = convert_to_svg(dvi_file, tex_template.output_format)
     if not config["no_latex_cleanup"]:
-        delete_nonsvg_files()
+        delete_nonsvg_files( jobname = dvi_file.stem )
     return svg_file
 
 
@@ -258,7 +258,8 @@ def convert_to_svg(dvi_file: Path, extension: str, page: int = 1):
     return result
 
 
-def delete_nonsvg_files(additional_endings: Iterable[str] = ()) -> None:
+def delete_nonsvg_files(additional_endings: Iterable[str] = (),
+                        jobname = None ) -> None:
     """Deletes every file that does not have a suffix in ``(".svg", ".tex", *additional_endings)``
 
     Parameters
@@ -269,10 +270,14 @@ def delete_nonsvg_files(additional_endings: Iterable[str] = ()) -> None:
     tex_dir = config.get_dir("tex_dir")
     file_suffix_whitelist = {".svg", ".tex", *additional_endings}
 
-    for f in tex_dir.iterdir():
-        if f.suffix not in file_suffix_whitelist:
-            f.unlink()
-
+    if not jobname:
+        for f in tex_dir.iterdir():
+            if f.suffix not in file_suffix_whitelist:
+                f.unlink()
+    else:
+        for f in tex_dir.iterdir():
+            if f.stem == jobname and f.suffix not in file_suffix_whitelist:
+                f.unlink()
 
 def print_all_tex_errors(log_file: Path, tex_compiler: str, tex_file: Path) -> None:
     if not log_file.exists():


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
In the current version, the call to delete_nonsvg_files (after a TeX run) deletes also files that are not related to the current TeX job. In the new version, an argument 'jobname' was added to delete_nonsvg_files that - when specified - restricts the deletion to files with a stem equal to jobname.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
This change avoids removing unrelated files. In a future contribution to Manim I would like to add a class that converts TeX (containing TikZ) to SVG and also writes a file that contains specific coordinates defined in the TikZ part to a file,such that you can use these coordinates in Manim. In that case the file extension of the coordinate file is added to the whitelist, such that the TeX run does not the coordinate file. The change of this pull request avoids that the coordinate file is deleted by a subsequent unrelated TeX run.
From this perspective, this fix is a necessary fix to allow for the future extension. It does not impede the current working of Manim.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
I did not change any documentation except for the docstrings inside the code.

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
None.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
