### PR TITLE
Rename `SceneFileWriter.save_final_image()` to `save_image()`

### DIFF
--- a/manim/renderer/cairo_renderer.py
+++ b/manim/renderer/cairo_renderer.py
@@ -27,8 +27,13 @@ __all__ = ["CairoRenderer"]
 class CairoRenderer:
     """A renderer using Cairo.
 
-    num_plays : Number of play() functions in the scene.
-    time: time elapsed since initialisation of scene.
+    Attributes
+    ----------
+    num_plays : int
+        Number of play() functions in the scene.
+
+    time : float
+        Time elapsed since initialisation of scene.
     """
 
     def __init__(
@@ -139,7 +144,6 @@ class CairoRenderer:
         ignore_skipping
 
         **kwargs
-
         """
         if self.skip_animations and not ignore_skipping:
             return
@@ -161,20 +165,18 @@ class CairoRenderer:
         self.add_frame(self.get_frame())
 
     def get_frame(self) -> PixelArray:
-        """
-        Gets the current frame as NumPy array.
+        """Gets the current frame as NumPy array.
 
         Returns
         -------
         np.array
             NumPy array of pixel values of each pixel in screen.
-            The shape of the array is height x width x 3
+            The shape of the array is height x width x 3.
         """
         return np.array(self.camera.pixel_array)
 
     def add_frame(self, frame: np.ndarray, num_frames: int = 1):
-        """
-        Adds a frame to the video_file_stream
+        """Adds a frame to the video_file_stream
 
         Parameters
         ----------
@@ -204,10 +206,7 @@ class CairoRenderer:
         )
 
     def show_frame(self):
-        """
-        Opens the current frame in the Default Image Viewer
-        of your system.
-        """
+        """Opens the current frame in the Default Image Viewer of your system."""
         self.update_frame(ignore_skipping=True)
         self.camera.get_image().show()
 
@@ -224,7 +223,7 @@ class CairoRenderer:
         scene
             The scene played.
         static_mobjects
-            Static mobjects of the scene. If None, self.static_image is set to None
+            Static mobjects of the scene. If None, self.static_image is set to None.
 
         Returns
         -------
@@ -277,4 +276,4 @@ class CairoRenderer:
         if config["save_last_frame"]:
             self.static_image = None
             self.update_frame(scene)
-            self.file_writer.save_final_image(self.camera.get_image())
+            self.file_writer.save_image(self.camera.get_image())

--- a/manim/renderer/opengl_renderer.py
+++ b/manim/renderer/opengl_renderer.py
@@ -401,8 +401,7 @@ class OpenGLRenderer:
         return self.path_to_texture_id[repr(path)]
 
     def update_skipping_status(self) -> None:
-        """
-        This method is used internally to check if the current
+        """This method is used internally to check if the current
         animation needs to be skipped or not. It also checks if
         the number of animations that were played correspond to
         the number of animations that need to be played, and
@@ -504,7 +503,7 @@ class OpenGLRenderer:
         if self.should_save_last_frame():
             config.save_last_frame = True
             self.update_frame(scene)
-            self.file_writer.save_final_image(self.get_image())
+            self.file_writer.save_image(self.get_image())
 
     def should_save_last_frame(self):
         if config["save_last_frame"]:

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -483,7 +483,7 @@ class SceneFileWriter:
             )
 
     def output_image(
-        self, image: Image.Image, target_dir: StrPath, ext: str, zero_pad: bool
+        self, image: Image.Image, target_dir: StrPath, ext: str, zero_pad: int
     ) -> None:
         if zero_pad:
             image.save(f"{target_dir}{str(self.frame_count).zfill(zero_pad)}{ext}")
@@ -491,9 +491,8 @@ class SceneFileWriter:
             image.save(f"{target_dir}{self.frame_count}{ext}")
         self.frame_count += 1
 
-    def save_final_image(self, image: Image.Image) -> None:
-        """The name is a misnomer. This method saves the image
-        passed to it as an in the default image directory.
+    def save_image(self, image: PixelArray) -> None:
+        """This method saves the image passed to it in the default image directory.
 
         Parameters
         ----------


### PR DESCRIPTION
* Rename `SceneFileWriter.save_final_image()` to `save_image()` and fix docstring

* fix two type annotations in `scene_file_writer.py`

* make docstrings consistent

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
`save_final_image()` was incorrectly named. It is simply saving an image at any point during the scene. It is used in `cairo_renderer.py` and `opengl_renderer.py` to save the last frame if `save_last_frame` is set in the configuration. 

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
