### PR TITLE
Ensure that stroke_width is an np.array in the Surface class

### DIFF
--- a/manim/mobject/three_d/three_dimensions.py
+++ b/manim/mobject/three_d/three_dimensions.py
@@ -128,7 +128,7 @@ class Surface(VGroup, metaclass=ConvertToOpenGL):
         else:
             self.checkerboard_colors = checkerboard_colors
         self.stroke_color: ManimColor = ManimColor(stroke_color)
-        self.stroke_width = stroke_width
+        self.stroke_width = np.array(stroke_width, ndmin=1)
         self.should_make_jagged = should_make_jagged
         self.pre_function_handle_to_anchor_scale_factor = (
             pre_function_handle_to_anchor_scale_factor


### PR DESCRIPTION
Here is a solution to issue https://github.com/ManimCommunity/manim/issues/4337

The PR ensures that the `stroke_width` parameter in the `Surface` class is set to an np.array instead of a float.


## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
