### PR TITLE
Fix default config of `manim init project` to use correct `pixel_height` and `pixel_width`

### DIFF
--- a/manim/cli/init/commands.py
+++ b/manim/cli/init/commands.py
@@ -76,8 +76,8 @@ def update_cfg(cfg_dict: dict[str, Any], project_cfg_path: Path) -> None:
     cli_config = config["CLI"]
     for key, value in cfg_dict.items():
         if key == "resolution":
-            cli_config["pixel_height"] = str(value[0])
-            cli_config["pixel_width"] = str(value[1])
+            cli_config["pixel_width"] = str(value[0])
+            cli_config["pixel_height"] = str(value[1])
         else:
             cli_config[key] = str(value)
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->
## Overview: What does this pull request change?
Fixes #4174 
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

When creating a manim project via `manim init project my-project --default` the created manim.cfg file has the `pixel_height` and `pixel_width` swapped. This causes the example animations to be rendered incorrectly. I swapped the `pixel_height` and `pixel_width` back to the correct resolution.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
