### PR TITLE
Use utf-8 encoding to read generated .tex files.

### DIFF
--- a/manim/utils/tex_file_writing.py
+++ b/manim/utils/tex_file_writing.py
@@ -288,7 +288,7 @@ def print_all_tex_errors(log_file: Path, tex_compiler: str, tex_file: Path) -> N
         index for index, line in enumerate(tex_compilation_log) if line.startswith("!")
     ]
     if error_indices:
-        with tex_file.open() as f:
+        with tex_file.open(encoding="utf-8") as f:
             tex = f.readlines()
         for error_index in error_indices:
             print_tex_error(tex_compilation_log, error_index, tex)


### PR DESCRIPTION
## Overview: What does this pull request change?
Fixes a little decoding error when handling tex-errors.

## Motivation and Explanation: Why and how do your changes improve the library?
- Python uses default encoding provided by OS.
- In windows, system default text encoding is some reason a ancient Microsoft cp1252-encoding, a version of ANSI.
- Tex will produce Utf-8 encoded files and current system will produce decoding error if tex file include any utf-8 characters.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
