### PR TITLE
Improve the output generated by --show_diff

### DIFF
--- a/manim/utils/testing/_show_diff.py
+++ b/manim/utils/testing/_show_diff.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 import warnings
 
-import numpy as np
-
 from manim.typing import PixelArray
 from manim.utils.color import BLACK, PURE_GREEN, PURE_RED
 
@@ -34,43 +32,11 @@ def show_diff_helper(
     ax.set_title("Expected")
 
     ax = fig.add_subplot(gs[1, :])
-    FRAME_DATA_SHAPE = frame_data.shape
+    generated_is_expected = (frame_data == expected_frame_data).all(2)
+    expected_is_black = (expected_frame_data == BLACK.to_int_rgba()).all(2)
     diff_im = expected_frame_data.copy()
-    np.putmask(
-        diff_im,
-        frame_data != BLACK.to_int_rgba(),  # When generated differs from pure black
-        PURE_GREEN.to_int_rgba().astype(np.uint8),  # set pixel to green
-    )  # Set any non-black pixels to green
-    np.putmask(
-        diff_im,
-        expected_frame_data != frame_data,
-        PURE_RED.to_int_rgba().astype(np.uint8),
-    )  # Set any different pixels to red
-    # Add the green color channel to all color channels
-    expected_frame_data = expected_frame_data + expected_frame_data[:, :, 1].repeat(
-        4, axis=1
-    ).reshape(FRAME_DATA_SHAPE)
-    frame_data = frame_data + frame_data[:, :, 1].repeat(4, axis=1).reshape(
-        FRAME_DATA_SHAPE
-    )
-    np.putmask(
-        diff_im,
-        expected_frame_data != frame_data,
-        PURE_RED.to_int_rgba().astype(np.uint8),
-    )  # Set any different pixels to red
-    # Add the blue color channel to all color channels
-    expected_frame_data = expected_frame_data + expected_frame_data[:, :, 2].repeat(
-        4, axis=1
-    ).reshape(FRAME_DATA_SHAPE)
-    frame_data = frame_data + frame_data[:, :, 2].repeat(4, axis=1).reshape(
-        FRAME_DATA_SHAPE
-    )
-    np.putmask(
-        diff_im,
-        expected_frame_data != frame_data,
-        PURE_RED.to_int_rgba().astype(np.uint8),
-    )  # Set any different pixels to red
-
+    diff_im[generated_is_expected & ~expected_is_black] = PURE_GREEN.to_int_rgba()
+    diff_im[~generated_is_expected & ~expected_is_black] = PURE_RED.to_int_rgba()
     ax.imshow(diff_im, interpolation="nearest")
     ax.set_title("Difference summary: (green = same, red = different)")
 


### PR DESCRIPTION
Do not only look at the red color channel values when computing the difference summary.

```
uv run pytest --show_diff tests/test_graphical_units/test_img_and_svg.py::test_UseTagInheritance
```

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

Prior state

<img width="1382" height="1028" alt="Screenshot from 2026-01-31 11-58-43" src="https://github.com/user-attachments/assets/dde10afa-828c-4c89-9087-43e756adf457" />

Posterior state 

<img width="1382" height="1028" alt="Screenshot from 2026-01-31 11-59-09" src="https://github.com/user-attachments/assets/1ae9feae-553b-4f6b-b8c4-f09aeddfc931" />


## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
