### PR TITLE
Add a `seed` config option + `--seed` CLI option for reproducible randomness in rendered scenes

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -299,6 +299,7 @@ class ManimConfig(MutableMapping):
         "save_last_frame",
         "save_pngs",
         "scene_names",
+        "seed",
         "show_in_file_browser",
         "tex_dir",
         "tex_template",
@@ -606,6 +607,7 @@ class ManimConfig(MutableMapping):
             # the next two must be set BEFORE digesting frame_width and frame_height
             "pixel_height",
             "pixel_width",
+            "seed",
             "window_monitor",
             "zero_pad",
         ]:
@@ -772,6 +774,7 @@ class ManimConfig(MutableMapping):
             "dry_run",
             "no_latex_cleanup",
             "preview_command",
+            "seed",
         ]:
             if hasattr(args, key):
                 attr = getattr(args, key)
@@ -1802,6 +1805,17 @@ class ManimConfig(MutableMapping):
     @plugins.setter
     def plugins(self, value: list[str]):
         self._d["plugins"] = value
+
+    @property
+    def seed(self) -> int | None:
+        """Random seed for reproducibility. None means no seed is set."""
+        return self._d["seed"]
+
+    @seed.setter
+    def seed(self, value: int | None) -> None:
+        if value is None:
+            return
+        self._set_pos_number("seed", value, False)
 
 
 # TODO: to be used in the future - see PR #620

--- a/manim/cli/render/commands.py
+++ b/manim/cli/render/commands.py
@@ -103,7 +103,7 @@ def render(**kwargs: Any) -> ClickArgs | dict[str, Any]:
             while keep_running:
                 for SceneClass in scene_classes_from_file(file):
                     with tempconfig({}):
-                        scene = SceneClass(renderer, random_seed=config.seed)
+                        scene = SceneClass(renderer)
                         rerun = scene.render()
                     if rerun or config["write_all"]:
                         renderer.num_plays = 0

--- a/manim/cli/render/commands.py
+++ b/manim/cli/render/commands.py
@@ -103,7 +103,7 @@ def render(**kwargs: Any) -> ClickArgs | dict[str, Any]:
             while keep_running:
                 for SceneClass in scene_classes_from_file(file):
                     with tempconfig({}):
-                        scene = SceneClass(renderer)
+                        scene = SceneClass(renderer, random_seed=config.seed)
                         rerun = scene.render()
                     if rerun or config["write_all"]:
                         renderer.num_plays = 0

--- a/manim/cli/render/global_options.py
+++ b/manim/cli/render/global_options.py
@@ -144,4 +144,10 @@ global_options = option_group(
         help="The command used to preview the output file (for example vlc for video files)",
         default=None,
     ),
+    option(
+        "--seed",
+        type=int,
+        help="Set the random seed to allow reproducibility.",
+        default=None,
+    ),
 )

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -177,7 +177,7 @@ class Scene:
     ) -> None:
         self.camera_class = camera_class
         self.always_update_mobjects = always_update_mobjects
-        self.random_seed = random_seed
+        self.random_seed = random_seed if random_seed is not None else config.seed
         self.skip_animations = skip_animations
 
         self.animations: list[Animation] | None = None

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -1163,11 +1163,13 @@ class Scene:
             and threading.current_thread().name != "MainThread"
         ):
             # TODO: are these actually being used?
-            kwargs.update({
-                "subcaption": subcaption,
-                "subcaption_duration": subcaption_duration,
-                "subcaption_offset": subcaption_offset,
-            })
+            kwargs.update(
+                {
+                    "subcaption": subcaption,
+                    "subcaption_duration": subcaption_duration,
+                    "subcaption_offset": subcaption_offset,
+                }
+            )
             self.queue.put(SceneInteractRerun("play", **kwargs))
             return
 

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -219,9 +219,9 @@ class Scene:
         self.mobjects: list[Mobject] = []
         # TODO, remove need for foreground mobjects
         self.foreground_mobjects: list[Mobject] = []
-        if self.random_seed is not None:
-            random.seed(self.random_seed)
-            np.random.default_rng(self.random_seed)
+
+        random.seed(self.random_seed)
+        np.random.seed(self.random_seed)  # noqa: NPY002 (only way to set seed globally)
 
     @property
     def camera(self) -> Camera | OpenGLCamera:
@@ -1163,13 +1163,11 @@ class Scene:
             and threading.current_thread().name != "MainThread"
         ):
             # TODO: are these actually being used?
-            kwargs.update(
-                {
-                    "subcaption": subcaption,
-                    "subcaption_duration": subcaption_duration,
-                    "subcaption_offset": subcaption_offset,
-                }
-            )
+            kwargs.update({
+                "subcaption": subcaption,
+                "subcaption_duration": subcaption_duration,
+                "subcaption_offset": subcaption_offset,
+            })
             self.queue.put(SceneInteractRerun("play", **kwargs))
             return
 

--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -1558,10 +1558,9 @@ class RandomColorGenerator:
         seed: int | None = None,
         sample_colors: list[ManimColor] | None = None,
     ) -> None:
-        self.choice = random.choice if seed is None else random.Random(seed).choice
-
         from manim.utils.color.manim_colors import _all_manim_colors
 
+        self.choice = random.choice if seed is None else random.Random(seed).choice
         self.colors = _all_manim_colors if sample_colors is None else sample_colors
 
     def next(self) -> ManimColor:

--- a/manim/utils/commands.py
+++ b/manim/utils/commands.py
@@ -18,7 +18,9 @@ __all__ = [
 
 
 def capture(
-    command: str, cwd: StrOrBytesPath | None = None, command_input: str | None = None
+    command: str | list[str],
+    cwd: StrOrBytesPath | None = None,
+    command_input: str | None = None,
 ) -> tuple[str, str, int]:
     p = run(
         command,

--- a/tests/module/scene/test_scene.py
+++ b/tests/module/scene/test_scene.py
@@ -4,7 +4,7 @@ import datetime
 
 import pytest
 
-from manim import Circle, FadeIn, Group, Mobject, Scene, Square
+from manim import Circle, Dot, FadeIn, Group, Mobject, Scene, Square
 from manim.animation.animation import Wait
 
 
@@ -101,3 +101,24 @@ def test_replace(dry_run):
     scene.replace(second, beta)
     assert_names(scene.mobjects, ["alpha", "group", "fourth"])
     assert_names(scene.mobjects[1], ["beta", "third"])
+
+
+def test_reproducible_scene(dry_run):
+    import numpy as np
+
+    scene = Scene(random_seed=42)
+    dots1 = []
+    for _ in range(10):
+        dot = Dot(np.random.uniform(-3, 3, size=3))  # noqa: NPY002
+        dots1.append(dot)
+    scene.add(*dots1)
+
+    scene2 = Scene(random_seed=42)
+    dots2 = []
+    for _ in range(5):
+        dot = Dot(np.random.uniform(-3, 3, size=3))  # noqa: NPY002
+        dots2.append(dot)
+    scene2.add(*dots2)
+
+    for d1, d2 in zip(dots1, dots2, strict=False):
+        np.testing.assert_allclose(d1.get_center(), d2.get_center())

--- a/tests/module/scene/test_scene.py
+++ b/tests/module/scene/test_scene.py
@@ -122,3 +122,27 @@ def test_reproducible_scene(dry_run):
 
     for d1, d2 in zip(dots1, dots2, strict=False):
         np.testing.assert_allclose(d1.get_center(), d2.get_center())
+
+
+def test_random_color_reproducibility_with_seed(dry_run):
+    from manim import config, random_color, tempconfig
+
+    with tempconfig({"seed": 123}):
+        # First run: create scene (which seeds global random state) and generate colors
+        scene1 = Scene()
+        colors_first_run = [random_color() for _ in range(5)]
+
+        # Interrupt with a scene that has an explicit different seed
+        scene_explicit = Scene(random_seed=999)
+        colors_interrupted = [random_color() for _ in range(3)]
+
+        # Second run: create a new scene without explicit seed (should use config.seed)
+        scene2 = Scene()
+        colors_second_run = [random_color() for _ in range(5)]
+
+        # The colors from the first and second run should match
+        # because both scenes were seeded with config.seed=123
+        assert colors_first_run == colors_second_run
+
+        # The interrupted colors should be different (seeded with 999)
+        assert colors_interrupted != colors_first_run[:3]

--- a/tests/module/scene/test_scene.py
+++ b/tests/module/scene/test_scene.py
@@ -125,7 +125,7 @@ def test_reproducible_scene(dry_run):
 
 
 def test_random_color_reproducibility_with_seed(dry_run):
-    from manim import config, random_color, tempconfig
+    from manim import random_color, tempconfig
 
     with tempconfig({"seed": 123}):
         # First run: create scene (which seeds global random state) and generate colors

--- a/tests/test_scene_rendering/simple_scenes.py
+++ b/tests/test_scene_rendering/simple_scenes.py
@@ -165,3 +165,15 @@ class ElaborateSceneWithSections(Scene):
         self.next_section("fade out")
         self.play(FadeOut(square))
         self.wait()
+
+
+class SceneWithRandomness(Scene):
+    def construct(self):
+        dots = VGroup()
+        for _ in range(10):
+            dot = Dot(
+                point=np.random.uniform(-3, 3, size=3),  # noqa: NPY002
+            )
+            dots.add(dot)
+        self.add(dots)
+        self.wait()


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

For example:

```python
class SceneWithRandomness(Scene):
    def construct(self):
        dots = VGroup()
        for _ in range(10):
            dot = Dot(point=np.random.uniform(-3, 3, size=3))
            dots.add(dot)
        self.add(dots)
        self.wait()

class SecondSceneWithRandomness(Scene):
    def construct(self):
        dots = VGroup()
        for _ in range(15:
            dot = Dot(point=np.random.uniform(-3, 3, size=3))
            dots.add(dot)
        self.add(dots)
        self.wait()
```
Before this PR, the points were never in the same position at each run. A `seed` option is added to get exactly the same result every time, e.g. with `manim -pql --seed 42 main.py *`.

It also works with multiple scenes. For example here, the 5 points of the second scene will be the same as the first 5 points of the first scene.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
https://manimce--4532.org.readthedocs.build/en/4532/guides/configuration.html

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

There is some drawbacks:
- Will break if something else than `random` or `numpy.random` is used for randomness (e.g. `secrets` or `torch.random`).
- To avoid any change for the user, it simply modifies the global random state at each scene initialization. A pseudo-code is:

    ```python
	set_seed(config.seed)
	scene = Scene1()
	scene.render()
  set_seed(config.seed)
	scene2 = Scene2()
	scene2.render()
	```
  So if scenes are created in a different order, or if anything that uses random numbers is created between the the init and the render, results will be different.

The only way for the user to avoid any drawback is to get a local random state for each scene

```python
rng = np.random.default_rng(config.seed)
class SceneWithRandomness(Scene):
	def construct(self):
		dots = VGroup()
		for _ in range(10):
			dot = Dot(point=rng.uniform(-3, 3, size=3))
			dots.add(dot)
		self.add(dots)
		self.wait()
```

or same with `rng = random.Random(config.seed)` for the `random` module.

In this case, the only thing that this PR brings is the `seed` config option, nothing else.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
