### PR TITLE
Add render option to use x265 with lossless settings

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -320,6 +320,7 @@ class ManimConfig(MutableMapping):
         "force_window",
         "no_latex_cleanup",
         "preview_command",
+        "lossless",
     }
 
     def __init__(self) -> None:
@@ -591,6 +592,7 @@ class ManimConfig(MutableMapping):
             "enable_wireframe",
             "force_window",
             "no_latex_cleanup",
+            "lossless",
         ]:
             setattr(self, key, parser["CLI"].getboolean(key, fallback=False))
 
@@ -767,6 +769,7 @@ class ManimConfig(MutableMapping):
             "dry_run",
             "no_latex_cleanup",
             "preview_command",
+            "lossless",
         ]:
             if hasattr(args, key):
                 attr = getattr(args, key)
@@ -1490,6 +1493,15 @@ class ManimConfig(MutableMapping):
     @zero_pad.setter
     def zero_pad(self, value: int) -> None:
         self._set_int_between("zero_pad", value, 0, 9)
+
+    @property
+    def lossless(self) -> bool:
+        """Whether to use lossless x265 encoding (mp4 format only)."""
+        return self._d["lossless"]
+
+    @lossless.setter
+    def lossless(self, value: bool) -> None:
+        self._set_boolean("lossless", value)
 
     def get_dir(self, key: str, **kwargs: Any) -> Path:
         """Resolve a config option that stores a directory.

--- a/manim/cli/render/render_options.py
+++ b/manim/cli/render/render_options.py
@@ -212,4 +212,10 @@ render_options = option_group(
         help="Use shaders for OpenGLVMobject stroke which are compatible with transformation matrices.",
         default=None,
     ),
+    option(
+        "--lossless",
+        is_flag=True,
+        help="Render with lossless x265 encoding (mp4 format only).",
+        default=False,
+    ),
 )

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -536,12 +536,20 @@ class SceneFileWriter:
 
         fps = to_av_frame_rate(config.frame_rate)
 
-        partial_movie_file_codec = "libx264"
         partial_movie_file_pix_fmt = "yuv420p"
         av_options = {
             "an": "1",  # ffmpeg: -an, no audio
-            "crf": "23",  # ffmpeg: -crf, constant rate factor (improved bitrate)
         }
+        if config.lossless:
+            partial_movie_file_codec = "libx265"
+            av_options["x265-params"] = (
+                "lossless=1"  # ffmpeg: set lossless mode for x265
+            )
+        else:
+            partial_movie_file_codec = "libx264"
+            av_options["crf"] = (
+                "23"  # ffmpeg: -crf, constant rate factor (improved bitrate)
+            )
 
         if config.movie_file_extension == ".webm":
             partial_movie_file_codec = "libvpx-vp9"


### PR DESCRIPTION
## Overview: What does this pull request change?

Adds an option to allow the `mp4` format to use `x265` as an output codec with lossless settings, so that the output is an exact rendering of the animation. This roughly doubles the final output file size, though possibly requires fewer resources to render.

## Motivation and Explanation: Why and how do your changes improve the library?

By default we use x264 when rendering to the `mp4` format with `crf` set to 23.

x265 (hevc) has a
[lossless](https://x265.readthedocs.io/en/stable/lossless.html) mode, where the encoder is configured such that the output is an exact copy of the input.

Since `manim` scenes consist of text and shapes, the lossless mode works well for us, and ensures that the output videos will be the highest quality when desired. This means that users can safely do an editing pass without risking losing further quality.

Anecdotally, I've noticed slightly better performance than x264 with about 2.5x the file size.

Before:

Before (1,436,872 bytes):

```shell
$ time venv/bin/manim -pqm quad.py Fermat
...
venv/bin/manim -pqm quad.py Fermat  59.41s user 144.46s system 253% cpu 1:20.44 total
```

After (3,494,923 bytes):

```shell
$ time venv/bin/manim -pqm quad.py Fermat --lossless
...
venv/bin/manim -pqm quad.py Fermat --lossless  144.52s user 12.46s system 274% cpu 57.276 total
```

So, I added this as an option (for `mp4` containers).

## Links to added or changed documentation pages

N/A

## Further Information and Comments

N/A

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
