### PR TITLE
docs: Fix links to Pango website

### DIFF
--- a/docs/source/guides/using_text.rst
+++ b/docs/source/guides/using_text.rst
@@ -50,7 +50,7 @@ For example:
             )
             self.add(text)
 
-.. _Pango library: https://pango.gnome.org
+.. _Pango library: https://pango.org
 
 Working with :class:`~.Text`
 ============================

--- a/manim/mobject/text/text_mobject.py
+++ b/manim/mobject/text/text_mobject.py
@@ -301,7 +301,7 @@ class Paragraph(VGroup):
 
 
 class Text(SVGMobject):
-    r"""Display (non-LaTeX) text rendered using `Pango <https://pango.gnome.org/>`_.
+    r"""Display (non-LaTeX) text rendered using `Pango <https://pango.org/>`_.
 
     Text objects behave like a :class:`.VGroup`-like iterable of all characters
     in the given text. In particular, slicing is possible.
@@ -864,7 +864,7 @@ class Text(SVGMobject):
 
 
 class MarkupText(SVGMobject):
-    r"""Display (non-LaTeX) text rendered using `Pango <https://pango.gnome.org/>`_.
+    r"""Display (non-LaTeX) text rendered using `Pango <https://pango.org/>`_.
 
     Text objects behave like a :class:`.VGroup`-like iterable of all characters
     in the given text. In particular, slicing is possible.


### PR DESCRIPTION
## Overview: What does this pull request change?
Change the dead links to the Pango website from the documentation to the new location.

## Motivation and Explanation: Why and how do your changes improve the library?
I noticed these links were dead in the docs, so I found the new link for it.

## Links to added or changed documentation pages
Just the link to the Pango website on these three pages should be affected:
- https://manimce--4217.org.readthedocs.build/en/4217/guides/using_text.html
- https://manimce--4217.org.readthedocs.build/en/4217/reference/manim.mobject.text.text_mobject.Text.html
- https://manimce--4217.org.readthedocs.build/en/4217/reference/manim.mobject.text.text_mobject.MarkupText.html

## Further Information and Comments
The i18n files _appear_ to be auto-generated (judging from the general commit history), so I have not tweaked those.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
