### PR TITLE
Gracefully fall back when version metadata is missing

### DIFF
--- a/manim/__init__.py
+++ b/manim/__init__.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python
 from __future__ import annotations
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = version(__name__)
+# Use installed distribution version if available; otherwise fall back to a
+# sensible default so that importing from a source checkout works without an
+# editable install (pip install -e .).
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    # Package is not installed; provide a fallback version string.
+    __version__ = "0.0.0+dev"
 
 
 # isort: off

--- a/manim/__init__.py
+++ b/manim/__init__.py
@@ -10,7 +10,7 @@ try:
     __version__ = version(__name__)
 except PackageNotFoundError:
     # Package is not installed; provide a fallback version string.
-    __version__ = "0.0.0+dev"
+    __version__ = "0.0.0+unknown"
 
 
 # isort: off


### PR DESCRIPTION
Importing Manim directly from a source checkout crashed with
`importlib.metadata.PackageNotFoundError` because distribution metadata
is absent until the package is installed.  
[manim/__init__.py](cci:7://file:///d:/Github/manim/manim/__init__.py:0:0-0:0) now catches that exception and provides a fallback
`"0.0.0+dev"` version string, allowing `import manim` to succeed
immediately after cloning the repository while preserving the correct
behaviour for installed distributions.