### PR TITLE
Fix of ImageMobject opacity bug

### DIFF
--- a/manim/utils/bezier.py
+++ b/manim/utils/bezier.py
@@ -1059,7 +1059,7 @@ def interpolate(
             * ``alpha`` is a :class:`float`, the return is another :class:`~.Point3D`.
             * ``alpha`` is a :class:`~.ColVector`, the return is a :class:`~.Point3D_Array`.
     """
-    return start + alpha * (end - start)
+    return (1 - alpha) * start + alpha * end
 
 
 def integer_interpolate(

--- a/tests/module/utils/test_bezier.py
+++ b/tests/module/utils/test_bezier.py
@@ -10,6 +10,7 @@ from manim.utils.bezier import (
     _get_subdivision_matrix,
     get_quadratic_approximation_of_cubic,
     get_smooth_cubic_bezier_handle_points,
+    interpolate,
     partial_bezier_points,
     split_bezier,
     subdivide_bezier,
@@ -215,3 +216,18 @@ def test_get_quadratic_approximation_of_cubic() -> None:
             ]
         ),
     )
+
+
+def test_interpolate() -> None:
+    """Test that :func:`interpolate` handles interpolation of both float and uint8 values."""
+    start = 127.0
+    end = 25.0
+    alpha = 0.2
+    val = interpolate(start, end, alpha)
+    assert np.allclose(val, 106.6000000)
+
+    start = np.array(127, dtype=np.uint8)
+    end = np.array(25, dtype=np.uint8)
+    alpha = 0.09739
+    val = interpolate(start, end, alpha)
+    assert np.allclose(val, np.array([117.06622]))


### PR DESCRIPTION
## Overview: What does this pull request change?
Closes #4072
The issue was introduced in #3960 as part of an optimization.

## Further Information and Comments
I would suggest to add a unittest that ensures that the bug is not reintroduced.

The problem was related to handling of unsigned integers.
The code below demonstrates the problem.

```
import numpy as np

def main():
    start = np.array(127, dtype=np.uint8)
    end = np.array(25, dtype=np.uint8)
    alpha = 0.09739

    val1 = start + alpha * (end - start)
    val2 = (1 - alpha) * start + alpha * end
    print(val1)
    print(val2)
    print(141)
    print(117)

main()
```

Which outputs
```
141.99806
117.06622
141
117

```
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
