### PR TITLE
Fix AttributeError: NumberLine object has no attribute 'default_numbers_to_display'

### DIFF
--- a/manim/mobject/graphing/number_line.py
+++ b/manim/mobject/graphing/number_line.py
@@ -503,6 +503,23 @@ class NumberLine(Line):
             num_mob.shift(num_mob[0].width * LEFT / 2)
         return num_mob
 
+    def default_numbers_to_display(self) -> np.ndarray:
+        """Returns the default numbers to display on the number line.
+        
+        This method returns the tick range excluding numbers that are in
+        the numbers_to_exclude list.
+        
+        Returns
+        -------
+        np.ndarray
+            Array of numbers that should be displayed by default.
+        """
+        tick_range = self.get_tick_range()
+        if self.numbers_to_exclude:
+            # Filter out excluded numbers
+            return np.array([x for x in tick_range if x not in self.numbers_to_exclude])
+        return tick_range
+
     def get_number_mobjects(self, *numbers: float, **kwargs: Any) -> VGroup:
         if len(numbers) == 0:
             numbers = self.default_numbers_to_display()


### PR DESCRIPTION
## Description

This PR fixes issue #4244 where calling get_number_mobjects() on a NumberLine object would raise an AttributeError because the default_numbers_to_display() method was missing.

## Changes Made

- Added the missing default_numbers_to_display() method to the NumberLine class
- The method returns the tick range excluding numbers in the numbers_to_exclude list
- Added proper documentation for the new method

## Testing

- Verified that the method exists and is properly called from get_number_mobjects()
- Tested the method logic with and without exclusions
- The original failing code from the issue should now work correctly

## Fixes

Closes #4244