### PR TITLE
Fix: Issue with OpenGL rendering for Transform of SVGMobjects #4182

### DIFF
--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -2581,7 +2581,7 @@ class OpenGLMobject:
             # can handle that case differently if they choose
             mob1.align_points(mob2)
             for key in mob1.data.keys() & mob2.data.keys():
-                if key == "points" or key == "stroke_width":
+                if key == "points":
                     continue
                 arr1 = mob1.data[key]
                 arr2 = mob2.data[key]
@@ -2675,8 +2675,6 @@ class OpenGLMobject:
         """
         for key in self.data:
             if key in self.locked_data_keys:
-                continue
-            if isinstance(self.data[key], int):
                 continue
             if len(self.data[key]) == 0:
                 continue

--- a/manim/mobject/opengl/opengl_vectorized_mobject.py
+++ b/manim/mobject/opengl/opengl_vectorized_mobject.py
@@ -124,7 +124,10 @@ class OpenGLVMobject(OpenGLMobject):
         self.data = {}
         self.fill_opacity = fill_opacity
         self.stroke_opacity = stroke_opacity
+        print("OpenGLVMobject")
+        print(stroke_width)
         self.stroke_width = np.array([[stroke_width]])
+        print("self.stroke_width:", self.stroke_width)
         self.draw_stroke_behind_fill = draw_stroke_behind_fill
         # Indicates that it will not be displayed, but
         # that it should count in parent mobject's path
@@ -199,6 +202,8 @@ class OpenGLVMobject(OpenGLMobject):
             color=self.fill_color or self.color,
             opacity=self.fill_opacity,
         )
+        print("init_colors")
+        print("self.stroke_width:", self.stroke_width)
         self.set_stroke(
             color=self.stroke_color or self.color,
             width=self.stroke_width,
@@ -267,8 +272,6 @@ class OpenGLVMobject(OpenGLMobject):
         background=None,
         recurse=True,
     ):
-        if width is None:
-            width = np.array([[0]])
         if opacity is not None:
             self.stroke_opacity = opacity
         if recurse:
@@ -312,8 +315,16 @@ class OpenGLVMobject(OpenGLMobject):
 
         if stroke_rgba is not None:
             self.stroke_rgba = resize_with_interpolation(stroke_rgba, len(fill_rgba))
+            print("set_style")
+            print(self)
+            print("stroke_width: ", stroke_width)
+            print("self.stroke_width:", self.stroke_width)
             self.set_stroke(width=stroke_width)
         else:
+            print("set_style")
+            print(self)
+            print("stroke_width: ", stroke_width)
+            print("self.stroke_width:", self.stroke_width)
             self.set_stroke(
                 color=stroke_color,
                 width=stroke_width,
@@ -359,6 +370,8 @@ class OpenGLVMobject(OpenGLMobject):
             self.opacity = opacity
 
         self.set_fill(color, opacity=opacity, recurse=recurse)
+        print("set_color")
+        print(self.stroke_width)
         self.set_stroke(color, opacity=opacity, recurse=recurse)
         return self
 
@@ -436,7 +449,11 @@ class OpenGLVMobject(OpenGLMobject):
     fill_color = property(get_fill_color, set_fill)
 
     def has_stroke(self):
+        print("has_stroke")
+        print(self)
+        print("self.stroke_width: ", self.stroke_width)
         stroke_widths = self.get_stroke_widths()
+        print("stroke_widths: ", stroke_widths)
         stroke_opacities = self.get_stroke_opacities()
         return (
             stroke_widths is not None

--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -126,9 +126,10 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
         self.fill_opacity = fill_opacity  # type: ignore[assignment]
         self.stroke_color = stroke_color
         self.stroke_opacity = stroke_opacity  # type: ignore[assignment]
-        self.stroke_width = stroke_width  # type: ignore[assignment]
-        if self.stroke_width is None:
-            self.stroke_width = 0
+        if stroke_width is None:
+            self.stroke_width = None
+        else:
+            self.stroke_width = np.array([[stroke_width]])  # type: ignore[assignment]
 
         if svg_default is None:
             svg_default = {
@@ -136,7 +137,7 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
                 "opacity": None,
                 "fill_color": None,
                 "fill_opacity": None,
-                "stroke_width": 0,
+                "stroke_width": None,
                 "stroke_color": None,
                 "stroke_opacity": None,
             }
@@ -327,6 +328,9 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
         shape
             The parsed SVG element.
         """
+        print("apply_style_to_mobject")
+        print("mob")
+        print("mob.stroke_width:", mob.stroke_width)
         mob.set_style(
             stroke_width=shape.stroke_width,
             stroke_color=shape.stroke.hexrgb,
@@ -334,6 +338,7 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
             fill_color=shape.fill.hexrgb,
             fill_opacity=shape.fill.opacity,
         )
+        print("mob.stroke_width:", mob.stroke_width)
         return mob
 
     def path_to_mobject(self, path: se.Path) -> VMobjectFromSVGPath:


### PR DESCRIPTION
This is a fix for issue https://github.com/ManimCommunity/manim/issues/4182

## Overview: What does this pull request change?
In some cases the `stroke_width` parameter is not saved as a `np.ndarray` but a `float` or `int` instead. 
In that case the `len(...)` call will fail in the `align_data` method in `opengl_mobject.py`.

In the PR the for loop in `align_data` is also skipped for data with the key `stroke_width` or if the `self.data[key]` is of type `int` in the `interpolate` method.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
