### PR TITLE
Remove PT004 from Ruff ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,8 +169,6 @@ ignore = [
   # due to the import * used in manim
   "F403",
   "F405",
-  # fixtures not returning anything should have leading underscore
-  "PT004",
   # Exception too broad (this would require lots of changes + re.escape) for little benefit
   "PT011",
   # as recommended by https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules


### PR DESCRIPTION
# Motivation
`PT004` was [removed from Ruff](https://docs.astral.sh/ruff/rules/pytest-missing-fixture-name-underscore/#removal) a few releases ago, it now doesn't do anything.