### PR TITLE
Fix(animation): Resolve bug in chained ReplacementTransform

### DIFF
--- a/manim/animation/transform.py
+++ b/manim/animation/transform.py
@@ -217,7 +217,7 @@ class Transform(Animation):
     def clean_up_from_scene(self, scene: Scene) -> None:
         super().clean_up_from_scene(scene)
         if self.replace_mobject_with_target_in_scene:
-            scene.replace(self.mobject, self.target_mobject)
+            scene.remove(self.mobject)
 
     def get_all_mobjects(self) -> Sequence[Mobject]:
         return [


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
This PR fixes a bug in `ReplacementTransform` where a chained sequence of animations fails if all involved mobjects are present on the scene from the start.

The change ensures that the internal state of the target mobject is not corrupted during the animation's cleanup phase, allowing it to be correctly used as a source in subsequent animations.

- Fixes a bug causing chained `ReplacementTransform` animations to fail.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Currently, running a chain of `ReplacementTransform` animations (e.g., `A -> B`, then `B -> C`) fails after the second link in the chain.

The root cause lies in the `clean_up_from_scene` method of the `Transform` class. The original code uses `scene.replace(self.mobject, self.target_mobject)`, which re-adds an existing mobject to the scene and corrupts its internal state.

This PR fixes the issue by replacing the `scene.replace(...)` call with a simpler `scene.remove(self.mobject)`. This new approach only removes the redundant source mobject and never touches the target, preserving its state integrity for the next animation in the chain.

### Visual Demonstration

**Before (Buggy Behavior):**
The animation incorrectly stops after the second transformation.

https://github.com/user-attachments/assets/14ba67ba-6dc2-4cef-8f9b-046beae0a37a


**After (Corrected Behavior):**
The animation chain now completes successfully.

https://github.com/user-attachments/assets/2c93d8af-5429-49bf-9859-a353ebfd0404

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
N/A

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
The bug can be reproduced with the following minimal example.

```python
from manim import *

class ChainedReplacementTransformBug(Scene):
    def construct(self):
        numbers = VGroup(*[Integer(i) for i in range(5)])
        numbers.arrange(direction=UP, buff=1)
        self.add(numbers)

        self.play(ReplacementTransform(numbers[0], numbers[1]))
        self.play(ReplacementTransform(numbers[1], numbers[2]))
        # Animation fails on the next line in the original code
        self.play(ReplacementTransform(numbers[2], numbers[3]))
        self.play(ReplacementTransform(numbers[3], numbers[4]))

        self.wait()
```

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
