### PR TITLE
Fix test_composition/test_animationgroup_calls_finish

### DIFF
--- a/tests/module/animation/test_composition.py
+++ b/tests/module/animation/test_composition.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Self
 from unittest.mock import MagicMock
 
 import pytest
@@ -188,6 +189,9 @@ def test_animationgroup_calls_finish():
 
         def finish(self):
             self.finished = True
+
+        def interpolate_submobject(self, *args) -> Self:
+            return self
 
     manager = Manager(Scene)
     scene = manager.scene


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

Fixes the test_animationgroup_calls_finish.

The test function implements the class MyAnimation which inherits form Animation but was not implementing the function interpolate_submobject, which by default raises a NotImplementedError exception. 

With this PR the test is fixed.


You can run the test with `uv run pytest tests/module/animation/test_composition.py`

## Motivation and Explanation: Why and how do your changes improve the library?
Fixes a test

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
