### PR TITLE
Improve `Line` Class: Add Docstrings, Remove `None` Handling for `path_arc`, and Simplify Logic

### DIFF
--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -65,6 +65,35 @@ if TYPE_CHECKING:
 
 
 class Line(TipableVMobject):
+    """A straight or curved line segment between two points or mobjects.
+
+    Parameters
+    ----------
+    start
+        The starting point or Mobject of the line.
+    end
+        The ending point or Mobject of the line.
+    buff
+        The distance to shorten the line from both ends.
+    path_arc
+        If nonzero, the line will be curved into an arc with this angle (in radians).
+    kwargs
+        Additional arguments to be passed to :class:`TipableVMobject`
+
+    Examples
+    --------
+    .. manim:: LineExample
+        :save_last_frame:
+
+        class LineExample(Scene):
+            def construct(self):
+                line1 = Line(LEFT*2, RIGHT*2)
+                line2 = Line(LEFT*2, RIGHT*2, buff=0.5)
+                line3 = Line(LEFT*2, RIGHT*2, path_arc=PI/2)
+                grp = VGroup(line1,line2,line3).arrange(DOWN, buff=2)
+                self.add(grp)
+    """
+
     def __init__(
         self,
         start: Point3DLike | Mobject = LEFT,

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -69,8 +69,8 @@ class Line(TipableVMobject):
         self,
         start: Point3DLike | Mobject = LEFT,
         end: Point3DLike | Mobject = RIGHT,
-        buff: float = 0,
-        path_arc: float | None = None,
+        buff: float = 0.0,
+        path_arc: float = 0.0,
         **kwargs: Any,
     ) -> None:
         self.dim = 3
@@ -78,22 +78,21 @@ class Line(TipableVMobject):
         self.path_arc = path_arc
         self._set_start_and_end_attrs(start, end)
         super().__init__(**kwargs)
-        # TODO: Deal with the situation where path_arc is None
 
     def generate_points(self) -> None:
         self.set_points_by_ends(
             start=self.start,
             end=self.end,
             buff=self.buff,
-            path_arc=self.path_arc,  # type: ignore[arg-type]
+            path_arc=self.path_arc,
         )
 
     def set_points_by_ends(
         self,
         start: Point3DLike | Mobject,
         end: Point3DLike | Mobject,
-        buff: float = 0,
-        path_arc: float = 0,
+        buff: float = 0.0,
+        path_arc: float = 0.0,
     ) -> None:
         """Sets the points of the line based on its start and end points.
         Unlike :meth:`put_start_and_end_on`, this method respects `self.buff` and
@@ -112,9 +111,6 @@ class Line(TipableVMobject):
         """
         self._set_start_and_end_attrs(start, end)
         if path_arc:
-            # self.path_arc could potentially be None, which is not accepted
-            # as parameter.
-            assert self.path_arc is not None
             arc = ArcBetweenPoints(self.start, self.end, angle=self.path_arc)
             self.set_points(arc.points)
         else:
@@ -125,16 +121,13 @@ class Line(TipableVMobject):
     init_points = generate_points
 
     def _account_for_buff(self, buff: float) -> None:
-        if buff == 0:
+        if buff <= 0:
             return
-        #
-        length = self.get_length() if self.path_arc == 0 else self.get_arc_length()
-        #
+        length = self.get_arc_length() if self.path_arc else self.get_length()
         if length < 2 * buff:
             return
         buff_proportion = buff / length
         self.pointwise_become_partial(self, buff_proportion, 1 - buff_proportion)
-        return
 
     def _set_start_and_end_attrs(
         self, start: Point3DLike | Mobject, end: Point3DLike | Mobject


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
- **Added Docstrings**: Docstrings have been added to improve code documentation and readability.
- **Removed `None` Handling for `path_arc`**: The unnecessary handling for `None` values in the `path_arc` parameter is removed by setting a default value of `0.0`. This simplifies the logic and eliminates redundant checks.
- **Removed Irrelevant `TODO` Comment**: The `TODO` comment related to handling `None` for `path_arc` is removed, as it is no longer needed.
- **Removed Redundant `return`**.
- **Added Example Usage**: Example usage has been added to the docstring.

## Links to added or changed documentation pages



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
