### PR TITLE
Properly define `init_points` methods for use in OpenGL instead of defining `init_points = generate_points`

### DIFF
--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -916,7 +916,8 @@ class AnnularSector(Arc):
         self.append_points(outer_arc.points)
         self.add_line_to(inner_arc.points[0])
 
-    init_points = generate_points
+    def init_points(self) -> None:
+        self.generate_points()
 
 
 class Sector(AnnularSector):
@@ -990,7 +991,8 @@ class Annulus(Circle):
         self.append_points(inner_circle.points)
         self.shift(self.arc_center)
 
-    init_points = generate_points
+    def init_points(self) -> None:
+        self.generate_points()
 
 
 class CubicBezier(VMobject, metaclass=ConvertToOpenGL):

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -147,7 +147,8 @@ class Line(TipableVMobject):
 
         self._account_for_buff(buff)
 
-    init_points = generate_points
+    def init_points(self) -> None:
+        self.generate_points()
 
     def _account_for_buff(self, buff: float) -> None:
         if buff <= 0:

--- a/manim/mobject/graphing/functions.py
+++ b/manim/mobject/graphing/functions.py
@@ -179,7 +179,8 @@ class ParametricFunction(VMobject, metaclass=ConvertToOpenGL):
             self.make_smooth()
         return self
 
-    init_points = generate_points
+    def init_points(self) -> None:
+        self.generate_points()
 
 
 class FunctionGraph(ParametricFunction):
@@ -317,4 +318,5 @@ class ImplicitFunction(VMobject, metaclass=ConvertToOpenGL):
             self.make_smooth()
         return self
 
-    init_points = generate_points
+    def init_points(self) -> None:
+        self.generate_points()

--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -496,7 +496,7 @@ class VMobjectFromSVGPath(VMobject, metaclass=ConvertToOpenGL):
 
         super().__init__(**kwargs)
 
-    def init_points(self) -> None:
+    def generate_points(self) -> None:
         # TODO: cache mobject in a re-importable way
 
         self.handle_commands()
@@ -509,7 +509,8 @@ class VMobjectFromSVGPath(VMobject, metaclass=ConvertToOpenGL):
                 # Get rid of any null curves
                 self.set_points(self.get_points_without_null_curves())
 
-    generate_points = init_points
+    def init_points(self) -> None:
+        self.generate_points()
 
     def handle_commands(self) -> None:
         all_points: list[np.ndarray] = []


### PR DESCRIPTION
As mentioned in a [comment thread](https://github.com/ManimCommunity/manim/pull/4003#discussion_r1855434608) to PR #4003, there are multiple definitions of `init_points` which look like
```py
init_points = generate_points
```

This caused the bug which was fixed in #4003. The solution there was to properly define `init_points` as
```py
def init_points(self) -> None:
    self.generate_points()
```

This PR fixes the rest of such definitions so that `init_points` is properly defined as stated above in every class which defines it.


## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
