### PR TITLE
Install missing dependencies in release pipeline

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Install dependencies
+      run: apt-get update && apt-get install -y build-essential python3-dev libcairo2-dev libpango1.0-dev
+
     - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:


### PR DESCRIPTION
See title. This fixes the automated code distribution triggered when a new release is published.

(Very confident that the pipeline will work, given that the release-publish-documentation pipeline has a comparable setup and [did run correctly for v0.19.2](https://github.com/ManimCommunity/manim/actions/runs/21091429185))