### PR TITLE
[Experimenta] Fix failing test where the same mobject was included in a scene twice.

### DIFF
--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -230,7 +230,11 @@ class Scene:
             index = self.mobjects.index(mobject)
             self.mobjects = [
                 *self.mobjects[:index],
-                *replacements,
+                *[
+                    replacement
+                    for replacement in replacements
+                    if replacement not in self.mobjects
+                ],
                 *self.mobjects[index + 1 :],
             ]
         return self


### PR DESCRIPTION
Prior to this PR, the test `tests/module/animation/test_transform.py::test_no_duplicate_references` failed with the message:

```
   def test_no_duplicate_references():
        manager = Manager(Scene)
        scene = manager.scene
        c = Circle()
        sq = Square()
        scene.add(c, sq)
        scene.play(ReplacementTransform(c, sq))
>       assert len(scene.mobjects) == 1
E       assert 2 == 1
E        +  where 2 = len([Square, Square])
E        +    where [Square, Square] = <manim.scene.scene.Scene object at 0x7012d76be270>.mobjects
```

The replace function in scene.py that executes the actions from the SceneBuffer, specifies that the replacements must not be in the scene, but that is not respected by the Transform::finish in transform.py that adds the replace actions.

Apparently the error was caused by the parameter `replacements` that did not meet the requirements stated in `scene.py:226`
```
        replacements
            One or more Mobjects which must not already be in the scene.
```

If the replace command is traced back, we find this path

```
transform.py:211  Transform::finish()
scene_buffer.py:62  SceneBuffer::replace()
scene.py:214  Scene::replace()
```

The suggested solution is to check all replacements if they are already in self.mobjects and only include them if that is not the case.

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
