### PR TITLE
Fix `VMobject.add_points_as_corners()` to return `self` and safely handle empty `points` parameter

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1039,7 +1039,7 @@ class VMobject(Mobject):
         if not self.is_closed():
             self.add_line_to(self.get_subpaths()[-1][0])
 
-    def add_points_as_corners(self, points: Point3DLike_Array) -> Point3D_Array:
+    def add_points_as_corners(self, points: Point3DLike_Array) -> Self:
         """Append multiple straight lines at the end of
         :attr:`VMobject.points`, which connect the given ``points`` in order
         starting from the end of the current path. These ``points`` would be
@@ -1058,10 +1058,14 @@ class VMobject(Mobject):
             path.
         """
         points = np.asarray(points).reshape(-1, self.dim)
+        num_points = points.shape[0]
+        if num_points == 0:
+            return self
+
         if self.has_new_path_started():
             # Pop the last point from self.points and
             # add it to start_corners
-            start_corners = np.empty((len(points), self.dim))
+            start_corners = np.empty((num_points, self.dim))
             start_corners[0] = self.points[-1]
             start_corners[1:] = points[:-1]
             end_corners = points
@@ -1078,8 +1082,7 @@ class VMobject(Mobject):
             new_points[i::nppcc] = interpolate(start_corners, end_corners, t)
 
         self.append_points(new_points)
-        # TODO: shouldn't this method return self instead of points?
-        return points
+        return self
 
     def set_points_as_corners(self, points: Point3DLike_Array) -> Self:
         """Given an array of points, set them as corners of the

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -84,16 +84,16 @@ def test_vmobject_add_points_as_corners():
     obj2 = VMobject().start_new_path(points[0])
     for point in points[1:]:
         obj2.add_line_to(point)
-    assert np.allclose(obj1.points, obj2.points)
+    np.testing.assert_allclose(obj1.points, obj2.points)
 
     # Test that passing an array with no points does nothing.
     obj3 = VMobject().start_new_path(points[0])
     points3_old = obj3.points.copy()
     obj3.add_points_as_corners([])
-    assert np.allclose(points3_old, obj3.points)
+    np.testing.assert_allclose(points3_old, obj3.points)
 
     obj3.add_points_as_corners(points[1:]).add_points_as_corners([])
-    assert np.allclose(obj1.points, obj3.points)
+    np.testing.assert_allclose(obj1.points, obj3.points)
 
 
 def test_vmobject_point_from_proportion():

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -65,6 +65,37 @@ def test_vmobject_add():
     assert len(obj.submobjects) == 1
 
 
+def test_vmobject_add_points_as_corners():
+    points = np.array(
+        [
+            [2, 0, 0],
+            [1, 1, 0],
+            [-1, 1, 0],
+            [-2, 0, 0],
+            [-1, -1, 0],
+            [1, -1, 0],
+            [2, 0, 0],
+        ]
+    )
+
+    # Test that add_points_as_corners(points) is equivalent to calling
+    # add_line_to(point) for every point in points.
+    obj1 = VMobject().start_new_path(points[0]).add_points_as_corners(points[1:])
+    obj2 = VMobject().start_new_path(points[0])
+    for point in points[1:]:
+        obj2.add_line_to(point)
+    assert np.allclose(obj1.points, obj2.points)
+
+    # Test that passing an array with no points does nothing.
+    obj3 = VMobject().start_new_path(points[0])
+    points3_old = obj3.points.copy()
+    obj3.add_points_as_corners([])
+    assert np.allclose(points3_old, obj3.points)
+
+    obj3.add_points_as_corners(points[1:]).add_points_as_corners([])
+    assert np.allclose(obj1.points, obj3.points)
+
+
 def test_vmobject_point_from_proportion():
     obj = VMobject()
 


### PR DESCRIPTION
Closes #4090 

In the earlier PR #3765, I optimized `VMobject.add_points_as_corners()` to allocate space for `VMobject.points` only once, instead of calling N times in a for loop the `add_line_to()` method which allocated space N times, one for each point. This is really helpful for drawing and animating multiple `ParametricFunction`s and/or `ImplicitFunction`s, which tend to require the computation of a lot of points which are then interpolated smoothly.

However, I missed the edge case in which the `points` parameter contains 0 points, which caused the crash described in #4090. It is possible that the `ImplicitFunction` algorithm for finding a sample of points belonging to the curve returns a single point for one or more branches (called `curves`) of the full implicit curve. In that case, the following three lines in `ImplicitFunction.generate_points()` will fail because of that mistake:
```py
        for curve in curves:
            self.start_new_path(curve[0])
            self.add_points_as_corners(curve[1:])
```

In this PR, I fix this behavior by returning earlier from `VMobject.add_points_as_corners()` if `points` is empty, in a similar way to what the original method already implicitly did (no points = no iterations inside the original for loop).

Plus, instead of returning the passed `points` (which is useless, because you already had the points beforehand), I made this method return `self` (which is consistent with many other methods and allows us to chain this method with other subsequent calls).

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
