### PR TITLE
Remove duplicate __all__ declarations in vectorized_mobject.py

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -72,16 +72,6 @@ if TYPE_CHECKING:
 # - Think about length of self.points.  Always 0 or 1 mod 4?
 #   That's kind of weird.
 
-__all__ = [
-    "VMobject",
-    "VGroup",
-    "VDict",
-    "VectorizedPoint",
-    "CurvesAsSubmobjects",
-    "VectorizedPoint",
-    "DashedVMobject",
-]
-
 
 class VMobject(Mobject):
     """A vectorized mobject.


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

This pull request removes duplicate `__all__` declarations and redundant entries within the `vectorized_mobject.py` module. By consolidating the exports list into a single `__all__`, this change ensures clarity, avoids confusion, and eliminates unnecessary duplication.

<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?

Why:
Having multiple `__all__` declarations in the same module is unnecessary and can create ambiguity. Moreover, redundant entries such as `VectorizedPoint` within the list serve no functional purpose and can confuse contributors or maintainers.
By consolidating `__all__` into a single declaration and removing duplicates, this change aligns with Python's best practices for maintaining clean and readable code.

How:
This change:
Merges the two `__all__` declarations into a single list at the top of the module.
Removes duplicate entries such as `VectorizedPoint` from the export list.
Ensures the final `__all__` is clear, concise, and reflective of intended exports.

<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
This is a non-breaking, backward-compatible change. It does not modify exported functionality but improves the codebase's maintainability by ensuring consistency and reducing redundancy.
Feedback or further suggestions are welcome!


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
