### PR TITLE
Add `.github/release.yml` for improved classifications in automatically generated changelogs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,4 @@
-# Changelog categorization for GitHub auto-generated release notes
-# Uses existing repo labels only - no new labels needed
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
 
 changelog:
   exclude:


### PR DESCRIPTION
See title. Documentation of the automated changelog generation can be found here: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes