### PR TITLE
Fix assertion in `ImageMobjectFromCamera.interpolate_color()`

### DIFF
--- a/manim/mobject/types/image_mobject.py
+++ b/manim/mobject/types/image_mobject.py
@@ -353,8 +353,8 @@ class ImageMobjectFromCamera(AbstractImageMobject):
     def interpolate_color(
         self, mobject1: Mobject, mobject2: Mobject, alpha: float
     ) -> None:
-        assert isinstance(mobject1, ImageMobject)
-        assert isinstance(mobject2, ImageMobject)
+        assert isinstance(mobject1, ImageMobjectFromCamera)
+        assert isinstance(mobject2, ImageMobjectFromCamera)
         assert mobject1.pixel_array.shape == mobject2.pixel_array.shape, (
             f"Mobject pixel array shapes incompatible for interpolation.\n"
             f"Mobject 1 ({mobject1}) : {mobject1.pixel_array.shape}\n"


### PR DESCRIPTION
When reviewing PR #4458, I missed an assertion in `ImageMobjectFromCamera.interpolate_color()` causing an error because the types of the Mobjects passed as parameters should have been `ImageMobjectFromCamera`, not `ImageMobject`. This is causing an example scene using `MovingScene` to crash. This PR fixes that.