### PR TITLE
[EXPERIMENTAL] Use `get_bounding_box_point()` instead of `get_critical_point()` in `GrowFromEdge`

### DIFF
--- a/manim/animation/growing.py
+++ b/manim/animation/growing.py
@@ -169,7 +169,7 @@ class GrowFromEdge(GrowFromPoint):
         point_color: ParsableManimColor | None = None,
         **kwargs: Any,
     ):
-        point = mobject.get_critical_point(edge)
+        point = mobject.get_bounding_box_point(edge)
         super().__init__(mobject, point, point_color=point_color, **kwargs)
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

<!--changelog-end-->

This PR makes the test in `tests/test_graphical_units/test_creation.py::test_GrowFromEdge` run.
Earlier it threw the error
```
AttributeError: 'Square' object has no attribute 'get_critical_point'
```

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
