### PR TITLE
Fix for issue 4255 - Do not clear point when the number of curves is zero

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -11,7 +11,6 @@ __all__ = [
     "DashedVMobject",
 ]
 
-
 import itertools as it
 import sys
 from collections.abc import Hashable, Iterable, Mapping, Sequence
@@ -1916,7 +1915,6 @@ class VMobject(Mobject):
             return self
         num_curves = vmobject.get_num_curves()
         if num_curves == 0:
-            self.clear_points()
             return self
 
         # The following two lines will compute which Bézier curves of the given Mobject must be processed.


### PR DESCRIPTION
## Overview: What does this pull request change?
The method pointwise_become_partial in the class VMobject resets the point defining the object to zero, if there is only one point.
The change simply lets the point be unchanged.

## Motivation and Explanation: Why and how do your changes improve the library?
The suggested change fixes issue #4255 .

## Further Information and Comments
See more comments to the issue here: 
https://github.com/ManimCommunity/manim/issues/4255#issuecomment-3018632084

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
