### PR TITLE
[Experimental] Added GraphicalDeviationError exception

### DIFF
--- a/manim/utils/testing/_frames_testers.py
+++ b/manim/utils/testing/_frames_testers.py
@@ -21,8 +21,13 @@ logger = logging.getLogger("manim")
 
 
 class GraphicalDeviationError(Exception):
+    # The __module__ parameter is set to "builtins" to avoid the full
+    # specifier for the exception to be included in the output from pytest.
+    # That is go from
+    # manim.utils.testing._frames_testers.GraphicalDeviationError
+    # to
+    # GraphicalDeviationError
     __module__ = "builtins"
-    pass
 
 
 class _FramesTester:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
To make it easier to track the different types of errors from the pytest test suite, I suggest to add this custom exception that will be shown in the output from pytest for the failed graphical tests.

A sample output from pytest after the change looks like this: 

```
FAILED tests/test_graphical_units/test_threed.py::test_Dot3D - GraphicalDeviationError: 210 pixels differ when comparing with 'Dot3D.npz'
FAILED tests/test_graphical_units/test_threed.py::test_Cone - GraphicalDeviationError: 29521 pixels differ when comparing with 'Cone.npz'
```


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
