### PR TITLE
Prevent infinite stroke_width array nesting in OpenGL VMObject

### DIFF
--- a/manim/mobject/opengl/opengl_vectorized_mobject.py
+++ b/manim/mobject/opengl/opengl_vectorized_mobject.py
@@ -269,7 +269,7 @@ class OpenGLVMobject(OpenGLMobject):
 
         if width is not None:
             for mob in self.get_family(recurse):
-                mob.stroke_width = np.array([[width] for width in tuplify(width)])
+                mob.stroke_width = np.array(tuplify(width))
 
         if background is not None:
             for mob in self.get_family(recurse):
@@ -323,7 +323,7 @@ class OpenGLVMobject(OpenGLMobject):
     def match_style(self, vmobject, recurse=True):
         vmobject_style = vmobject.get_style()
         if config.renderer == RendererType.OPENGL:
-            vmobject_style["stroke_width"] = vmobject_style["stroke_width"][0][0]
+            vmobject_style["stroke_width"] = vmobject_style["stroke_width"][0]
             vmobject_style["fill_opacity"] = self.get_fill_opacity()
         self.set_style(**vmobject_style, recurse=False)
         if recurse:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Motivation and Explanation: Why and how do your changes improve the library?
This is an attempt to solve [#4097](https://github.com/ManimCommunity/manim/issues/4097)

## Further Information and Comments
To be honest I'm not sure what kind of values can be assigned to stroke_width. Based on the methods I've seen it should be just a float. Internally I see that we need an array, but then maybe the internal representation shouldn't be used externally (only via a property). I'm not familiar enough with the repo, but this seemed like a small change. Let me know if this would break anything. 

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
