### PR TITLE
Prevent potential `UnboundLocalError` in `PolarPlane`

### DIFF
--- a/manim/mobject/graphing/coordinate_systems.py
+++ b/manim/mobject/graphing/coordinate_systems.py
@@ -3245,6 +3245,7 @@ class PolarPlane(Axes):
             }
             for i in a_values
         ]
+        a_tex = []
         if self.azimuth_units == "PI radians" or self.azimuth_units == "TAU radians":
             a_tex = [
                 self.get_radian_label(


### PR DESCRIPTION
I noticed a potential 'UnboundLocalError' in 'PolarPlane.get_coordinate_labels'. The variable 'a_tex' is defined within multiple 'if/elif' blocks but lacks a default initialization or an 'else' catch-all. If 'self.azimuth_units' were to contain an unexpected value (e.g. through manual modification after initialization), the subsequent 'VGroup(*a_tex)' call would crash. This change ensures 'a_tex' is always defined.