### PR TITLE
Introduce seed in `random_color` method to produce colors deterministically

### DIFF
--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -1513,13 +1513,12 @@ def random_color() -> ManimColor:
 
 class RandomColorGenerator:
     """
-    A generator for producing random colors from the Manim color palette,
+    A generator for producing random colors from a given list of Manim colors,
     optionally in a reproducible sequence using a seed value.
 
-    When initialized with a specific seed, this class generates a deterministic
-    sequence of Manim colors, which is useful for reproducibility in testing or animations.
-    If no seed is provided, it behaves like Python’s standard `random.choice`, yielding
-    different results on each run.
+    When initialized with a specific seed, this class produces a deterministic
+    sequence of `ManimColor` instances. If no seed is provided, the selection is
+    non-deterministic using Python’s global random state.
 
     Parameters
     ----------
@@ -1527,14 +1526,16 @@ class RandomColorGenerator:
         A seed value to initialize the internal random number generator.
         If None (default), colors are chosen using the global random state.
 
+    sample_colors : list[ManimColor], optional
+        A custom list of Manim colors to sample from. Defaults to the full Manim color palette.
+
     Examples
     --------
     Without a seed (non-deterministic):
-    >>> from manim import RandomColorGenerator, ManimColor
+    >>> from manim import RandomColorGenerator, ManimColor, RED, GREEN, BLUE
     >>> rnd = RandomColorGenerator()
     >>> isinstance(rnd.next(), ManimColor)
     True
-
 
     With a seed (deterministic sequence):
     >>> rnd = RandomColorGenerator(42)
@@ -1545,7 +1546,7 @@ class RandomColorGenerator:
     >>> rnd.next()
     ManimColor('#BBBBBB')
 
-    Re-initializing with the same seed produces the same sequence:
+    Re-initializing with the same seed gives the same sequence:
     >>> rnd2 = RandomColorGenerator(42)
     >>> rnd2.next()
     ManimColor('#ECE7E2')
@@ -1553,6 +1554,19 @@ class RandomColorGenerator:
     ManimColor('#BBBBBB')
     >>> rnd2.next()
     ManimColor('#BBBBBB')
+
+    Using a custom color list:
+    >>> custom_palette = [RED, GREEN, BLUE]
+    >>> rnd_custom = RandomColorGenerator(1, sample_colors=custom_palette)
+    >>> rnd_custom.next() in custom_palette
+    True
+    >>> rnd_custom.next() in custom_palette
+    True
+
+    Without a seed and custom palette (non-deterministic):
+    >>> rnd_nodet = RandomColorGenerator(sample_colors=[RED])
+    >>> rnd_nodet.next()
+    ManimColor('#FC6255')
     """
 
     import manim.utils.color.manim_colors as manim_colors
@@ -1567,20 +1581,19 @@ class RandomColorGenerator:
 
     def next(self) -> ManimColor:
         """
-        Returns the next color from the Manim color palette.
+        Returns the next color from the configured color list.
 
         Returns
         -------
         ManimColor
-            A color randomly selected from the predefined Manim color palette.
+            A randomly selected color from the specified color list.
 
         Examples
         --------
-        >>> rnd = RandomColorGenerator(23)
+        >>> from manim import RandomColorGenerator, RED
+        >>> rnd = RandomColorGenerator(sample_colors=[RED])
         >>> rnd.next()
-        ManimColor('#A6CF8C')
-        >>> rnd.next()
-        ManimColor('#222222')
+        ManimColor('#FC6255')
         """
         return self.choice(self.colors)
 

--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -1569,15 +1569,16 @@ class RandomColorGenerator:
     ManimColor('#FC6255')
     """
 
-    import manim.utils.color.manim_colors as manim_colors
-
     def __init__(
         self,
         seed: int | None = None,
-        sample_colors: list[ManimColor] = manim_colors._all_manim_colors,
+        sample_colors: list[ManimColor] | None = None,
     ) -> None:
         self.choice = random.choice if seed is None else random.Random(seed).choice
-        self.colors = sample_colors
+
+        from manim.utils.color.manim_colors import _all_manim_colors
+
+        self.colors = _all_manim_colors if sample_colors is None else sample_colors
 
     def next(self) -> ManimColor:
         """

--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -1555,8 +1555,15 @@ class RandomColorGenerator:
     ManimColor('#BBBBBB')
     """
 
-    def __init__(self, seed: int | None = None) -> None:
+    import manim.utils.color.manim_colors as manim_colors
+
+    def __init__(
+        self,
+        seed: int | None = None,
+        sample_colors: list[ManimColor] = manim_colors._all_manim_colors,
+    ) -> None:
         self.choice = random.choice if seed is None else random.Random(seed).choice
+        self.colors = sample_colors
 
     def next(self) -> ManimColor:
         """
@@ -1575,9 +1582,7 @@ class RandomColorGenerator:
         >>> rnd.next()
         ManimColor('#222222')
         """
-        import manim.utils.color.manim_colors as manim_colors
-
-        return self.choice(manim_colors._all_manim_colors)
+        return self.choice(self.colors)
 
 
 def get_shaded_rgb(

--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -1512,12 +1512,68 @@ def random_color() -> ManimColor:
 
 
 class RandomColorGenerator:
-    """A class to generate random colors from the Manim color palette in a reproducible manner using a seed value."""
+    """
+    A generator for producing random colors from the Manim color palette,
+    optionally in a reproducible sequence using a seed value.
+
+    When initialized with a specific seed, this class generates a deterministic
+    sequence of Manim colors, which is useful for reproducibility in testing or animations.
+    If no seed is provided, it behaves like Python’s standard `random.choice`, yielding
+    different results on each run.
+
+    Parameters
+    ----------
+    seed : int | None, optional
+        A seed value to initialize the internal random number generator.
+        If None (default), colors are chosen using the global random state.
+
+    Examples
+    --------
+    Without a seed (non-deterministic):
+    >>> from manim.utils.color.core import RandomColorGenerator
+    >>> rnd = RandomColorGenerator()
+    >>> isinstance(rnd.next().hex, str)
+    True
+
+    With a seed (deterministic sequence):
+    >>> rnd = RandomColorGenerator(42)
+    >>> rnd.next()
+    ManimColor('#ECE7E2')
+    >>> rnd.next()
+    ManimColor('#BBBBBB')
+    >>> rnd.next()
+    ManimColor('#BBBBBB')
+
+    Re-initializing with the same seed produces the same sequence:
+    >>> rnd2 = RandomColorGenerator(42)
+    >>> rnd2.next()
+    ManimColor('#ECE7E2')
+    >>> rnd2.next()
+    ManimColor('#BBBBBB')
+    >>> rnd2.next()
+    ManimColor('#BBBBBB')
+    """
 
     def __init__(self, seed: int | None = None) -> None:
         self.choice = random.choice if seed is None else random.Random(seed).choice
 
     def next(self) -> ManimColor:
+        """
+        Returns the next color from the Manim color palette.
+
+        Returns
+        -------
+        ManimColor
+            A color randomly selected from the predefined Manim color palette.
+
+        Examples
+        --------
+        >>> rnd = RandomColorGenerator(23)
+        >>> rnd.next()
+        ManimColor('#A6CF8C')
+        >>> rnd.next()
+        ManimColor('#222222')
+        """
         import manim.utils.color.manim_colors as manim_colors
 
         return self.choice(manim_colors._all_manim_colors)
@@ -1576,6 +1632,7 @@ __all__ = [
     "average_color",
     "random_bright_color",
     "random_color",
+    "RandomColorGenerator",
     "get_shaded_rgb",
     "HSV",
     "RGBA",

--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -1508,10 +1508,17 @@ def random_color() -> ManimColor:
     ManimColor
         A random :class:`ManimColor`.
     """
-    import manim.utils.color.manim_colors as manim_colors
+    return RandomColorGenerator().next()
 
-    return random.choice(manim_colors._all_manim_colors)
-
+class RandomColorGenerator:
+    """A class to generate random colors from the Manim color palette in a reproducible manner using a seed value."""
+    def __init__(self, seed: int | None = None) -> None:
+        self.choice = random.choice if seed is None else random.Random(seed).choice
+    
+    def next(self) -> ManimColor:
+        import manim.utils.color.manim_colors as manim_colors
+        
+        return self.choice(manim_colors._all_manim_colors)
 
 def get_shaded_rgb(
     rgb: RGB_Array_Float,

--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -1531,42 +1531,47 @@ class RandomColorGenerator:
 
     Examples
     --------
-    Without a seed (non-deterministic):
-    >>> from manim import RandomColorGenerator, ManimColor, RED, GREEN, BLUE
-    >>> rnd = RandomColorGenerator()
-    >>> isinstance(rnd.next(), ManimColor)
-    True
+    Without a seed (non-deterministic)::
 
-    With a seed (deterministic sequence):
-    >>> rnd = RandomColorGenerator(42)
-    >>> rnd.next()
-    ManimColor('#ECE7E2')
-    >>> rnd.next()
-    ManimColor('#BBBBBB')
-    >>> rnd.next()
-    ManimColor('#BBBBBB')
+        >>> from manim import RandomColorGenerator, ManimColor, RED, GREEN, BLUE
+        >>> rnd = RandomColorGenerator()
+        >>> isinstance(rnd.next(), ManimColor)
+        True
 
-    Re-initializing with the same seed gives the same sequence:
-    >>> rnd2 = RandomColorGenerator(42)
-    >>> rnd2.next()
-    ManimColor('#ECE7E2')
-    >>> rnd2.next()
-    ManimColor('#BBBBBB')
-    >>> rnd2.next()
-    ManimColor('#BBBBBB')
+    With a seed (deterministic sequence)::
 
-    Using a custom color list:
-    >>> custom_palette = [RED, GREEN, BLUE]
-    >>> rnd_custom = RandomColorGenerator(1, sample_colors=custom_palette)
-    >>> rnd_custom.next() in custom_palette
-    True
-    >>> rnd_custom.next() in custom_palette
-    True
+        >>> rnd = RandomColorGenerator(42)
+        >>> rnd.next()
+        ManimColor('#ECE7E2')
+        >>> rnd.next()
+        ManimColor('#BBBBBB')
+        >>> rnd.next()
+        ManimColor('#BBBBBB')
 
-    Without a seed and custom palette (non-deterministic):
-    >>> rnd_nodet = RandomColorGenerator(sample_colors=[RED])
-    >>> rnd_nodet.next()
-    ManimColor('#FC6255')
+    Re-initializing with the same seed gives the same sequence::
+
+        >>> rnd2 = RandomColorGenerator(42)
+        >>> rnd2.next()
+        ManimColor('#ECE7E2')
+        >>> rnd2.next()
+        ManimColor('#BBBBBB')
+        >>> rnd2.next()
+        ManimColor('#BBBBBB')
+
+    Using a custom color list::
+
+        >>> custom_palette = [RED, GREEN, BLUE]
+        >>> rnd_custom = RandomColorGenerator(1, sample_colors=custom_palette)
+        >>> rnd_custom.next() in custom_palette
+        True
+        >>> rnd_custom.next() in custom_palette
+        True
+
+    Without a seed and custom palette (non-deterministic)::
+
+        >>> rnd_nodet = RandomColorGenerator(sample_colors=[RED])
+        >>> rnd_nodet.next()
+        ManimColor('#FC6255')
     """
 
     def __init__(

--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -1530,10 +1530,11 @@ class RandomColorGenerator:
     Examples
     --------
     Without a seed (non-deterministic):
-    >>> from manim.utils.color.core import RandomColorGenerator
+    >>> from manim import RandomColorGenerator, ManimColor
     >>> rnd = RandomColorGenerator()
-    >>> isinstance(rnd.next().hex, str)
+    >>> isinstance(rnd.next(), ManimColor)
     True
+
 
     With a seed (deterministic sequence):
     >>> rnd = RandomColorGenerator(42)

--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -1512,22 +1512,22 @@ def random_color() -> ManimColor:
 
 
 class RandomColorGenerator:
-    """
-    A generator for producing random colors from a given list of Manim colors,
+    """A generator for producing random colors from a given list of Manim colors,
     optionally in a reproducible sequence using a seed value.
 
     When initialized with a specific seed, this class produces a deterministic
-    sequence of `ManimColor` instances. If no seed is provided, the selection is
+    sequence of :class:`.ManimColor` instances. If no seed is provided, the selection is
     non-deterministic using Python’s global random state.
 
     Parameters
     ----------
-    seed : int | None, optional
+    seed
         A seed value to initialize the internal random number generator.
-        If None (default), colors are chosen using the global random state.
+        If ``None`` (the default), colors are chosen using the global random state.
 
-    sample_colors : list[ManimColor], optional
-        A custom list of Manim colors to sample from. Defaults to the full Manim color palette.
+    sample_colors
+        A custom list of Manim colors to sample from. Defaults to the full Manim
+        color palette.
 
     Examples
     --------
@@ -1586,8 +1586,7 @@ class RandomColorGenerator:
         self.colors = _all_manim_colors if sample_colors is None else sample_colors
 
     def next(self) -> ManimColor:
-        """
-        Returns the next color from the configured color list.
+        """Returns the next color from the configured color list.
 
         Returns
         -------
@@ -1596,10 +1595,12 @@ class RandomColorGenerator:
 
         Examples
         --------
-        >>> from manim import RandomColorGenerator, RED
-        >>> rnd = RandomColorGenerator(sample_colors=[RED])
-        >>> rnd.next()
-        ManimColor('#FC6255')
+        Usage::
+
+            >>> from manim import RandomColorGenerator, RED
+            >>> rnd = RandomColorGenerator(sample_colors=[RED])
+            >>> rnd.next()
+            ManimColor('#FC6255')
         """
         return self.choice(self.colors)
 

--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -1510,15 +1510,18 @@ def random_color() -> ManimColor:
     """
     return RandomColorGenerator().next()
 
+
 class RandomColorGenerator:
     """A class to generate random colors from the Manim color palette in a reproducible manner using a seed value."""
+
     def __init__(self, seed: int | None = None) -> None:
         self.choice = random.choice if seed is None else random.Random(seed).choice
-    
+
     def next(self) -> ManimColor:
         import manim.utils.color.manim_colors as manim_colors
-        
+
         return self.choice(manim_colors._all_manim_colors)
+
 
 def get_shaded_rgb(
     rgb: RGB_Array_Float,

--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -1500,18 +1500,16 @@ def random_bright_color() -> ManimColor:
 def random_color() -> ManimColor:
     """Return a random :class:`ManimColor`.
 
-    .. warning::
-        This operation is very expensive. Please keep in mind the performance loss.
-
     Returns
     -------
     ManimColor
         A random :class:`ManimColor`.
     """
-    return RandomColorGenerator().next()
+    return RandomColorGenerator._random_color()
 
 
 class RandomColorGenerator:
+    _singleton: RandomColorGenerator | None = None
     """A generator for producing random colors from a given list of Manim colors,
     optionally in a reproducible sequence using a seed value.
 
@@ -1603,6 +1601,23 @@ class RandomColorGenerator:
             ManimColor('#FC6255')
         """
         return self.choice(self.colors)
+
+    @classmethod
+    def _random_color(cls) -> ManimColor:
+        """Internal method to generate a random color using the singleton instance of
+        `RandomColorGenerator`.
+        It will be used by proxy method `random_color` publicly available
+        and makes it backwards compatible.
+
+        Returns
+        -------
+        ManimColor:
+            A randomly selected color from the configured color list of
+            the singleton instance.
+        """
+        if cls._singleton is None:
+            cls._singleton = cls()
+        return cls._singleton.next()
 
 
 def get_shaded_rgb(


### PR DESCRIPTION
## Overview: What does this pull request change?
* Introduces a new class `RandomColorGenerator`, which enables deterministic generation of colors from Manim's color palette using an optional seed.
* Refactors the `random_color()` function to use this class internally, preserving existing behavior and output style.


## Motivation and Explanation: Why and how do your changes improve the library?
The existing `random_color()` function uses Python’s global `random` module, which makes the results non-deterministic and unsuitable for use cases like tests or reproducible animations.

This PR introduces `RandomColorGenerator`, a utility that allows users to generate a **repeatable sequence** of random Manim colors by initializing it with a specific seed. The sequence is generated **statefully**—each call to `.next()` returns the next color in that seeded sequence. Here’s an example:

```python
>>> from manim.utils.color.core import RandomColorGenerator
>>> rnd = RandomColorGenerator(42)
>>> rnd.next(), rnd.next()
(ManimColor('#ECE7E2'), ManimColor('#BBBBBB'))

>>> rnd2 = RandomColorGenerator(42)
>>> rnd2.next(), rnd2.next()
(ManimColor('#ECE7E2'), ManimColor('#BBBBBB'))  # same as above
```

Meanwhile, the `random_color()` function continues to behave the same:

```python
>>> from manim import random_color
>>> random_color()
ManimColor('#9A72AC')
```

This ensures full **backward compatibility**, with zero impact on existing code using `random_color()`.


## Further Information and Comments
Based on the discussion in the related issue, this design addresses two key requirements:

* Provide a deterministic way to generate random colors for testing or consistent rendering.
* Do not introduce breaking changes to the existing `random_color()` API, which is widely used.

Importantly, we **do not** add a `seed` parameter to `random_color()` to avoid confusion around stateless vs stateful behavior. Instead, the `RandomColorGenerator` class provides an explicit, opt-in mechanism for seeded, stateful random color generation—making the intended behavior clear to users.

This separation keeps the API clean while offering more control to advanced users who need it.



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
