### PR TITLE
Remove deprecation warning from pytest "np.trapz" -> "np.trapezoid"

### DIFF
--- a/manim/utils/space_ops.py
+++ b/manim/utils/space_ops.py
@@ -658,7 +658,7 @@ def shoelace(x_y: Point2D_Array) -> float:
     """
     x = x_y[:, 0]
     y = x_y[:, 1]
-    val: float = np.trapz(y, x)
+    val: float = np.trapezoid(y, x)
     return val
 
 


### PR DESCRIPTION


## Overview: What does this pull request change?

The PR changes the use of deprecated function np.trapz to the replacement np.trapezoid.

## Motivation and Explanation: Why and how do your changes improve the library?

When running the pytest testsuite, the following warning was included in the summary.

```
tests/module/utils/test_space_ops.py::test_shoelace
  /home/hemi/localbuild/manim/manim/utils/space_ops.py:661: DeprecationWarning: `trapz` is deprecated. Use `trapezoid` instead, or one of the numerical integration functions in `scipy.integrate`.
    val: float = np.trapz(y, x)
```


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
