### PR TITLE
Ensure `stroke_width` attribute of `SVGMobject` is not set to `None`

### DIFF
--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -125,6 +125,8 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
         self.stroke_color = stroke_color
         self.stroke_opacity = stroke_opacity
         self.stroke_width = stroke_width
+        if self.stroke_width is None:
+            self.stroke_width = 0
 
         if svg_default is None:
             svg_default = {


### PR DESCRIPTION
This change fixes issue [4311](https://github.com/ManimCommunity/manim/issues/4311).

## Overview: What does this pull request change?
When the `mobject.become` method is used to change one `SVGMobject` into another, it interpolates a number of properties between the two objects. One of these properties is the `stroke_width`, which in the `SVGMobject` `__init__` method is set None by default. This makes the interpolation of the `stroke_width` fail.

The suggested solution ensures that the `stroke_width` property of `SVGMobject` is not set to None.

As I read the code, the `stroke_width` property is not used elsewhere in the `SVGMobject`.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
