### PR TITLE
Add Docstring for ChangingDecimal and ChangingDecimalToValue

### DIFF
--- a/manim/animation/numbers.py
+++ b/manim/animation/numbers.py
@@ -16,6 +16,40 @@ from ..utils.bezier import interpolate
 
 
 class ChangingDecimal(Animation):
+    """Animate a :class:`~.DecimalNumber` to values specified by a user-supplied function.
+
+    Parameters
+    ----------
+    decimal_mob
+        The :class:`~.DecimalNumber` instance to animate.
+    number_update_func
+        A function that returns the number to display at each point in the animation.
+    suspend_mobject_updating
+        If ``True``, the mobject is not updated outside this animation.
+
+    Raises
+    ------
+    TypeError
+        If *decimal_mob* is not an instance of :class:`~.DecimalNumber`.
+
+    Examples
+    --------
+
+    .. manim:: ChangingDecimalExample
+
+        class ChangingDecimalExample(Scene):
+            def construct(self):
+                number = DecimalNumber(0)
+                self.add(number)
+                self.play(
+                    ChangingDecimal(
+                        number,
+                        lambda a: 5 * a,
+                        run_time=3
+                    )
+                )
+                self.wait()
+    """
     def __init__(
         self,
         decimal_mob: DecimalNumber,
@@ -34,10 +68,38 @@ class ChangingDecimal(Animation):
             raise TypeError("ChangingDecimal can only take in a DecimalNumber")
 
     def interpolate_mobject(self, alpha: float) -> None:
+        """Interpolates the mobject of the Animation based on alpha value.
+
+        Parameters
+        ----------
+        alpha
+            A float between 0 and 1 representing the animation progress.
+        """
         self.mobject.set_value(self.number_update_func(self.rate_func(alpha)))  # type: ignore[attr-defined]
 
 
 class ChangeDecimalToValue(ChangingDecimal):
+    """Animate a :class:`~.DecimalNumber` to a target value using linear interpolation.
+
+    Parameters
+    ----------
+    decimal_mob
+        The :class:`~.DecimalNumber` instance to animate.
+    target_number
+        The target value to transition to.
+
+    Examples
+    --------
+
+    .. manim:: ChangeDecimalToValueExample
+
+        class ChangeDecimalToValueExample(Scene):
+            def construct(self):
+                number = DecimalNumber(0)
+                self.add(number)
+                self.play(ChangeDecimalToValue(number, 10, run_time=3))
+                self.wait()
+    """
     def __init__(
         self, decimal_mob: DecimalNumber, target_number: int, **kwargs: Any
     ) -> None:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

Adds docstring under ChangingDecimal and ChangingDecimalToValue classes (related to the issue #4344). 

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
The ChangingDecimal and ChangingDecimalToValue classes did not have any docstring. This PR implements the docstring to properly describe these classes.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
This affects the inline documentation in manim/animation/numbers.py

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
