### PR TITLE
Fix: Typo in constants.py

### DIFF
--- a/manim/constants.py
+++ b/manim/constants.py
@@ -48,7 +48,7 @@ __all__ = [
     "START_X",
     "START_Y",
     "DEFAULT_DOT_RADIUS",
-    "DEFAULT_SMALL_DOT_RADIUS",
+    "HEAVY",
     "DEFAULT_DASH_LENGTH",
     "DEFAULT_ARROW_TIP_LENGTH",
     "SMALL_BUFF",


### PR DESCRIPTION
There's a typo in constants.py, the word "ULTRAHEAVY" is written "ULTRAHEAV", which can cause issues and confusion.

Applied fixes:
```diff
--- a/manim\constants.py
+++ b/manim\constants.py
@@ -48,7 +48,7 @@
     "MEDIUM",
     "SEMIBOLD",
     "ULTRABOLD",
-    "HEAVY",
+    "HEAVY",
     "ULTRAHEAVY",
     "RESAMPLING_ALGORITHMS",
     "ORIGIN",
```