### PR TITLE
Refactor imports from `collections.abc`, `typing` and `typing_extensions` for Python 3.9

### DIFF
--- a/.github/scripts/ci_build_cairo.py
+++ b/.github/scripts/ci_build_cairo.py
@@ -14,8 +14,8 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import typing
 import urllib.request
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from sys import stdout
@@ -67,7 +67,7 @@ def run_command(command, cwd=None, env=None):
 
 
 @contextmanager
-def gha_group(title: str) -> typing.Generator:
+def gha_group(title: str) -> Generator:
     if not is_ci():
         yield
         return

--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -14,10 +14,10 @@ from ..utils.rate_functions import linear, smooth
 __all__ = ["Animation", "Wait", "Add", "override_animation"]
 
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from copy import deepcopy
 from functools import partialmethod
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import Self
 

--- a/manim/animation/changing.py
+++ b/manim/animation/changing.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 __all__ = ["AnimatedBoundary", "TracedPath"]
 
-from collections.abc import Sequence
-from typing import Callable
+from collections.abc import Callable, Sequence
+from typing import Any
 
-from typing_extensions import Any, Self
+from typing_extensions import Self
 
 from manim.mobject.mobject import Mobject
 from manim.mobject.opengl.opengl_compatibility import ConvertToOpenGL

--- a/manim/animation/composition.py
+++ b/manim/animation/composition.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import types
 from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any
 

--- a/manim/animation/composition.py
+++ b/manim/animation/composition.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import types
-from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 

--- a/manim/animation/creation.py
+++ b/manim/animation/creation.py
@@ -76,8 +76,8 @@ __all__ = [
 
 
 import itertools as it
-from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 

--- a/manim/animation/fading.py
+++ b/manim/animation/fading.py
@@ -19,8 +19,9 @@ __all__ = [
     "FadeIn",
 ]
 
+from typing import Any
+
 import numpy as np
-from typing_extensions import Any
 
 from manim.mobject.opengl.opengl_mobject import OpenGLMobject
 

--- a/manim/animation/growing.py
+++ b/manim/animation/growing.py
@@ -31,7 +31,7 @@ __all__ = [
     "SpinInFromNothing",
 ]
 
-import typing
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -39,7 +39,7 @@ from ..animation.transform import Transform
 from ..constants import PI
 from ..utils.paths import spiral_path
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from manim.mobject.geometry.line import Arrow
 
     from ..mobject.mobject import Mobject

--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -39,7 +39,7 @@ __all__ = [
     "Blink",
 ]
 
-from collections.abc import Callale, Iterable
+from collections.abc import Iterable
 from typing import Any
 
 import numpy as np

--- a/manim/animation/indication.py
+++ b/manim/animation/indication.py
@@ -39,8 +39,7 @@ __all__ = [
     "Blink",
 ]
 
-from collections.abc import Iterable
-from typing import Callable
+from collections.abc import Callable, Iterable
 
 import numpy as np
 

--- a/manim/animation/numbers.py
+++ b/manim/animation/numbers.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 __all__ = ["ChangingDecimal", "ChangeDecimalToValue"]
 
 
-import typing
-
-from typing_extensions import Any
+from collections.abc import Callable
+from typing import Any
 
 from manim.mobject.text.numbers import DecimalNumber
 
@@ -54,7 +53,7 @@ class ChangingDecimal(Animation):
     def __init__(
         self,
         decimal_mob: DecimalNumber,
-        number_update_func: typing.Callable[[float], float],
+        number_update_func: Callable[[float], float],
         suspend_mobject_updating: bool = False,
         **kwargs: Any,
     ) -> None:

--- a/manim/animation/rotation.py
+++ b/manim/animation/rotation.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 __all__ = ["Rotating", "Rotate"]
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from typing_extensions import Any
 
 from ..animation.animation import Animation
 from ..animation.transform import Transform

--- a/manim/animation/speedmodifier.py
+++ b/manim/animation/speedmodifier.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import inspect
 import types
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from numpy import piecewise
 

--- a/manim/animation/transform.py
+++ b/manim/animation/transform.py
@@ -28,8 +28,8 @@ __all__ = [
 
 import inspect
 import types
-from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 

--- a/manim/animation/updaters/mobject_update_utils.py
+++ b/manim/animation/updaters/mobject_update_utils.py
@@ -15,7 +15,8 @@ __all__ = [
 
 
 import inspect
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 

--- a/manim/animation/updaters/update.py
+++ b/manim/animation/updaters/update.py
@@ -6,14 +6,12 @@ __all__ = ["UpdateFromFunc", "UpdateFromAlphaFunc", "MaintainPositionRelativeTo"
 
 
 import operator as op
-import typing
-from typing import Callable
-
-from typing_extensions import Any
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from manim.animation.animation import Animation
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from manim.mobject.mobject import Mobject
 
 

--- a/manim/camera/camera.py
+++ b/manim/camera/camera.py
@@ -8,9 +8,9 @@ import copy
 import itertools as it
 import operator as op
 import pathlib
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from functools import reduce
-from typing import Any, Callable
+from typing import Any
 
 import cairo
 import numpy as np

--- a/manim/camera/three_d_camera.py
+++ b/manim/camera/three_d_camera.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 __all__ = ["ThreeDCamera"]
 
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 

--- a/manim/cli/checkhealth/checks.py
+++ b/manim/cli/checkhealth/checks.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 import os
 import shutil
-from typing import Callable, Protocol, cast
+from collections.abc import Callable
+from typing import Protocol, cast
 
 __all__ = ["HEALTH_CHECKS"]
 

--- a/manim/cli/default_group.py
+++ b/manim/cli/default_group.py
@@ -13,7 +13,8 @@ In particular, this class is what allows ``manim`` to act as ``manim render``.
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import cloup
 

--- a/manim/mobject/frame.py
+++ b/manim/mobject/frame.py
@@ -8,7 +8,7 @@ __all__ = [
 ]
 
 
-from typing_extensions import Any
+from typing import Any
 
 from manim.mobject.geometry.polygram import Rectangle
 

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -44,7 +44,7 @@ __all__ = [
 
 import itertools
 import warnings
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 from typing_extensions import Self
@@ -64,7 +64,6 @@ from manim.utils.space_ops import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from typing import Any
 
     import manim.mobject.geometry.tips as tips
     from manim.mobject.mobject import Mobject

--- a/manim/mobject/geometry/boolean_ops.py
+++ b/manim/mobject/geometry/boolean_ops.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from pathops import Path as SkiaPath
@@ -13,8 +13,6 @@ from manim.mobject.opengl.opengl_compatibility import ConvertToOpenGL
 from manim.mobject.types.vectorized_mobject import VMobject
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from manim.typing import Point2DLike_Array, Point3D_Array, Point3DLike_Array
 
 from ...constants import RendererType

--- a/manim/mobject/geometry/labeled.py
+++ b/manim/mobject/geometry/labeled.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 __all__ = ["Label", "LabeledLine", "LabeledArrow", "LabeledPolygram"]
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -22,8 +22,6 @@ from manim.utils.color import WHITE
 from manim.utils.polylabel import polylabel
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from manim.typing import Point3DLike_Array
 
 

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -14,7 +14,7 @@ __all__ = [
     "RightAngle",
 ]
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
@@ -30,9 +30,7 @@ from manim.utils.color import WHITE
 from manim.utils.space_ops import angle_of_vector, line_intersection, normalize
 
 if TYPE_CHECKING:
-    from typing import Any
-
-    from typing_extensions import Literal, Self, TypeAlias
+    from typing_extensions import Self, TypeAlias
 
     from manim.typing import Point2DLike, Point3D, Point3DLike, Vector3D
     from manim.utils.color import ParsableManimColor

--- a/manim/mobject/geometry/polygram.py
+++ b/manim/mobject/geometry/polygram.py
@@ -18,7 +18,7 @@ __all__ = [
 
 
 from math import ceil
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
@@ -32,8 +32,6 @@ from manim.utils.qhull import QuickHull
 from manim.utils.space_ops import angle_between_vectors, normalize, regular_vertices
 
 if TYPE_CHECKING:
-    from typing import Any, Literal
-
     import numpy.typing as npt
     from typing_extensions import Self
 

--- a/manim/mobject/geometry/tips.py
+++ b/manim/mobject/geometry/tips.py
@@ -13,7 +13,7 @@ __all__ = [
     "StealthTip",
 ]
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -25,8 +25,6 @@ from manim.mobject.types.vectorized_mobject import VMobject
 from manim.utils.space_ops import angle_of_vector
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from manim.typing import Point3D, Vector3D
 
 

--- a/manim/mobject/graphing/coordinate_systems.py
+++ b/manim/mobject/graphing/coordinate_systems.py
@@ -13,8 +13,8 @@ __all__ = [
 
 import fractions as fr
 import numbers
-from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, overload
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 import numpy as np
 from typing_extensions import Self

--- a/manim/mobject/graphing/functions.py
+++ b/manim/mobject/graphing/functions.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 __all__ = ["ParametricFunction", "FunctionGraph", "ImplicitFunction"]
 
 
-from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from isosurfaces import plot_isoline

--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -8,8 +8,8 @@ from manim.mobject.opengl.opengl_vectorized_mobject import OpenGLVMobject
 __all__ = ["NumberLine", "UnitInterval"]
 
 
-from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from manim.mobject.geometry.tips import ArrowTip

--- a/manim/mobject/logo.py
+++ b/manim/mobject/logo.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 __all__ = ["ManimBanner"]
 
+from typing import Any
+
 import svgelements as se
-from typing_extensions import Any
 
 from manim.animation.updaters.update import UpdateFromAlphaFunc
 from manim.mobject.geometry.arc import Circle

--- a/manim/mobject/matrix.py
+++ b/manim/mobject/matrix.py
@@ -40,8 +40,8 @@ __all__ = [
 
 
 import itertools as it
-from collections.abc import Iterable, Sequence
-from typing import Any, Callable
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any
 
 import numpy as np
 from typing_extensions import Self

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -14,10 +14,10 @@ import random
 import sys
 import types
 import warnings
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from functools import partialmethod, reduce
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
@@ -41,8 +41,6 @@ from ..utils.paths import straight_path
 from ..utils.space_ops import angle_between_vectors, normalize, rotation_matrix
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Literal
-
     from typing_extensions import Self, TypeAlias
 
     from manim.typing import (

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -6,10 +6,10 @@ import itertools as it
 import random
 import sys
 import types
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from functools import partialmethod, wraps
 from math import ceil
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import moderngl
 import numpy as np

--- a/manim/mobject/opengl/opengl_vectorized_mobject.py
+++ b/manim/mobject/opengl/opengl_vectorized_mobject.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import itertools as it
 import operator as op
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from functools import reduce, wraps
-from typing import Callable
 
 import moderngl
 import numpy as np

--- a/manim/mobject/table.py
+++ b/manim/mobject/table.py
@@ -65,8 +65,7 @@ __all__ = [
 
 
 import itertools as it
-from collections.abc import Iterable, Sequence
-from typing import Callable
+from collections.abc import Callable, Iterable, Sequence
 
 from manim.mobject.geometry.line import Line
 from manim.mobject.geometry.polygram import Polygon

--- a/manim/mobject/three_d/three_dimensions.py
+++ b/manim/mobject/three_d/three_dimensions.py
@@ -19,8 +19,8 @@ __all__ = [
     "Torus",
 ]
 
-from collections.abc import Iterable, Sequence
-from typing import Any, Callable
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any
 
 import numpy as np
 from typing_extensions import Self

--- a/manim/mobject/types/image_mobject.py
+++ b/manim/mobject/types/image_mobject.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 __all__ = ["AbstractImageMobject", "ImageMobject", "ImageMobjectFromCamera"]
 
 import pathlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from PIL import Image
@@ -23,8 +23,6 @@ from ...utils.images import change_to_rgba_array, get_full_raster_image_path
 __all__ = ["ImageMobject", "ImageMobjectFromCamera"]
 
 if TYPE_CHECKING:
-    from typing import Any
-
     import numpy.typing as npt
     from typing_extensions import Self
 

--- a/manim/mobject/types/point_cloud_mobject.py
+++ b/manim/mobject/types/point_cloud_mobject.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 __all__ = ["PMobject", "Mobject1D", "Mobject2D", "PGroup", "PointCloudDot", "Point"]
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -29,9 +30,6 @@ from ...utils.iterables import stretch_array_to_length
 __all__ = ["PMobject", "Mobject1D", "Mobject2D", "PGroup", "PointCloudDot", "Point"]
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any
-
     import numpy.typing as npt
     from typing_extensions import Self
 

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -13,8 +13,8 @@ __all__ = [
 
 import itertools as it
 import sys
-from collections.abc import Hashable, Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, Callable, Literal
+from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 from PIL.Image import Image
@@ -47,8 +47,6 @@ from manim.utils.iterables import (
 from manim.utils.space_ops import rotate_vector, shoelace_direction
 
 if TYPE_CHECKING:
-    from typing import Any
-
     import numpy.typing as npt
     from typing_extensions import Self
 

--- a/manim/mobject/vector_field.py
+++ b/manim/mobject/vector_field.py
@@ -10,9 +10,8 @@ __all__ = [
 
 import itertools as it
 import random
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from math import ceil, floor
-from typing import Callable
 
 import numpy as np
 from PIL import Image

--- a/manim/renderer/cairo_renderer.py
+++ b/manim/renderer/cairo_renderer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import typing
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -13,9 +14,7 @@ from ..scene.scene_file_writer import SceneFileWriter
 from ..utils.exceptions import EndSceneEarlyException
 from ..utils.iterables import list_update
 
-if typing.TYPE_CHECKING:
-    from typing import Any
-
+if TYPE_CHECKING:
     from manim.animation.animation import Animation
     from manim.scene.scene import Scene
 
@@ -120,7 +119,7 @@ class CairoRenderer:
     def update_frame(  # TODO Description in Docstring
         self,
         scene: Scene,
-        mobjects: typing.Iterable[Mobject] | None = None,
+        mobjects: Iterable[Mobject] | None = None,
         include_submobjects: bool = True,
         ignore_skipping: bool = True,
         **kwargs: Any,
@@ -214,8 +213,8 @@ class CairoRenderer:
     def save_static_frame_data(
         self,
         scene: Scene,
-        static_mobjects: typing.Iterable[Mobject],
-    ) -> typing.Iterable[Mobject] | None:
+        static_mobjects: Iterable[Mobject],
+    ) -> Iterable[Mobject] | None:
         """Compute and save the static frame, that will be reused at each frame
         to avoid unnecessarily computing static mobjects.
 

--- a/manim/renderer/vectorized_mobject_rendering.py
+++ b/manim/renderer/vectorized_mobject_rendering.py
@@ -25,7 +25,7 @@ __all__ = [
 
 def build_matrix_lists(
     mob: OpenGLVMobject,
-) -> collections.defaultdict[tuple[float, ...], list[OpenGLVMobject]]:
+) -> defaultdict[tuple[float, ...], list[OpenGLVMobject]]:
     root_hierarchical_matrix = mob.hierarchical_model_matrix()
     matrix_to_mobject_list = defaultdict(list)
     if mob.has_points():

--- a/manim/renderer/vectorized_mobject_rendering.py
+++ b/manim/renderer/vectorized_mobject_rendering.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import collections
+from collections import defaultdict
 
 import numpy as np
 
@@ -16,7 +16,7 @@ __all__ = [
 
 def build_matrix_lists(mob):
     root_hierarchical_matrix = mob.hierarchical_model_matrix()
-    matrix_to_mobject_list = collections.defaultdict(list)
+    matrix_to_mobject_list = defaultdict(list)
     if mob.has_points():
         matrix_to_mobject_list[tuple(root_hierarchical_matrix.ravel())].append(mob)
     mobject_to_hierarchical_matrix = {mob: root_hierarchical_matrix}

--- a/manim/scene/moving_camera_scene.py
+++ b/manim/scene/moving_camera_scene.py
@@ -89,7 +89,7 @@ from __future__ import annotations
 
 __all__ = ["MovingCameraScene"]
 
-from typing_extensions import Any
+from typing import Any
 
 from manim.animation.animation import Animation
 from manim.mobject.mobject import Mobject

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -33,7 +33,7 @@ except ImportError:
     dearpygui_imported = False
 
 from collections.abc import Callable, Iterable, Sequence
-from typing import TYPE_CHECKING, Any, TypeAlias, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import numpy as np
 from tqdm import tqdm
@@ -63,7 +63,7 @@ from ..utils.module_ops import scene_classes_from_file
 if TYPE_CHECKING:
     from types import FrameType
 
-    from typing_extensions import Self
+    from typing_extensions import Self, TypeAlias
 
     from manim.typing import Point3D
 

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -31,7 +31,9 @@ try:
     window = dpg.generate_uuid()
 except ImportError:
     dearpygui_imported = False
-from typing import TYPE_CHECKING
+
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, TypeAlias, Union
 
 import numpy as np
 from tqdm import tqdm
@@ -59,9 +61,7 @@ from ..utils.iterables import list_difference_update, list_update
 from ..utils.module_ops import scene_classes_from_file
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
     from types import FrameType
-    from typing import Any, Callable, TypeAlias, Union
 
     from typing_extensions import Self
 

--- a/manim/scene/vector_space_scene.py
+++ b/manim/scene/vector_space_scene.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 __all__ = ["VectorScene", "LinearTransformationScene"]
 
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Callable, cast
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
@@ -45,8 +45,6 @@ from ..utils.rate_functions import rush_from, rush_into
 from ..utils.space_ops import angle_of_vector
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from typing_extensions import Self
 
     from manim.typing import MappingFunction, Point2DLike, Point3D, Point3DLike

--- a/manim/typing.py
+++ b/manim/typing.py
@@ -20,9 +20,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from os import PathLike
-from typing import Callable, Union
+from typing import Union
 
 import numpy as np
 import numpy.typing as npt

--- a/manim/utils/bezier.py
+++ b/manim/utils/bezier.py
@@ -20,9 +20,9 @@ __all__ = [
 ]
 
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from functools import reduce
-from typing import TYPE_CHECKING, Callable, overload
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
 

--- a/manim/utils/caching.py
+++ b/manim/utils/caching.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from .. import config, logger
 from ..utils.hashing import get_hash_from_play_call
@@ -8,8 +9,6 @@ from ..utils.hashing import get_hash_from_play_call
 __all__ = ["handle_caching_play"]
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from manim.renderer.opengl_renderer import OpenGLRenderer
     from manim.scene.scene import Scene
 

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -8,8 +8,8 @@ __all__ = ["deprecated", "deprecated_params"]
 import inspect
 import logging
 import re
-from collections.abc import Iterable
-from typing import Any, Callable, TypeVar, overload
+from collections.abc import Callable, Iterable
+from typing import Any, TypeVar, overload
 
 from decorator import decorate, decorator
 

--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -2,21 +2,20 @@
 
 from __future__ import annotations
 
-import collections
 import copy
 import inspect
 import json
-import typing
 import zlib
+from collections.abc import Callable, Hashable, Iterable
 from time import perf_counter
 from types import FunctionType, MappingProxyType, MethodType, ModuleType
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from manim._config import config, logger
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from manim.animation.animation import Animation
     from manim.camera.camera import Camera
     from manim.mobject.mobject import Mobject
@@ -117,7 +116,7 @@ class _Memoizer:
     def _handle_already_processed(
         cls,
         obj,
-        default_function: typing.Callable[[Any], Any],
+        default_function: Callable[[Any], Any],
     ):
         if isinstance(
             obj,
@@ -131,7 +130,7 @@ class _Memoizer:
             # It makes no sense (and it'd slower) to memoize objects of these primitive
             # types.  Hence, we simply return the object.
             return obj
-        if isinstance(obj, collections.abc.Hashable):
+        if isinstance(obj, Hashable):
             try:
                 return cls._return(obj, hash, default_function)
             except TypeError:
@@ -144,8 +143,8 @@ class _Memoizer:
     @classmethod
     def _return(
         cls,
-        obj: typing.Any,
-        obj_to_membership_sign: typing.Callable[[Any], int],
+        obj: Any,
+        obj_to_membership_sign: Callable[[Any], int],
         default_func,
         memoizing=True,
     ) -> str | Any:
@@ -234,7 +233,7 @@ class _CustomEncoder(json.JSONEncoder):
         # Serialize it with only the type of the object. You can change this to whatever string when debugging the serialization process.
         return str(type(obj))
 
-    def _cleaned_iterable(self, iterable: typing.Iterable[Any]):
+    def _cleaned_iterable(self, iterable: Iterable[Any]):
         """Check for circular reference at each iterable that will go through the JSONEncoder, as well as key of the wrong format.
 
         If a key with a bad format is found (i.e not a int, string, or float), it gets replaced byt its hash using the same process implemented here.
@@ -325,8 +324,8 @@ def get_json(obj: dict):
 def get_hash_from_play_call(
     scene_object: Scene,
     camera_object: Camera | OpenGLCamera,
-    animations_list: typing.Iterable[Animation],
-    current_mobjects_list: typing.Iterable[Mobject],
+    animations_list: Iterable[Animation],
+    current_mobjects_list: Iterable[Mobject],
 ) -> str:
     """Take the list of animations and a list of mobjects and output their hashes. This is meant to be used for `scene.play` function.
 

--- a/manim/utils/iterables.py
+++ b/manim/utils/iterables.py
@@ -20,6 +20,7 @@ __all__ = [
 
 import itertools as it
 from collections.abc import (
+    Callable,
     Collection,
     Generator,
     Hashable,
@@ -27,7 +28,7 @@ from collections.abc import (
     Reversible,
     Sequence,
 )
-from typing import TYPE_CHECKING, Callable, TypeVar, overload
+from typing import TYPE_CHECKING, TypeVar, overload
 
 import numpy as np
 

--- a/manim/utils/module_ops.py
+++ b/manim/utils/module_ops.py
@@ -7,7 +7,7 @@ import sys
 import types
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from manim._config import config, console, logger
 from manim.constants import (
@@ -19,8 +19,6 @@ from manim.constants import (
 from manim.scene.scene_file_writer import SceneFileWriter
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from manim.scene.scene import Scene
 
 __all__ = ["scene_classes_from_file"]

--- a/manim/utils/opengl.py
+++ b/manim/utils/opengl.py
@@ -15,12 +15,6 @@ if TYPE_CHECKING:
     from manim.typing import MatrixMN, Point3D
 
 
-if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
-
-    from manim.typing import MatrixMN
-
-
 depth = 20
 
 __all__ = [

--- a/manim/utils/simple_functions.py
+++ b/manim/utils/simple_functions.py
@@ -10,8 +10,9 @@ __all__ = [
 ]
 
 
+from collections.abc import Callable
 from functools import lru_cache
-from typing import Any, Callable, Protocol, TypeVar
+from typing import Any, Protocol, TypeVar
 
 import numpy as np
 from scipy import special

--- a/manim/utils/space_ops.py
+++ b/manim/utils/space_ops.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import itertools as it
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from mapbox_earcut import triangulate_float32 as earcut

--- a/manim/utils/testing/_test_class_makers.py
+++ b/manim/utils/testing/_test_class_makers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from manim.renderer.cairo_renderer import CairoRenderer
 from manim.renderer.opengl_renderer import OpenGLRenderer

--- a/manim/utils/testing/frames_comparison.py
+++ b/manim/utils/testing/frames_comparison.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import functools
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import cairo
 import pytest


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Refactored imports from `collections.abc`, `typing` and `typing_extensions`. This PR is valid as long as we support Python 3.9. Changes might need to be done in the future after dropping support for that version.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
- `typing.Callable` is a deprecated alias for `collections.abc.Callable`, which is why I used the latter instead.
- There were some imports of `Any` from `typing_extensions` when it's perfectly possible to import it from `typing` (unless we used `Any` as a base class, which we don't), so I did the latter instead.
- Sometimes, `import typing` was used instead of `from typing import X, Y, Z`. Sometimes, both kinds of imports were present in a file at the same time, or there were multiple `from typing import X, Y, Z` lines in different parts of the code, so I cleaned them.
- There was an `import collections` line in order to use `collections.abc.Hashable` and `collections.abc.Iterable`. In the same file, there was an `import typing` to use `typing.Callable` and other things, so I replaced the previous lines with `from collections.abc import Callable, Hashable, Iterable`.
- There was an `import collections` line in order to use `collections.defaultdict`, but other files simply used `from collections import defaultdict`, so I used the latter for consistency.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
