### PR TITLE
Make new `Code` mobject compatible with OpenGL renderer

### DIFF
--- a/manim/mobject/geometry/shape_matchers.py
+++ b/manim/mobject/geometry/shape_matchers.py
@@ -20,6 +20,7 @@ from manim.constants import (
 from manim.mobject.geometry.line import Line
 from manim.mobject.geometry.polygram import RoundedRectangle
 from manim.mobject.mobject import Mobject
+from manim.mobject.opengl.opengl_mobject import OpenGLMobject
 from manim.mobject.types.vectorized_mobject import VGroup
 from manim.utils.color import BLACK, RED, YELLOW, ManimColor, ParsableManimColor
 
@@ -58,7 +59,7 @@ class SurroundingRectangle(RoundedRectangle):
     ) -> None:
         from manim.mobject.mobject import Group
 
-        if not all(isinstance(mob, Mobject) for mob in mobjects):
+        if not all(isinstance(mob, (Mobject, OpenGLMobject)) for mob in mobjects):
             raise TypeError(
                 "Expected all inputs for parameter mobjects to be a Mobjects"
             )

--- a/manim/mobject/text/code_mobject.py
+++ b/manim/mobject/text/code_mobject.py
@@ -18,11 +18,11 @@ from pygments.styles import get_all_styles
 from manim.constants import *
 from manim.mobject.geometry.arc import Dot
 from manim.mobject.geometry.shape_matchers import SurroundingRectangle
+from manim.mobject.opengl.opengl_compatibility import ConvertToOpenGL
 from manim.mobject.text.text_mobject import Paragraph
 from manim.mobject.types.vectorized_mobject import VGroup, VMobject
 from manim.typing import StrPath
 from manim.utils.color import WHITE, ManimColor
-from manim.mobject.opengl.opengl_compatibility import ConvertToOpenGL
 
 
 class Code(VMobject, metaclass=ConvertToOpenGL):

--- a/manim/mobject/text/code_mobject.py
+++ b/manim/mobject/text/code_mobject.py
@@ -22,9 +22,10 @@ from manim.mobject.text.text_mobject import Paragraph
 from manim.mobject.types.vectorized_mobject import VGroup, VMobject
 from manim.typing import StrPath
 from manim.utils.color import WHITE, ManimColor
+from manim.mobject.opengl.opengl_compatibility import ConvertToOpenGL
 
 
-class Code(VMobject):
+class Code(VMobject, metaclass=ConvertToOpenGL):
     """A highlighted source code listing.
 
     Examples


### PR DESCRIPTION
This implements the OpenGL compatibility mechanism for the reworked `Code` mobject.

Fixes #4163.