### PR TITLE
Fix `VGroup.scale(scale_stroke=True)` to Respect Submobjects' Stroke Widths

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -522,11 +522,12 @@ class VMobject(Mobject):
 
         """
         if scale_stroke:
-            self.set_stroke(width=abs(scale_factor) * self.get_stroke_width())
-            self.set_stroke(
-                width=abs(scale_factor) * self.get_stroke_width(background=True),
-                background=True,
-            )
+            for mob in self.family_members_with_points():
+                mob.set_stroke(width=abs(scale_factor) * mob.get_stroke_width())
+                mob.set_stroke(
+                    width=abs(scale_factor) * mob.get_stroke_width(background=True),
+                    background=True,
+                )
         super().scale(scale_factor, **kwargs)
         return self
 

--- a/tests/module/mobject/types/vectorized_mobject/test_stroke.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_stroke.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import numpy as np
+
 import manim.utils.color as C
-from manim import VMobject
+from manim import Square, VGroup, VMobject
 from manim.mobject.vector_field import StreamLines
 
 
@@ -41,23 +43,34 @@ def test_streamline_attributes_for_single_color():
     assert vector_field[0].stroke_opacity == 0.2
 
 
-def test_stroke_scale():
-    a = VMobject()
-    b = VMobject()
-    a.set_stroke(width=50)
-    b.set_stroke(width=50)
-    a.scale(0.5)
-    b.scale(0.5, scale_stroke=True)
-    assert a.get_stroke_width() == 50
-    assert b.get_stroke_width() == 25
+def test_scale_with_scale_stroke_true_and_false():
+    square = Square()
+    square.set_stroke(width=40)
+    square.set_stroke(width=60, background=True)
+    original_height = square.get_height()
+    original_stroke = square.get_stroke_width()
+    original_background = square.get_stroke_width(background=True)
 
+    vg = VGroup(square)
 
-def test_background_stroke_scale():
-    a = VMobject()
-    b = VMobject()
-    a.set_stroke(width=50, background=True)
-    b.set_stroke(width=50, background=True)
-    a.scale(0.5)
-    b.scale(0.5, scale_stroke=True)
-    assert a.get_stroke_width(background=True) == 50
-    assert b.get_stroke_width(background=True) == 25
+    # Scale 1.0 (scale_stroke=True): No changes expected
+    vg.scale(1.0, scale_stroke=True)
+    assert np.isclose(square.get_height(), original_height)
+    assert square.get_stroke_width() == original_stroke
+    assert square.get_stroke_width(background=True) == original_background
+
+    # Scale 0.5 (scale_stroke=True): Size and stroke width halved
+    vg.scale(0.5, scale_stroke=True)
+    assert np.isclose(square.get_height(), original_height * 0.5)
+    assert np.isclose(square.get_stroke_width(), original_stroke * 0.5)
+    assert np.isclose(
+        square.get_stroke_width(background=True), original_background * 0.5
+    )
+
+    # Scale 2.0 (scale_stroke=False): Size doubled, stroke width unchanged
+    vg.scale(2.0, scale_stroke=False)
+    assert np.isclose(square.get_height(), original_height)
+    assert np.isclose(square.get_stroke_width(), original_stroke * 0.5)
+    assert np.isclose(
+        square.get_stroke_width(background=True), original_background * 0.5
+    )


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
1. Fix: https://github.com/ManimCommunity/manim/issues/4229
2. Add related test

## Further Information and Comments
Example:
```python
class FixVGroupScaling(Scene):
    def construct(self):
        square = Square(side_length=2).set_stroke(color=RED_E, width=20)
        square.set_stroke(color=WHITE, width=60, background=True)
        self.add(square)
        vg = VGroup(square)
        
        # Scale 1.0 (scale_stroke=True): No changes expected
        self.play(vg.animate.scale(1, scale_stroke=True))

        # Scale 0.5 (scale_stroke=True): Size and stroke width halved
        self.play(vg.animate.scale(0.5, scale_stroke=True))
        
        # Scale 2.0 (scale_stroke=False): Size doubled, stroke width unchanged
        self.play(vg.animate.scale(2))
        self.wait()
```


https://github.com/user-attachments/assets/89c344da-b8da-4c31-b34a-969f7a3b58a5



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
