### PR TITLE
Exclude check for cyclic imports by CodeQL

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -10,7 +10,9 @@ query-filters:
     - exclude:
           id: py/missing-call-to-init
     - exclude:
-        id: py/method-first-arg-is-not-self
+          id: py/method-first-arg-is-not-self
+    - exclude:
+          id: py/cyclic-import
 paths:
     - manim
 paths-ignore:

--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -13,6 +13,8 @@ query-filters:
           id: py/method-first-arg-is-not-self
     - exclude:
           id: py/cyclic-import
+    - exclude:
+          id: py/unsafe-cyclic-import
 paths:
     - manim
 paths-ignore:


### PR DESCRIPTION
See title: the cyclic import checks done by CodeQL apparently do not respect whether imports happen within a block guarded by `TYPE_CHECKING`, leading to many false positives.