### PR TITLE
Optimize `always_redraw()` by reducing `Mobject` copying in `Mobject.become()`

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -3103,21 +3103,22 @@ class Mobject:
         --------
         :meth:`~.Mobject.align_data`, :meth:`~.VMobject.interpolate_color`
         """
-        mobject = mobject.copy()
-        if stretch:
-            mobject.stretch_to_fit_height(self.height)
-            mobject.stretch_to_fit_width(self.width)
-            mobject.stretch_to_fit_depth(self.depth)
-        else:
-            if match_height:
-                mobject.match_height(self)
-            if match_width:
-                mobject.match_width(self)
-            if match_depth:
-                mobject.match_depth(self)
+        if stretch or match_height or match_width or match_depth or match_center:
+            mobject = mobject.copy()
+            if stretch:
+                mobject.stretch_to_fit_height(self.height)
+                mobject.stretch_to_fit_width(self.width)
+                mobject.stretch_to_fit_depth(self.depth)
+            else:
+                if match_height:
+                    mobject.match_height(self)
+                if match_width:
+                    mobject.match_width(self)
+                if match_depth:
+                    mobject.match_depth(self)
 
-        if match_center:
-            mobject.move_to(self.get_center())
+            if match_center:
+                mobject.move_to(self.get_center())
 
         self.align_data(mobject, skip_point_alignment=True)
         for sm1, sm2 in zip(self.get_family(), mobject.get_family()):


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Inside the method `Mobject.become(self, mobject, ...)` where `self` morphs into a target `mobject`, the latter was always copied before the morphing. Now, it's copied only when it's explicitly altered (when `stretch` or `match_[height|width|depth|center]` is `True`), which is rarely the case. This optimizes `Mobject.become()` in most cases and, therefore, leads to a speedup when using `always_redraw()`, which under the hood creates a `Mobject` with a `become()` updater attached to it.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Copying Mobjects is expensive, so it should be done only when necessary. In the case of `Mobject.become()`, one usually calls it without specifying `stretch` or `match_[height|width|depth|center]` which are all `False` by default. In that case, the target `mobject` is not modified at all, so it's not necessary to copy it before making `self` morph into it.

By removing the copy in that case, `Mobject.become()` gets a lot faster. By profiling the following code:

```py
if __name__ == "__main__":
    with tempconfig({"quality": "low_quality"}):
        SineCurveUnitCircle().render()
```

where [`SineCurveUnitCircle` is a scene from the example gallery](https://docs.manim.community/en/stable/examples.html#sinecurveunitcircle), I get the following results showing around 4x speedup in `Mobject.become()`:

| Before | After |
| --- | --- |
| <img width="1908" height="783" alt="imagen" src="https://github.com/user-attachments/assets/991f4b7d-0a7c-42a6-930c-0805bcf9d86f" /> | <img width="1910" height="786" alt="imagen" src="https://github.com/user-attachments/assets/7bac5f74-3553-41f5-aead-1a94f4a9c225" /> |



## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
