### PR TITLE
Fix :meth:`VMobject.pointwise_become_partial` failing when `vmobject` is `self`

### DIFF
--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -133,7 +133,7 @@ class Line(TipableVMobject):
         if length < 2 * buff:
             return
         buff_proportion = buff / length
-        self.pointwise_become_partial(self.copy(), buff_proportion, 1 - buff_proportion)
+        self.pointwise_become_partial(self, buff_proportion, 1 - buff_proportion)
         return
 
     def _set_start_and_end_attrs(

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -133,7 +133,7 @@ class Line(TipableVMobject):
         if length < 2 * buff:
             return
         buff_proportion = buff / length
-        self.pointwise_become_partial(self, buff_proportion, 1 - buff_proportion)
+        self.pointwise_become_partial(self.copy(), buff_proportion, 1 - buff_proportion)
         return
 
     def _set_start_and_end_attrs(

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1928,12 +1928,18 @@ class VMobject(Mobject):
         upper_index, upper_residue = integer_interpolate(0, num_curves, b)
 
         nppc = self.n_points_per_curve
+
+        # Copy vmobject.points if vmobject is self to prevent unintended in-place modification
+        vmobject_points = (
+            vmobject.points.copy() if self is vmobject else vmobject.points
+        )
+
         # If both indices coincide, get a part of a single Bézier curve.
         if lower_index == upper_index:
             # Look at the "lower_index"-th Bézier curve and select its part from
             # t=lower_residue to t=upper_residue.
             self.points = partial_bezier_points(
-                vmobject.points[nppc * lower_index : nppc * (lower_index + 1)],
+                vmobject_points[nppc * lower_index : nppc * (lower_index + 1)],
                 lower_residue,
                 upper_residue,
             )
@@ -1943,19 +1949,19 @@ class VMobject(Mobject):
             # Look at the "lower_index"-th Bezier curve and select its part from
             # t=lower_residue to t=1. This is the first curve in self.points.
             self.points[:nppc] = partial_bezier_points(
-                vmobject.points[nppc * lower_index : nppc * (lower_index + 1)],
+                vmobject_points[nppc * lower_index : nppc * (lower_index + 1)],
                 lower_residue,
                 1,
             )
             # If there are more curves between the "lower_index"-th and the
             # "upper_index"-th Béziers, add them all to self.points.
-            self.points[nppc:-nppc] = vmobject.points[
+            self.points[nppc:-nppc] = vmobject_points[
                 nppc * (lower_index + 1) : nppc * upper_index
             ]
             # Look at the "upper_index"-th Bézier curve and select its part from
             # t=0 to t=upper_residue. This is the last curve in self.points.
             self.points[-nppc:] = partial_bezier_points(
-                vmobject.points[nppc * upper_index : nppc * (upper_index + 1)],
+                vmobject_points[nppc * upper_index : nppc * (upper_index + 1)],
                 0,
                 upper_residue,
             )

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1938,32 +1938,24 @@ class VMobject(Mobject):
                 upper_residue,
             )
         else:
-            # Copy points if self.points is vmobject.points before setting
-            # self.points = np.empty(...) to avoid in-place modification
-            vmobject_points = (
-                vmobject.points.copy()
-                if self.points is vmobject.points
-                else vmobject.points
-            )
-
             # Allocate space for (upper_index-lower_index+1) Bézier curves.
             self.points = np.empty((nppc * (upper_index - lower_index + 1), self.dim))
             # Look at the "lower_index"-th Bezier curve and select its part from
             # t=lower_residue to t=1. This is the first curve in self.points.
             self.points[:nppc] = partial_bezier_points(
-                vmobject_points[nppc * lower_index : nppc * (lower_index + 1)],
+                vmobject.points[nppc * lower_index : nppc * (lower_index + 1)],
                 lower_residue,
                 1,
             )
             # If there are more curves between the "lower_index"-th and the
             # "upper_index"-th Béziers, add them all to self.points.
-            self.points[nppc:-nppc] = vmobject_points[
+            self.points[nppc:-nppc] = vmobject.points[
                 nppc * (lower_index + 1) : nppc * upper_index
             ]
             # Look at the "upper_index"-th Bézier curve and select its part from
             # t=0 to t=upper_residue. This is the last curve in self.points.
             self.points[-nppc:] = partial_bezier_points(
-                vmobject_points[nppc * upper_index : nppc * (upper_index + 1)],
+                vmobject.points[nppc * upper_index : nppc * (upper_index + 1)],
                 0,
                 upper_residue,
             )

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1938,24 +1938,32 @@ class VMobject(Mobject):
                 upper_residue,
             )
         else:
+            # Copy points if self.points is vmobject.points before setting
+            # self.points = np.empty(...) to avoid in-place modification
+            vmobject_points = (
+                vmobject.points.copy()
+                if self.points is vmobject.points
+                else vmobject.points
+            )
+
             # Allocate space for (upper_index-lower_index+1) Bézier curves.
             self.points = np.empty((nppc * (upper_index - lower_index + 1), self.dim))
             # Look at the "lower_index"-th Bezier curve and select its part from
             # t=lower_residue to t=1. This is the first curve in self.points.
             self.points[:nppc] = partial_bezier_points(
-                vmobject.points[nppc * lower_index : nppc * (lower_index + 1)],
+                vmobject_points[nppc * lower_index : nppc * (lower_index + 1)],
                 lower_residue,
                 1,
             )
             # If there are more curves between the "lower_index"-th and the
             # "upper_index"-th Béziers, add them all to self.points.
-            self.points[nppc:-nppc] = vmobject.points[
+            self.points[nppc:-nppc] = vmobject_points[
                 nppc * (lower_index + 1) : nppc * upper_index
             ]
             # Look at the "upper_index"-th Bézier curve and select its part from
             # t=0 to t=upper_residue. This is the last curve in self.points.
             self.points[-nppc:] = partial_bezier_points(
-                vmobject.points[nppc * upper_index : nppc * (upper_index + 1)],
+                vmobject_points[nppc * upper_index : nppc * (upper_index + 1)],
                 0,
                 upper_residue,
             )

--- a/tests/module/mobject/geometry/test_unit_geometry.py
+++ b/tests/module/mobject/geometry/test_unit_geometry.py
@@ -4,7 +4,17 @@ import logging
 
 import numpy as np
 
-from manim import BackgroundRectangle, Circle, Sector, Square, SurroundingRectangle
+from manim import (
+    DEGREES,
+    LEFT,
+    RIGHT,
+    BackgroundRectangle,
+    Circle,
+    Line,
+    Sector,
+    Square,
+    SurroundingRectangle,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -53,3 +63,36 @@ def test_changing_Square_side_length_updates_the_square_appropriately():
 def test_Square_side_length_consistent_after_scale_and_rotation():
     sq = Square(side_length=1).scale(3).rotate(np.pi / 4)
     assert np.isclose(sq.side_length, 3)
+
+
+def test_line_with_buff_and_path_arc():
+    line = Line(LEFT, RIGHT, path_arc=60 * DEGREES, buff=0.3)
+    expected_points = np.array(
+        [
+            [-0.7299265, -0.12999304, 0.0],
+            [-0.6605293, -0.15719695, 0.0],
+            [-0.58965623, -0.18050364, 0.0],
+            [-0.51763809, -0.19980085, 0.0],
+            [-0.51763809, -0.19980085, 0.0],
+            [-0.43331506, -0.22239513, 0.0],
+            [-0.34760317, -0.23944429, 0.0],
+            [-0.26105238, -0.25083892, 0.0],
+            [-0.26105238, -0.25083892, 0.0],
+            [-0.1745016, -0.26223354, 0.0],
+            [-0.08729763, -0.26794919, 0.0],
+            [0.0, -0.26794919, 0.0],
+            [0.0, -0.26794919, 0.0],
+            [0.08729763, -0.26794919, 0.0],
+            [0.1745016, -0.26223354, 0.0],
+            [0.26105238, -0.25083892, 0.0],
+            [0.26105238, -0.25083892, 0.0],
+            [0.34760317, -0.23944429, 0.0],
+            [0.43331506, -0.22239513, 0.0],
+            [0.51763809, -0.19980085, 0.0],
+            [0.51763809, -0.19980085, 0.0],
+            [0.58965623, -0.18050364, 0.0],
+            [0.6605293, -0.15719695, 0.0],
+            [0.7299265, -0.12999304, 0.0],
+        ]
+    )
+    np.testing.assert_allclose(line.points, expected_points)

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -526,3 +526,25 @@ def test_proportion_from_point():
     abc.scale(0.8)
     props = [abc.proportion_from_point(p) for p in abc.get_vertices()]
     np.testing.assert_allclose(props, [0, 1 / 3, 2 / 3])
+
+
+def test_pointwise_become_partial_where_vmobject_is_self():
+    sq = Square()
+    sq.pointwise_become_partial(vmobject=sq, a=0.2, b=0.7)
+    expected_points = np.array(
+        [
+            [-0.6, 1.0, 0.0],
+            [-0.73333333, 1.0, 0.0],
+            [-0.86666667, 1.0, 0.0],
+            [-1.0, 1.0, 0.0],
+            [-1.0, 1.0, 0.0],
+            [-1.0, 0.33333333, 0.0],
+            [-1.0, -0.33333333, 0.0],
+            [-1.0, -1.0, 0.0],
+            [-1.0, -1.0, 0.0],
+            [-0.46666667, -1.0, 0.0],
+            [0.06666667, -1.0, 0.0],
+            [0.6, -1.0, 0.0],
+        ]
+    )
+    np.testing.assert_allclose(sq.points, expected_points)


### PR DESCRIPTION
_EDIT by chopan050 - Original title: "Fix `Line` failing with `buff` and `path_arc`"_

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Fixes issue: [#4132](https://github.com/ManimCommunity/manim/issues/4132)

## Motivation and Explanation: Why and how do your changes improve the library?

### Issue Explanation  

When `buff` is given, `Line` internally calls `pointwise_become_partial`, passing `self` as the argument for `vmobject`:  
```python
self.pointwise_become_partial(vmobject=self, a=buff_proportion, b=1 - buff_proportion)
```
In Manim v0.19.0, the `pointwise_become_partial` code was modified in commit [`374eeeba`](https://github.com/ManimCommunity/manim/commit/374eeeba0d16f19963d59675093cd9d244b70266) (from PR [#3760](https://github.com/ManimCommunity/manim/pull/3760)). This change introduced the issue.

Initially (in my first commit), I addressed this issue by modifying `pointwise_become_partial` so that it creates a copy of `vmobject.points` if `vmobject` is `self`, avoiding in-place modification of `vmobject.points` when `self.points` is set to `np.empty(...)`. Making a copy is essential because `self.points` and `vmobject.points` are used together after `self.points` is set to `np.empty(...)`. See the related [source code](https://github.com/ManimCommunity/manim/blob/44da20d71dc091255c0ec8698467394baa75b6b2/manim/mobject/types/vectorized_mobject.py#L1942-L1961).

However, I realized that a simpler solution exists which avoids modifying `pointwise_become_partial`. Instead, the issue can be resolved by adjusting how `Line` uses it:  When calling it, instead of passing `vmobject=self`, we should pass `vmobject=self.copy()`. I’ve implemented this in my most recent commit.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
