### PR TITLE
Fix for issue 3562 - OpenGL: DecimalNumber set_value

### DIFF
--- a/manim/mobject/opengl/opengl_vectorized_mobject.py
+++ b/manim/mobject/opengl/opengl_vectorized_mobject.py
@@ -279,7 +279,10 @@ class OpenGLVMobject(OpenGLMobject):
 
         if width is not None:
             for mob in self.get_family(recurse):
-                mob.stroke_width = np.array([[width] for width in tuplify(width)])
+                if isinstance(width, np.ndarray):
+                    mob.stroke_width = width
+                else:
+                    mob.stroke_width = np.array([[width] for width in tuplify(width)])
 
         if background is not None:
             for mob in self.get_family(recurse):


### PR DESCRIPTION
## Overview: What does this pull request change?
This PR solves issue https://github.com/ManimCommunity/manim/issues/3562.

## Further Information and Comments

The issue was inside these lines of the `set_stroke` method of the `OpenGLVMobject` class.
```
if width is not None:
  for mob in self.get_family(recurse):
    mob.stroke_width = np.array([[width] for width in tuplify(width)])
```
Each time `set_stroke` was called with the `width` parameter set to an `ndarray`, it increased the nesting of the array.
This worked fine until the nesting reached a depth of 64 levels, where numpy bailed out.

The suggested change is to check if `width` is an `ndarray` and if that is the case just use that value, in the other case use the old behaviour.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
