### PR TITLE
Re-add ffmpeg as dependency within Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -qq \
         libffi-dev \
         libpango1.0-dev \
         freeglut3-dev \
+        ffmpeg \
         pkg-config \
         make \
         wget \


### PR DESCRIPTION
As long as we still depend on `pydub`, which raises a warning whenever `ffmpeg` is not found on the system path, the Docker image should still contain ffmpeg as an explicit dependency.

Other solutions would be
- explicitly suppress the warning emitted by `pydub`,
- update the discord bot to ignore warnings printed to stderr.

I think updating the Docker image is fine though.