### PR TITLE
Fix publish release workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -39,6 +39,7 @@ jobs:
           name: manim.tar.gz
 
     - name: Upload Release Asset
+      shell: bash
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |


### PR DESCRIPTION
Our publish workflow has -- yet again -- failed (see https://github.com/ManimCommunity/manim/actions/runs/22245001472/job/64356983357). These changes simplify the action a bit and add the missing write permission.