### PR TITLE
docs: improve TransformFromCopy docstring

### DIFF
--- a/manim/animation/transform.py
+++ b/manim/animation/transform.py
@@ -304,7 +304,7 @@ class ReplacementTransform(Transform):
 
 
 class TransformFromCopy(Transform):
-    """Performs a reversed Transform"""
+    """Preserves a copy of the original VMobject and transforms only it's copy to the target VMobject"""
 
     def __init__(self, mobject: Mobject, target_mobject: Mobject, **kwargs) -> None:
         super().__init__(target_mobject, mobject, **kwargs)


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
This pull request changes the docstring for the class TransfromFromCopy. 


## Motivation and Explanation: Why and how do your changes improve the library?
The existing docstring for this class states: "Performs a reversed Transform". However, in actuality, it doesn't do anything in reverse. It's just a normal transform, except for that the original VMobject remains as such and only it's copy gets transformed to the target VMobject. 
The original docstring is misleading.

I have changed that docstring to state: "Preserves a copy of the original VMobject and transforms only it's copy to the target VMobject", as this is what it does. 

## Links to added or changed documentation pages
I've changed the animations>transform.py file.






<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
