### PR TITLE
Fix `BraceLabel.change_label()` and document `BraceText`

### DIFF
--- a/manim/mobject/svg/brace.py
+++ b/manim/mobject/svg/brace.py
@@ -271,7 +271,7 @@ class BraceLabel(VMobject, metaclass=ConvertToOpenGL):
         self.brace = Brace(obj, self.brace_direction, **kwargs)
         self.brace.put_at_tip(self.label)
         return self
-    
+
     def change_label(self, *text: str, **kwargs: Any) -> Self:
         self.remove(self.label)
         self.label = self.label_constructor(*text, **kwargs)  # type: ignore[arg-type]
@@ -329,6 +329,7 @@ class BraceText(BraceLabel):
                     self.add(br2)
                     self.wait(0.1)
     """
+
     def __init__(
         self,
         obj: Mobject,


### PR DESCRIPTION
## Overview: What does this pull request change?
Fixes #4340 

This PR fixes issue https://github.com/ManimCommunity/manim/issues/4340, by making the change_label method actually change the rendered label of an instance of the BraceLabel class.

## Links to added or changed documentation pages
Documentation for BraceText was added:
https://manimce--4347.org.readthedocs.build/en/4347/reference/manim.mobject.svg.brace.BraceText.html


## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
