### PR TITLE
Add Homotopy example for waving square

### DIFF
--- a/manim/animation/movement.py
+++ b/manim/animation/movement.py
@@ -44,7 +44,7 @@ class Homotopy(Animation):
         Keyword arguments propagated to :meth:`.Mobject.apply_function`.
     kwargs
         Further keyword arguments passed to the parent class.
-    
+
     Examples
     --------
 
@@ -53,17 +53,17 @@ class Homotopy(Animation):
         class HomotopyExample(Scene):
             def construct(self):
                 square = Square()
-                
+
                 def homotopy(x, y, z, t):
                     if t <= 0.25:
-                        progress = t / 0.25  
+                        progress = t / 0.25
                         return (x, y + progress * 0.2 * np.sin(x), z)
                     else:
-                        wave_progress = (t - 0.25) / 0.75  
+                        wave_progress = (t - 0.25) / 0.75
                         return (x, y + 0.2 * np.sin(x + 10 * wave_progress), z)
 
                 self.play(Homotopy(homotopy, square, rate_func= linear, run_time=2))
-    
+
     """
 
     def __init__(

--- a/manim/animation/movement.py
+++ b/manim/animation/movement.py
@@ -44,6 +44,26 @@ class Homotopy(Animation):
         Keyword arguments propagated to :meth:`.Mobject.apply_function`.
     kwargs
         Further keyword arguments passed to the parent class.
+    
+    Examples
+    --------
+
+    .. manim:: HomotopyExample
+
+        class HomotopyExample(Scene):
+            def construct(self):
+                square = Square()
+                
+                def homotopy(x, y, z, t):
+                    if t <= 0.25:
+                        progress = t / 0.25  
+                        return (x, y + progress * 0.2 * np.sin(x), z)
+                    else:
+                        wave_progress = (t - 0.25) / 0.75  
+                        return (x, y + 0.2 * np.sin(x + 10 * wave_progress), z)
+
+                self.play(Homotopy(homotopy, square, rate_func= linear, run_time=2))
+    
     """
 
     def __init__(


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

This pull request introduces a new example for the Homotopy class. This example is inspired by the previous PR in [PR #2959](https://github.com/ManimCommunity/manim/pull/2959). The idea of a waving square is simple and easy to understand, so I modify the code. This new example demonstrates a smooth transition from the original square shape to a waving square. Unlike the example there, which started directly with the deformed shape, this update ensures that the original square is visible at the start, and the deformation happens gradually. This change aims to provide a more intuitive and visually clear demonstration of how homotopy works. 

<!--changelog-start-->

- Added a new Homotopy example showing a smooth transition from the original square to the waving square.
- The transition starts with the original square, which then gradually deforms into the waving square.

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

The result is below

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
