### PR TITLE
Fix c2p/coords_to_point with single flat list or 1D array input

### DIFF
--- a/manim/mobject/graphing/coordinate_systems.py
+++ b/manim/mobject/graphing/coordinate_systems.py
@@ -2089,6 +2089,10 @@ class Axes(VGroup, CoordinateSystem, metaclass=ConvertToOpenGL):
 
             ``ax.coords_to_point( [[x_0, y_0, z_0], [x_1, y_1, z_1]] )``
 
+            A single coordinate can also be passed as a flat list or 1D array:
+
+            ``ax.coords_to_point( [x, y, z] )``
+
         Returns
         -------
         np.ndarray
@@ -2117,6 +2121,10 @@ class Axes(VGroup, CoordinateSystem, metaclass=ConvertToOpenGL):
             array([[0.  , 0.86, 0.86],
                    [0.75, 0.75, 0.  ],
                    [0.  , 0.  , 0.  ]])
+            >>> np.around(ax.coords_to_point([1, 0, 0]), 2)
+            array([0.86, 0.  , 0.  ])
+            >>> np.around(ax.coords_to_point(np.array([1, 0])), 2)
+            array([0.86, 0.  , 0.  ])
 
         .. manim:: CoordsToPointExample
             :save_last_frame:
@@ -2159,6 +2167,10 @@ class Axes(VGroup, CoordinateSystem, metaclass=ConvertToOpenGL):
             else:
                 coords = coords.T
                 are_coordinates_transposed = True
+        # If coords is in the format ([x, y, z]) -- a single flat list/array passed as one argument:
+        elif coords.ndim == 2 and coords.shape[0] == 1:
+            # Extract the single list so [x, y, z] is treated like c2p(x, y, z).
+            coords = coords[0]
         # Otherwise, coords already looked like (x, y, z) or ([x1 x2 ...], [y1 y2 ...], [z1 z2 ...]),
         # so no further processing is needed.
 


### PR DESCRIPTION
## Summary

Fixes #4073

When a single flat list or 1D numpy array is passed to `Axes.coords_to_point()` / `Axes.c2p()`, the values are incorrectly interpreted as multiple x-coordinates instead of a single point:

```python
ax = Axes()
ax.c2p(1, 2)             # Correct: [0.857, 1.5, 0.0]
ax.c2p([1, 2])           # Before:  [[0.857, 1.714], [0, 0], [0, 0]]  (wrong!)
ax.c2p([1, 2])           # After:   [0.857, 1.5, 0.0]  (same as c2p(1, 2))
ax.c2p(np.array([1, 2])) # After:   [0.857, 1.5, 0.0]  (same as c2p(1, 2))
```

### Root cause

When `c2p([1, 2])` is called, `*coords` captures it as `([1, 2],)`. Then `np.asarray(([1, 2],))` produces shape `(1, 2)` with ndim=2. This falls through to the default code path where `coords[0]` (`[1, 2]`) is treated as a list of x-values rather than as a single `[x, y]` coordinate.

### Fix

Added an `elif` branch that detects this case (`ndim == 2 and shape[0] == 1`) and extracts the inner array so `[x, y, z]` is handled identically to passing `x, y, z` as separate arguments.

### Changes

- **`manim/mobject/graphing/coordinate_systems.py`**: Added 4-line elif branch in `Axes.coords_to_point()` to handle single flat list/array input. Updated docstring and added 2 doctests for the newly-supported format.

### Testing

All existing tests pass:
- `test_coords_to_point` 
- `test_coords_to_point_vectorized`
- `test_axes_origin_shift` (all 4 variants)
- All 3 doctests in `coordinate_systems.py`

Verified the fix handles all cases from the issue:

| Input | Before (broken) | After (fixed) |
|-------|-----------------|---------------|
| `c2p([1, 2])` | `[[0.86, 1.71], [0, 0], [0, 0]]` | `[0.86, 1.5, 0]` |
| `c2p([1, 2, 1])` | `[[0.86, 1.71, 0.86], [0, 0, 0], [0, 0, 0]]` | `[0.86, 1.5, 0]` |
| `c2p(np.array([1, 2]))` | `[[0.86, 1.71], [0, 0], [0, 0]]` | `[0.86, 1.5, 0]` |
| `c2p(np.array([1, 2, 1]))` | `[[0.86, 1.71, 0.86], [0, 0, 0], [0, 0, 0]]` | `[0.86, 1.5, 0]` |
| `c2p(1, 2)` | `[0.86, 1.5, 0]` (unchanged) | `[0.86, 1.5, 0]` |
| `c2p([[1,2],[2,3]])` | `[[0.86, 1.5, 0], [1.71, 2.25, 0]]` (unchanged) | `[[0.86, 1.5, 0], [1.71, 2.25, 0]]` |
| `c2p([1, 2], [3, 4])` | batch format (unchanged) | batch format (unchanged) |

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments!*