### PR TITLE
Maintain groups when importing svg files

### DIFF
--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -292,8 +292,7 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
             vgroups[group_name] = vg
 
             if isinstance(element, (se.Group, se.Use)):
-                for subelement in element[::-1]:
-                    stack.append((subelement, depth + 1))
+                stack.extend((subelement, depth + 1) for subelement in element[::-1])
             # Add element to the parent vgroup
             try:
                 if isinstance(


### PR DESCRIPTION
## Overview: What does this pull request change?
This is a work in progress for being able to access groups in objects created from SVG files.
I hope that this could be useful for addressing the following issues and pull requests: 

- https://github.com/ManimCommunity/manim/issues/3941
  - This issue should be fixed by the suggested PR directly
- https://github.com/ManimCommunity/manim/pull/4457
  - This PR can be improved by the suggested PR
- https://github.com/ManimCommunity/manim/issues/3548
  -  This issue can be solved by building on top of the suggested PR
- https://github.com/ManimCommunity/manim/issues/2970
  - This issue was solved by an earlier version of the suggested PR.
- https://github.com/ManimCommunity/manim/issues/2884
  - I think that this issue can be handled better based on the suggested PR

<!--changelog-start-->
When reading data from a SVG file, maintain the groupings of the document, which also allows the user to select (groups of) elements by their id.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->


The following example demonstrates how custom grouping of elements inside a latex equation can be achieved. This is based on an idea presented by @behackl in the discord dev-chat the 18th of august 2025.

```
from manim import *

class SvgTest3(Scene):
    def construct(self):
        t = MathTex(r'\frac{a}{b \special{dvisvgm:raw <g id="unique02">}\cdot c \special{dvisvgm:raw </g>}}')
        t.set_color(WHITE)
        t.id_to_vgroup_dict['unique02'].set_color(RED)
        self.add(t)
```

renders like

<img width="1920" height="1080" alt="SvgTest3_ManimCE_v0 19 0" src="https://github.com/user-attachments/assets/86b3be85-0a11-497c-a1ea-5abd3cb19777" />


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
