### PR TITLE
Add type annotations to `moving_camera.py`

### DIFF
--- a/manim/camera/moving_camera.py
+++ b/manim/camera/moving_camera.py
@@ -209,11 +209,6 @@ class MovingCamera(Camera):
             scene_critical_y_down,
         ) = self._get_bounding_box(mobjects, only_mobjects_in_frame)
 
-        if scene_critical_x_left is None:
-            raise Exception(
-                "Could not determine bounding box of the mobjects given to 'auto_zoom'."
-            )
-
         # calculate center x and y
         x = (scene_critical_x_left + scene_critical_x_right) / 2
         y = (scene_critical_y_up + scene_critical_y_down) / 2
@@ -265,6 +260,11 @@ class MovingCamera(Camera):
 
                 if m.get_critical_point(DOWN)[1] < scene_critical_y_down:
                     scene_critical_y_down = m.get_critical_point(DOWN)[1]
+
+        if not bounding_box_located:
+            raise Exception(
+                "Could not determine bounding box of the mobjects given to 'auto_zoom'."
+            )
 
         return (
             scene_critical_x_left,

--- a/manim/camera/moving_camera.py
+++ b/manim/camera/moving_camera.py
@@ -69,28 +69,6 @@ class MovingCamera(Camera):
         """
         return self.frame.height
 
-    @property
-    def frame_width(self) -> float:
-        """Returns the width of the frame
-
-        Returns
-        -------
-        float
-            The width of the frame.
-        """
-        return self.frame.width
-
-    @property
-    def frame_center(self) -> Point3D:
-        """Returns the centerpoint of the frame in cartesian coordinates.
-
-        Returns
-        -------
-        np.array
-            The cartesian coordinates of the center of the frame.
-        """
-        return self.frame.get_center()
-
     @frame_height.setter
     def frame_height(self, frame_height: float) -> None:
         """Sets the height of the frame in MUnits.
@@ -102,6 +80,17 @@ class MovingCamera(Camera):
         """
         self.frame.stretch_to_fit_height(frame_height)
 
+    @property
+    def frame_width(self) -> float:
+        """Returns the width of the frame
+
+        Returns
+        -------
+        float
+            The width of the frame.
+        """
+        return self.frame.width
+
     @frame_width.setter
     def frame_width(self, frame_width: float) -> None:
         """Sets the width of the frame in MUnits.
@@ -112,6 +101,17 @@ class MovingCamera(Camera):
             The new frame_width.
         """
         self.frame.stretch_to_fit_width(frame_width)
+
+    @property
+    def frame_center(self) -> Point3D:
+        """Returns the centerpoint of the frame in cartesian coordinates.
+
+        Returns
+        -------
+        np.array
+            The cartesian coordinates of the center of the frame.
+        """
+        return self.frame.get_center()
 
     @frame_center.setter
     def frame_center(self, frame_center: Point3DLike | Mobject) -> None:

--- a/manim/camera/moving_camera.py
+++ b/manim/camera/moving_camera.py
@@ -232,10 +232,11 @@ class MovingCamera(Camera):
     def _get_bounding_box(
         self, mobjects: Iterable[Mobject], only_mobjects_in_frame: bool
     ) -> tuple[float, float, float, float]:
-        scene_critical_x_left: float | None = None
-        scene_critical_x_right: float | None = None
-        scene_critical_y_up: float | None = None
-        scene_critical_y_down: float | None = None
+        bounding_box_located = False
+        scene_critical_x_left: float = 0
+        scene_critical_x_right: float = 1
+        scene_critical_y_up: float = 1
+        scene_critical_y_down: float = 0
 
         for m in mobjects:
             if (m == self.frame) or (
@@ -245,11 +246,12 @@ class MovingCamera(Camera):
                 continue
 
             # initialize scene critical points with first mobjects critical points
-            if scene_critical_x_left is None:
+            if not bounding_box_located:
                 scene_critical_x_left = m.get_critical_point(LEFT)[0]
                 scene_critical_x_right = m.get_critical_point(RIGHT)[0]
                 scene_critical_y_up = m.get_critical_point(UP)[1]
                 scene_critical_y_down = m.get_critical_point(DOWN)[1]
+                bounding_box_located = True
 
             else:
                 if m.get_critical_point(LEFT)[0] < scene_critical_x_left:

--- a/mypy.ini
+++ b/mypy.ini
@@ -75,9 +75,6 @@ ignore_errors = True
 [mypy-manim.camera.mapping_camera]
 ignore_errors = True
 
-[mypy-manim.camera.moving_camera]
-ignore_errors = True
-
 [mypy-manim.mobject.graphing.coordinate_systems]
 ignore_errors = True
 


### PR DESCRIPTION
## Overview: What does this pull request change?
This PR adds type annotations to `moving_camera.py`.

The process of adding type annotations have led to the following changes in the code: 

- moved setters closer to the associated properties (for `frame_height`, `frame_width` and `frame_center`)
- extracted the method `_get_bounding_box`

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
