### PR TITLE
Fix environment formating for Tex() mobject

### DIFF
--- a/manim/utils/tex.py
+++ b/manim/utils/tex.py
@@ -184,7 +184,7 @@ def _texcode_for_environment(environment: str) -> tuple[str, str]:
         A pair of strings representing the opening and closing of the tex environment, e.g.
         ``\begin{tabular}{cccl}`` and ``\end{tabular}``
     """
-    environment.removeprefix(r"\begin").removeprefix("{")
+    environment = environment.removeprefix(r"\begin").removeprefix("{")
 
     # The \begin command takes everything and closes with a brace
     begin = r"\begin{" + environment

--- a/tests/module/utils/test_tex.py
+++ b/tests/module/utils/test_tex.py
@@ -1,6 +1,6 @@
 import pytest
 
-from manim.utils.tex import TexTemplate
+from manim.utils.tex import TexTemplate, _texcode_for_environment
 
 DEFAULT_BODY = r"""\documentclass[preview]{standalone}
 \usepackage[english]{babel}
@@ -116,3 +116,27 @@ def test_tex_template_fixed_body():
         match="This TeX template was created with a fixed body, trying to add text the document will have no effect.",
     ):
         template.add_to_document("dummy")
+
+
+def test_texcode_for_environment():
+    """Test that the environment is correctly extracted from the input"""
+    # environment without arguments
+    assert _texcode_for_environment("align*") == (r"\begin{align*}", r"\end{align*}")
+    assert _texcode_for_environment("{align*}") == (r"\begin{align*}", r"\end{align*}")
+    assert _texcode_for_environment(r"\begin{align*}") == (
+        r"\begin{align*}",
+        r"\end{align*}",
+    )
+    # environment with arguments
+    assert _texcode_for_environment("{tabular}[t]{cccl}") == (
+        r"\begin{tabular}[t]{cccl}",
+        r"\end{tabular}",
+    )
+    assert _texcode_for_environment("tabular}{cccl") == (
+        r"\begin{tabular}{cccl}",
+        r"\end{tabular}",
+    )
+    assert _texcode_for_environment(r"\begin{tabular}[t]{cccl}") == (
+        r"\begin{tabular}[t]{cccl}",
+        r"\end{tabular}",
+    )


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Fixes #4158
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Any leading ``\begin`` and/or ``{`` were not properly removed.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
