### PR TITLE
Fix(graph): Allow any Line subclass as edge_type in Graph/DiGraph

### DIFF
--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -1035,7 +1035,10 @@ class GenericGraph(VMobject, metaclass=ConvertToOpenGL):
         self._edge_config[(u, v)] = edge_config
 
         edge_mobject = edge_type(
-            self[u].get_center(), self[v].get_center(), z_index=-1, **edge_config
+            start=self[u].get_center(),
+            end=self[v].get_center(),
+            z_index=-1,
+            **edge_config,
         )
         self.edges[(u, v)] = edge_mobject
 
@@ -1543,8 +1546,8 @@ class Graph(GenericGraph):
     ):
         self.edges = {
             (u, v): edge_type(
-                self[u].get_center(),
-                self[v].get_center(),
+                start=self[u].get_center(),
+                end=self[v].get_center(),
                 z_index=-1,
                 **self._edge_config[(u, v)],
             )
@@ -1750,8 +1753,8 @@ class DiGraph(GenericGraph):
     ):
         self.edges = {
             (u, v): edge_type(
-                self[u],
-                self[v],
+                start=self[u],
+                end=self[v],
                 z_index=-1,
                 **self._edge_config[(u, v)],
             )

--- a/tests/module/mobject/test_graph.py
+++ b/tests/module/mobject/test_graph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from manim import DiGraph, Graph, Scene, Text, tempconfig
+from manim import DiGraph, Graph, LabeledLine, Scene, Text, tempconfig
 from manim.mobject.graph import _layouts
 
 
@@ -89,6 +89,29 @@ def test_graph_remove_edges():
     assert str(G) == "Undirected graph on 5 vertices and 0 edges"
     assert set(G._graph.edges()) == set()
     assert set(G.edges.keys()) == set()
+
+
+def test_graph_accepts_labeledline_as_edge_type():
+    vertices = [1, 2, 3, 4]
+    edges = [(1, 2), (2, 3), (3, 4), (4, 1)]
+    edge_config = {
+        (1, 2): {"label": "A"},
+        (2, 3): {"label": "B"},
+        (3, 4): {"label": "C"},
+        (4, 1): {"label": "D"},
+    }
+    G_manual = Graph(vertices, edges, edge_type=LabeledLine, edge_config=edge_config)
+    G_directed = DiGraph(
+        vertices, edges, edge_type=LabeledLine, edge_config=edge_config
+    )
+
+    for _edge_key, edge_obj in G_manual.edges.items():
+        assert isinstance(edge_obj, LabeledLine)
+        assert hasattr(edge_obj, "label")
+
+    for _edge_key, edge_obj in G_directed.edges.items():
+        assert isinstance(edge_obj, LabeledLine)
+        assert hasattr(edge_obj, "label")
 
 
 def test_custom_animation_mobject_list():


### PR DESCRIPTION
## Overview: What does this pull request change?
<!--changelog-start-->
Fix #4250 
<!--changelog-end-->
**More broadly, this fix allows any subclass of `Line` to be used as an `edge_type`** in the `Graph` and `DiGraph`, making the implementation more flexible and extensible.

## Motivation and Explanation: Why and how do your changes improve the library?
Previously, the `Graph` and `DiGraph` classes assumed that the `edge_type`  will always have its first two arguments as start and end point.
But, such is not true for subclasses of `Line`. This change lets user use any subclass of `Line` in `Graph` and `DiGraph`.

## Changes

- **Refactored Graph and DiGraph:**
  - Fixed edge handling logic to support all subclasses of `Line`, not just `LabeledLine`.
  - Modified `_add_edge` accordingly.
- **Testing:**
  - Added/updated tests for `LabeledLine` as edge types in `test_graph.py`.

 

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
