### PR TITLE
Fix Microsoft typo in `TexFontTemplateLibrary` scene in `example_scenes/advanced_tex_fonts.py`

### DIFF
--- a/example_scenes/advanced_tex_fonts.py
+++ b/example_scenes/advanced_tex_fonts.py
@@ -52,7 +52,7 @@ class TexFontTemplateLibrary(Scene):
     Many of the in the TexFontTemplates collection require that specific fonts
     are installed on your local machine.
     For example, choosing the template TexFontTemplates.comic_sans will
-    not compile if the Comic Sans Micrososft font is not installed.
+    not compile if the Comic Sans Microsoft font is not installed.
 
     This scene will only render those Templates that do not cause a TeX
     compilation error on your system. Furthermore, some of the ones that do render,


### PR DESCRIPTION
Fixes https://github.com/ManimCommunity/manim/issues/4294 
This is a very small PR that fixes a typo in advanced_tex_fonts.py.
I could not find the encoding error mentioned in the issue, Półtawskiego is encoded correctly on every occurence on my end.