### PR TITLE
Fix Sphinx exceptions when trying to build documentation via latex / as pdf

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -156,6 +156,7 @@ html_title = f"Manim Community v{manim.__version__}"
 # This specifies any additional css files that will override the theme's
 html_css_files = ["custom.css"]
 
+latex_engine = "lualatex"
 
 # external links
 extlinks = {

--- a/manim/utils/docbuild/autocolor_directive.py
+++ b/manim/utils/docbuild/autocolor_directive.py
@@ -89,7 +89,8 @@ class ManimColorModuleDocumenter(Directive):
                         format="html",
                     )
                 else:
-                    col1 = col2 = nodes.literal(text="")
+                    col1 = nodes.literal(text="")
+                    col2 = nodes.raw("", "", format="html")
                 row += nodes.entry("", col1)
                 row += nodes.entry("", col2)
             tbody += row

--- a/manim/utils/docbuild/autocolor_directive.py
+++ b/manim/utils/docbuild/autocolor_directive.py
@@ -79,15 +79,17 @@ class ManimColorModuleDocumenter(Directive):
 
         for base_i in range(0, len(color_elements), num_color_cols):
             row = nodes.row()
-            for member_name, hex_code, font_color in color_elements[
-                base_i : base_i + num_color_cols
-            ]:
-                col1 = nodes.literal(text=member_name)
-                col2 = nodes.raw(
-                    "",
-                    f'<div style="background-color:{hex_code};padding: 0.25rem 0;border-radius:8px;margin: 0.5rem 0.2rem"><code style="color:{font_color};">{hex_code}</code></div>',
-                    format="html",
-                )
+            for idx in range(base_i, base_i + num_color_cols):
+                if idx < len(color_elements):
+                    member_name, hex_code, font_color = color_elements[idx]
+                    col1 = nodes.literal(text=member_name)
+                    col2 = nodes.raw(
+                        "",
+                        f'<div style="background-color:{hex_code};padding: 0.25rem 0;border-radius:8px;margin: 0.5rem 0.2rem"><code style="color:{font_color};">{hex_code}</code></div>',
+                        format="html",
+                    )
+                else:
+                    col1 = col2 = nodes.literal(text="")
                 row += nodes.entry("", col1)
                 row += nodes.entry("", col2)
             tbody += row

--- a/manim/utils/docbuild/manim_directive.py
+++ b/manim/utils/docbuild/manim_directive.py
@@ -399,7 +399,11 @@ def _delete_rendering_times(*args: tuple[Any]) -> None:
 
 
 def setup(app: Sphinx) -> SetupMetadata:
-    app.add_node(SkipManimNode, html=(visit, depart))
+    app.add_node(
+        SkipManimNode,
+        html=(visit, depart),
+        latex=(lambda a, b: None, lambda a, b: None)
+    )
 
     setup.app = app  # type: ignore[attr-defined]
     setup.config = app.config  # type: ignore[attr-defined]

--- a/manim/utils/docbuild/manim_directive.py
+++ b/manim/utils/docbuild/manim_directive.py
@@ -402,7 +402,7 @@ def setup(app: Sphinx) -> SetupMetadata:
     app.add_node(
         SkipManimNode,
         html=(visit, depart),
-        latex=(lambda a, b: None, lambda a, b: None)
+        latex=(lambda a, b: None, lambda a, b: None),
     )
 
     setup.app = app  # type: ignore[attr-defined]


### PR DESCRIPTION
See title. Marginal improvements for pdf documentation (its still not great, but it compiles at least). Closes #4145.

The issue was caused by our color directive that created table rows with fewer entries than in the header.