### PR TITLE
Fix argument passed to `get_hash_from_play_call` in hashing

### DIFF
--- a/manim/utils/caching.py
+++ b/manim/utils/caching.py
@@ -48,9 +48,8 @@ def handle_caching_play(func: Callable[..., None]) -> Callable[..., None]:
             return
         if not config["disable_caching"]:
             mobjects_on_scene = scene.mobjects
-            # TODO: the first argument seems wrong. Shouldn't it be scene instead?
             hash_play = get_hash_from_play_call(
-                self,  # type: ignore[arg-type]
+                scene,
                 self.camera,
                 animations,
                 mobjects_on_scene,


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
 Fixed type error in `caching.py`: pass `scene` instead of `self` to `get_hash_from_play_call()`
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
The `get_hash_from_play_call()` function expects a `Scene` object as its first argument, but `self` (an `OpenGLRenderer`) was being passed instead. This was flagged with a TODO comment and a `# type: ignore`.

This PR passes `scene` instead of `self` and removes both the TODO and the type ignore.
  
  
## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
