### PR TITLE
Fix Bug with Introducers in Successions

### DIFF
--- a/manim/animation/composition.py
+++ b/manim/animation/composition.py
@@ -78,8 +78,8 @@ class AnimationGroup(Animation):
 
     def _get_unintroduced_mobjects(self) -> Sequence[Mobject]:
         return remove_list_redundancies(
-                [anim.mobject for anim in self.animations if not anim.is_introducer()],
-            )
+            [anim.mobject for anim in self.animations if not anim.is_introducer()],
+        )
 
     def get_all_mobjects(self) -> Sequence[Mobject]:
         return list(self.group)


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Fix Issue described in #4257 It's currently only handling the case where introducers are added directly to the succession. Adding another animation group wont work
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Fixed Bug in Successions causing mobjects to be added before they should have been introduced by an animation
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
I've extracted a private method _get_unintroduced_mobjects in the succession parent AnimationGroup. I did this to avoid duplicating the code creating the group

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
