### PR TITLE
Allow passing iterables to `Scene.add()` and improve comments for `flatten_iterable_parameters()`

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -36,6 +36,7 @@ from ..utils.color import (
 )
 from ..utils.exceptions import MultiAnimationOverrideException
 from ..utils.iterables import list_update, remove_list_redundancies
+from ..utils.parameter_parsing import flatten_iterable_parameters
 from ..utils.paths import straight_path
 from ..utils.space_ops import angle_between_vectors, normalize, rotation_matrix
 
@@ -501,6 +502,8 @@ class Mobject:
             [child]
 
         """
+        # Allow passing a generator or any iterable to self.add and Group instead of comma separated arguments
+        mobjects = flatten_iterable_parameters(mobjects)
         self._assert_valid_submobjects(mobjects)
         unique_mobjects = remove_list_redundancies(mobjects)
         if len(mobjects) != len(unique_mobjects):

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -502,8 +502,6 @@ class Mobject:
             [child]
 
         """
-        # Allow passing a generator or any iterable to self.add and Group instead of comma separated arguments
-        mobjects = flatten_iterable_parameters(mobjects)
         self._assert_valid_submobjects(mobjects)
         unique_mobjects = remove_list_redundancies(mobjects)
         if len(mobjects) != len(unique_mobjects):
@@ -3067,6 +3065,8 @@ class Group(Mobject, metaclass=ConvertToOpenGL):
 
     def __init__(self, *mobjects, **kwargs) -> None:
         super().__init__(**kwargs)
+        # Allow passing a generator or any iterable to Group instead of comma separated arguments
+        mobjects = flatten_iterable_parameters(mobjects)
         self.add(*mobjects)
 
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -36,7 +36,6 @@ from ..utils.color import (
 )
 from ..utils.exceptions import MultiAnimationOverrideException
 from ..utils.iterables import list_update, remove_list_redundancies
-from ..utils.parameter_parsing import flatten_iterable_parameters
 from ..utils.paths import straight_path
 from ..utils.space_ops import angle_between_vectors, normalize, rotation_matrix
 
@@ -502,8 +501,6 @@ class Mobject:
             [child]
 
         """
-        # Allow passing a generator or any iterable to self.add instead of comma separated arguments
-        mobjects = flatten_iterable_parameters(mobjects)
         self._assert_valid_submobjects(mobjects)
         unique_mobjects = remove_list_redundancies(mobjects)
         if len(mobjects) != len(unique_mobjects):

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -36,6 +36,7 @@ from ..utils.color import (
 )
 from ..utils.exceptions import MultiAnimationOverrideException
 from ..utils.iterables import list_update, remove_list_redundancies
+from ..utils.parameter_parsing import flatten_iterable_parameters
 from ..utils.paths import straight_path
 from ..utils.space_ops import angle_between_vectors, normalize, rotation_matrix
 
@@ -501,6 +502,8 @@ class Mobject:
             [child]
 
         """
+        # Allow passing a generator or any iterable to self.add instead of comma separated arguments
+        mobjects = flatten_iterable_parameters(mobjects)
         self._assert_valid_submobjects(mobjects)
         unique_mobjects = remove_list_redundancies(mobjects)
         if len(mobjects) != len(unique_mobjects):

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -36,7 +36,6 @@ from ..utils.color import (
 )
 from ..utils.exceptions import MultiAnimationOverrideException
 from ..utils.iterables import list_update, remove_list_redundancies
-from ..utils.parameter_parsing import flatten_iterable_parameters
 from ..utils.paths import straight_path
 from ..utils.space_ops import angle_between_vectors, normalize, rotation_matrix
 
@@ -3065,8 +3064,6 @@ class Group(Mobject, metaclass=ConvertToOpenGL):
 
     def __init__(self, *mobjects, **kwargs) -> None:
         super().__init__(**kwargs)
-        # Allow passing a generator or any iterable to Group instead of comma separated arguments
-        mobjects = flatten_iterable_parameters(mobjects)
         self.add(*mobjects)
 
 

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -464,6 +464,9 @@ class Scene:
             The same scene after adding the Mobjects in.
 
         """
+        # Allows passing an iterable of mobjects without unpacking it first
+        mobjects = flatten_iterable_parameters(mobjects)
+        
         if config.renderer == RendererType.OPENGL:
             new_mobjects = []
             new_meshes = []

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -466,7 +466,7 @@ class Scene:
         """
         # Allows passing an iterable of mobjects without unpacking it first
         mobjects = flatten_iterable_parameters(mobjects)
-        
+
         if config.renderer == RendererType.OPENGL:
             new_mobjects = []
             new_meshes = []

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -899,9 +899,10 @@ class Scene:
         Tuple[:class:`Animation`]
             Animations to be played.
         """
-        animations = []
+        # Allow passing a generator or any iterable to self.play instead of comma separated arguments
+        # and also without needing to unpack it first
         arg_anims = flatten_iterable_parameters(args)
-        # Allow passing a generator to self.play instead of comma separated arguments
+        animations = []
         for arg in arg_anims:
             try:
                 animations.append(prepare_animation(arg))

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -464,7 +464,7 @@ class Scene:
             The same scene after adding the Mobjects in.
 
         """
-        # Allows passing an iterable of mobjects without unpacking it first
+        # Allow passing a generator or any iterable to self.add instead of comma separated arguments
         mobjects = flatten_iterable_parameters(mobjects)
 
         if config.renderer == RendererType.OPENGL:
@@ -902,10 +902,9 @@ class Scene:
         Tuple[:class:`Animation`]
             Animations to be played.
         """
-        # Allow passing a generator or any iterable to self.play instead of comma separated arguments
-        # and also without needing to unpack it first
-        arg_anims = flatten_iterable_parameters(args)
         animations = []
+        arg_anims = flatten_iterable_parameters(args)
+        # Allow passing a generator to self.play instead of comma separated arguments
         for arg in arg_anims:
             try:
                 animations.append(prepare_animation(arg))

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -6,8 +6,6 @@ from typing import TypeVar
 
 T = TypeVar("T")
 
-__all__ = ["flatten_iterable_parameters"]
-
 
 def flatten_iterable_parameters(
     args: Iterable[T | Iterable[T] | GeneratorType],
@@ -29,8 +27,8 @@ def flatten_iterable_parameters(
     -----
     Instances of :class:`Mobject` are technically iterable because they define
     `__iter__()`, but they should be treated as single objects rather than
-    being expanded. To prevent unintended behavior, we explicitly check
-    `not isinstance(arg, Mobject)` before extending the list.
+    being expanded. To prevent unintended behavior, we explicitly check if it's not instance of Mobject,
+    by checking its sumbmobjects attribute: `not hasattr(arg, "submobjects")` before extending the list.
     """
     flattened_parameters: list[T] = []
     for arg in args:

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -33,7 +33,6 @@ def flatten_iterable_parameters(
     `not isinstance(arg, Mobject)` before extending the list.
     """
     # avoiding cyclic import
-    from ..mobject.mobject import Mobject
 
     flattened_parameters: list[T] = []
     for arg in args:

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -32,7 +32,6 @@ def flatten_iterable_parameters(
     being expanded. To prevent unintended behavior, we explicitly check
     `not isinstance(arg, Mobject)` before extending the list.
     """
-    # avoiding cyclic import
 
     flattened_parameters: list[T] = []
     for arg in args:

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -28,7 +28,7 @@ def flatten_iterable_parameters(
         # Mobject is iterable as it has `__iter__()`, but it should be appended.
         # To avoid cyclic import, we check for the `submobjects` attribute.
         if hasattr(arg, "submobjects"):
-            flattened_parameters.append(cast(T, arg))
+            flattened_parameters.append(arg)  # type: ignore[arg-type]
         elif isinstance(arg, (Iterable, GeneratorType)):
             flattened_parameters.extend(arg)
         else:

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -8,6 +8,7 @@ from ..mobject.mobject import Mobject
 
 T = TypeVar("T")
 
+__all__ = ["flatten_iterable_parameters"]
 
 def flatten_iterable_parameters(
     args: Iterable[T | Iterable[T] | GeneratorType],

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -4,8 +4,6 @@ from collections.abc import Iterable
 from types import GeneratorType
 from typing import TypeVar
 
-from ..mobject.mobject import Mobject
-
 T = TypeVar("T")
 
 __all__ = ["flatten_iterable_parameters"]
@@ -37,7 +35,9 @@ def flatten_iterable_parameters(
     flattened_parameters: list[T] = []
     for arg in args:
         # Only extend if arg is iterable and NOT an instance of Mobject
-        if isinstance(arg, (Iterable, GeneratorType)) and not hasattr(arg, "submobjects"):
+        if isinstance(arg, (Iterable, GeneratorType)) and not hasattr(
+            arg, "submobjects"
+        ):
             flattened_parameters.extend(arg)
         else:
             flattened_parameters.append(arg)

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -4,8 +4,6 @@ from collections.abc import Iterable
 from types import GeneratorType
 from typing import TypeVar
 
-from ..mobject.mobject import Mobject
-
 T = TypeVar("T")
 
 
@@ -32,6 +30,9 @@ def flatten_iterable_parameters(
     being expanded. To prevent unintended behavior, we explicitly check
     `not isinstance(arg, Mobject)` before extending the list.
     """
+    # avoiding cyclic import
+    from ..mobject.mobject import Mobject
+    
     flattened_parameters: list[T] = []
     for arg in args:
         # Only extend if arg is iterable and NOT an instance of Mobject

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from types import GeneratorType
-from typing import TypeVar, cast
+from typing import TypeVar
 
 T = TypeVar("T")
 

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -27,10 +27,8 @@ def flatten_iterable_parameters(
     for arg in args:
         # Mobject is iterable as it has `__iter__()`, but it should be appended.
         # To avoid cyclic import, we check for the `submobjects` attribute.
-        if hasattr(arg, "submobjects"):
-            flattened_parameters.append(arg)  # type: ignore[arg-type]
-        elif isinstance(arg, (Iterable, GeneratorType)):
+        if isinstance(arg, (Iterable, GeneratorType)) and not hasattr(arg, "submobjects"):
             flattened_parameters.extend(arg)
         else:
-            flattened_parameters.append(arg)
+            flattened_parameters.append(arg)  # type: ignore[arg-type]
     return flattened_parameters

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -32,7 +32,6 @@ def flatten_iterable_parameters(
     being expanded. To prevent unintended behavior, we explicitly check
     `not isinstance(arg, Mobject)` before extending the list.
     """
-
     flattened_parameters: list[T] = []
     for arg in args:
         # Only extend if arg is iterable and NOT an instance of Mobject

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -27,7 +27,7 @@ def flatten_iterable_parameters(
     for arg in args:
         # Mobject is iterable as it has `__iter__()`, but it should be appended.
         # To avoid cyclic import, we check for the `submobjects` attribute.
-        if hasattr(arg, 'submobjects'):
+        if hasattr(arg, "submobjects"):
             flattened_parameters.append(arg)
         elif isinstance(arg, (Iterable, GeneratorType)):
             flattened_parameters.extend(arg)

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -38,5 +38,5 @@ def flatten_iterable_parameters(
         ):
             flattened_parameters.extend(arg)
         else:
-            flattened_parameters.append(arg)
+            flattened_parameters.append(arg) # type: ignore[arg-type]
     return flattened_parameters

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -4,6 +4,8 @@ from collections.abc import Iterable
 from types import GeneratorType
 from typing import TypeVar
 
+from ..mobject.mobject import Mobject
+
 T = TypeVar("T")
 
 
@@ -22,10 +24,18 @@ def flatten_iterable_parameters(
     -------
     :class:`list`
         The flattened list of parameters.
+        
+    Notes
+    -----
+    Instances of :class:`Mobject` are technically iterable because they define
+    `__iter__()`, but they should be treated as single objects rather than
+    being expanded. To prevent unintended behavior, we explicitly check
+    `not isinstance(arg, Mobject)` before extending the list.
     """
     flattened_parameters: list[T] = []
     for arg in args:
-        if isinstance(arg, (Iterable, GeneratorType)):
+        # Only extend if arg is iterable and NOT an instance of Mobject
+        if isinstance(arg, (Iterable, GeneratorType)) and not isinstance(arg, Mobject):
             flattened_parameters.extend(arg)
         else:
             flattened_parameters.append(arg)

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -4,6 +4,8 @@ from collections.abc import Iterable
 from types import GeneratorType
 from typing import TypeVar
 
+from ..mobject.mobject import Mobject
+
 T = TypeVar("T")
 
 

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -27,7 +27,9 @@ def flatten_iterable_parameters(
     for arg in args:
         # Mobject is iterable as it has `__iter__()`, but it should be appended.
         # To avoid cyclic import, we check for the `submobjects` attribute.
-        if isinstance(arg, (Iterable, GeneratorType)) and not hasattr(arg, "submobjects"):
+        if isinstance(arg, (Iterable, GeneratorType)) and not hasattr(
+            arg, "submobjects"
+        ):
             flattened_parameters.extend(arg)
         else:
             flattened_parameters.append(arg)  # type: ignore[arg-type]

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -37,7 +37,7 @@ def flatten_iterable_parameters(
     flattened_parameters: list[T] = []
     for arg in args:
         # Only extend if arg is iterable and NOT an instance of Mobject
-        if isinstance(arg, (Iterable, GeneratorType)) and not isinstance(arg, Mobject):
+        if isinstance(arg, (Iterable, GeneratorType)) and not hasattr(arg, "submobjects"):
             flattened_parameters.extend(arg)
         else:
             flattened_parameters.append(arg)

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -10,6 +10,7 @@ T = TypeVar("T")
 
 __all__ = ["flatten_iterable_parameters"]
 
+
 def flatten_iterable_parameters(
     args: Iterable[T | Iterable[T] | GeneratorType],
 ) -> list[T]:

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -24,7 +24,7 @@ def flatten_iterable_parameters(
     -------
     :class:`list`
         The flattened list of parameters.
-        
+
     Notes
     -----
     Instances of :class:`Mobject` are technically iterable because they define

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from types import GeneratorType
-from typing import TypeVar
+from typing import TypeVar, cast
 
 T = TypeVar("T")
 
@@ -28,7 +28,7 @@ def flatten_iterable_parameters(
         # Mobject is iterable as it has `__iter__()`, but it should be appended.
         # To avoid cyclic import, we check for the `submobjects` attribute.
         if hasattr(arg, "submobjects"):
-            flattened_parameters.append(arg)
+            flattened_parameters.append(cast(T, arg))
         elif isinstance(arg, (Iterable, GeneratorType)):
             flattened_parameters.extend(arg)
         else:

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -22,17 +22,13 @@ def flatten_iterable_parameters(
     -------
     :class:`list`
         The flattened list of parameters.
-
-    Notes
-    -----
-    Instances of :class:`Mobject` are technically iterable because they define
-    `__iter__()`, but they should be treated as single objects rather than
-    being expanded. To prevent unintended behavior, we explicitly check if it's not instance of Mobject,
-    by checking its sumbmobjects attribute: `not hasattr(arg, "submobjects")` before extending the list.
     """
     flattened_parameters: list[T] = []
     for arg in args:
-        # Only extend if arg is iterable and NOT an instance of Mobject
+        # If we want to pass a Mobject, we must consider that it is technically iterable 
+        # because it defines `__iter__()`. However, Mobject and its subclasses should be 
+        # treated as single objects rather than being expanded. To identify them, 
+        # we check for the `submobjects` attribute.
         if isinstance(arg, (Iterable, GeneratorType)) and not hasattr(
             arg, "submobjects"
         ):

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -38,5 +38,5 @@ def flatten_iterable_parameters(
         ):
             flattened_parameters.extend(arg)
         else:
-            flattened_parameters.append(arg) # type: ignore[arg-type]
+            flattened_parameters.append(arg)  # type: ignore[arg-type]
     return flattened_parameters

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -25,14 +25,12 @@ def flatten_iterable_parameters(
     """
     flattened_parameters: list[T] = []
     for arg in args:
-        # If we want to pass a Mobject, we must consider that it is technically iterable
-        # because it defines `__iter__()`. However, Mobject and its subclasses should be
-        # treated as single objects rather than being expanded. To identify them,
-        # we check for the `submobjects` attribute.
-        if isinstance(arg, (Iterable, GeneratorType)) and not hasattr(
-            arg, "submobjects"
-        ):
+        # Mobject is iterable as it has `__iter__()`, but it should be appended.
+        # To avoid cyclic import, we check for the `submobjects` attribute.
+        if hasattr(arg, 'submobjects'):
+            flattened_parameters.append(arg)
+        elif isinstance(arg, (Iterable, GeneratorType)):
             flattened_parameters.extend(arg)
         else:
-            flattened_parameters.append(arg)  # type: ignore[arg-type]
+            flattened_parameters.append(arg)
     return flattened_parameters

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -32,7 +32,7 @@ def flatten_iterable_parameters(
     """
     # avoiding cyclic import
     from ..mobject.mobject import Mobject
-    
+
     flattened_parameters: list[T] = []
     for arg in args:
         # Only extend if arg is iterable and NOT an instance of Mobject

--- a/manim/utils/parameter_parsing.py
+++ b/manim/utils/parameter_parsing.py
@@ -25,9 +25,9 @@ def flatten_iterable_parameters(
     """
     flattened_parameters: list[T] = []
     for arg in args:
-        # If we want to pass a Mobject, we must consider that it is technically iterable 
-        # because it defines `__iter__()`. However, Mobject and its subclasses should be 
-        # treated as single objects rather than being expanded. To identify them, 
+        # If we want to pass a Mobject, we must consider that it is technically iterable
+        # because it defines `__iter__()`. However, Mobject and its subclasses should be
+        # treated as single objects rather than being expanded. To identify them,
         # we check for the `submobjects` attribute.
         if isinstance(arg, (Iterable, GeneratorType)) and not hasattr(
             arg, "submobjects"


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
This PR allows `Scene.add()` to accept iterable inputs directly, without requiring explicit unpacking.

## Motivation and Explanation: Why and how do your changes improve the library?
Currently, `Scene.add()` requires unpacking when passing an iterable of `mobjects` (e.g., `self.add(*mobjects)`). This PR modifies `Scene.add()` to use `flatten_iterable_parameters()`, allowing users to pass iterables directly (e.g., `self.add(mobjects)`). This improves consistency with `Scene.play()`, which already supports this behavior.
Additionally, comments for `flatten_iterable_parameters()` have been improved to clarify that it allows passing iterables—including generators—to `self.play()` without explicit unpacking.

`self.play()` can already accept both unpacked and non-unpacked iterables because it utilizes function `flatten_iterable_parameters()`. This PR applies the same approach to `self.add()`, allowing it to accept iterables directly without requiring unpacking.

## Enhancement: Allow `self.add()` to accept iterables without unpacking

### Current Behavior
Before this PR, `self.play()` already accepts both unpacked and non-unpacked iterables:

#### With unpacking:
```python
class IterableWithSelfPlay(Scene): 
    def construct(self):
        st, sq, c = Star(), Square().shift(RIGHT*3), Circle().shift(LEFT*3)
        animations = [Create(st), Write(sq), FadeIn(c)]
        self.play(*animations, run_time=2)
```
#### Without unpacking:
```python
class IterableWithSelfPlay(Scene): 
    def construct(self):
        st, sq, c = Star(), Square().shift(RIGHT*3), Circle().shift(LEFT*3)
        animations = [Create(st), Write(sq), FadeIn(c)]
        self.play(animations, run_time=2)
```
Both approaches work as expected.

However, `self.add()` **requires** unpacking:
```python
class IterableWithSelfAdd(Scene): 
    def construct(self):
        grp = [Star(), Square().shift(RIGHT*3), Circle().shift(LEFT*3)]
        self.add(*grp)  # Unpacking is required
```
### New Behavior
With this PR, `self.add()` can now accept iterables **without** unpacking:
```python
class IterableWithSelfAdd(Scene): 
    def construct(self):
        grp = [Star(), Square().shift(RIGHT*3), Circle().shift(LEFT*3)]
        self.add(grp)  # Now works without unpacking
```
This change makes `self.add()` consistent with `self.play()` in handling iterables.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
