### PR TITLE
Allow passing a tuple to `buff` in `SurroundingRectangle` to specify buffer in x and y direction independently

### DIFF
--- a/manim/mobject/geometry/shape_matchers.py
+++ b/manim/mobject/geometry/shape_matchers.py
@@ -53,7 +53,7 @@ class SurroundingRectangle(RoundedRectangle):
         self,
         *mobjects: Mobject,
         color: ParsableManimColor = YELLOW,
-        buff: float = SMALL_BUFF,
+        buff: float | tuple[float, float] = SMALL_BUFF,
         corner_radius: float = 0.0,
         **kwargs: Any,
     ) -> None:
@@ -64,11 +64,17 @@ class SurroundingRectangle(RoundedRectangle):
                 "Expected all inputs for parameter mobjects to be a Mobjects"
             )
 
+        if isinstance(buff, tuple):
+            buff_x = buff[0]
+            buff_y = buff[1]
+        else:
+            buff_x = buff_y = buff
+
         group = Group(*mobjects)
         super().__init__(
             color=color,
-            width=group.width + 2 * buff,
-            height=group.height + 2 * buff,
+            width=group.width + 2 * buff_x,
+            height=group.height + 2 * buff_y,
             corner_radius=corner_radius,
             **kwargs,
         )
@@ -108,7 +114,7 @@ class BackgroundRectangle(SurroundingRectangle):
         stroke_width: float = 0,
         stroke_opacity: float = 0,
         fill_opacity: float = 0.75,
-        buff: float = 0,
+        buff: float | tuple[float, float] = 0,
         **kwargs: Any,
     ) -> None:
         if color is None:

--- a/tests/module/mobject/geometry/test_unit_geometry.py
+++ b/tests/module/mobject/geometry/test_unit_geometry.py
@@ -116,6 +116,17 @@ def test_SurroundingRectangle():
     assert sr.get_fill_opacity() == 0.42
 
 
+def test_SurroundingRectangle_buff():
+    sq = Square()
+    rect1 = SurroundingRectangle(sq, buff=1)
+    assert rect1.width == sq.width + 2
+    assert rect1.height == sq.height + 2
+
+    rect2 = SurroundingRectangle(sq, buff=(1, 2))
+    assert rect2.width == sq.width + 2
+    assert rect2.height == sq.height + 4
+
+
 def test_BackgroundRectangle(manim_caplog):
     circle = Circle()
     square = Square()


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
Now you can give `SurroundingRectangle` a `tuple[float, float]` for its `buff` parameter to have different buffers in the x and y directions.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
