### PR TITLE
tests: Add unit tests for Paragraph alignment

### DIFF
--- a/tests/module/mobject/text/test_text_mobject.py
+++ b/tests/module/mobject/text/test_text_mobject.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from contextlib import redirect_stdout
 from io import StringIO
 
+from numpy.testing import assert_almost_equal
+
 from manim.constants import LEFT, RIGHT
 from manim.mobject.text.text_mobject import MarkupText, Paragraph, Text
 
@@ -36,28 +38,35 @@ def test_font_warnings():
 
 
 def test_paragraph_alignment():
-    def float_eq(a: float, b: float, delta: float = 1e-2):
-        return abs(a - b) <= delta
-
     # check paragraph left alignment
     par_left = Paragraph("This is", "a left-aligned", "paragraph", alignment="left")
-    assert float_eq(par_left[0][0].get_x(LEFT), par_left[1][0].get_x(LEFT))
-    assert float_eq(par_left[0][0].get_x(LEFT), par_left[2][0].get_x(LEFT))
+    assert_almost_equal(
+        par_left[0][0].get_x(LEFT), par_left[1][0].get_x(LEFT), decimal=2
+    )
+    assert_almost_equal(
+        par_left[0][0].get_x(LEFT), par_left[2][0].get_x(LEFT), decimal=2
+    )
 
     # check paragraph right alignment
     par_right = Paragraph("This is", "a right-aligned", "paragraph", alignment="right")
-    assert float_eq(par_right[0][-1].get_x(RIGHT), par_right[1][-1].get_x(RIGHT))
-    assert float_eq(par_right[0][-1].get_x(RIGHT), par_right[2][-1].get_x(RIGHT))
+    assert_almost_equal(
+        par_right[0][-1].get_x(RIGHT), par_right[1][-1].get_x(RIGHT), decimal=2
+    )
+    assert_almost_equal(
+        par_right[0][-1].get_x(RIGHT), par_right[2][-1].get_x(RIGHT), decimal=2
+    )
 
     # check paragraph center alignment
     par_center = Paragraph(
         "This is", "a center-aligned", "paragraph", alignment="center"
     )
-    assert float_eq(
+    assert_almost_equal(
         (par_center[0][0].get_x(LEFT) + par_center[0][-1].get_x(RIGHT)) / 2,
         (par_center[1][0].get_x(LEFT) + par_center[1][-1].get_x(RIGHT)) / 2,
+        decimal=2,
     )
-    assert float_eq(
+    assert_almost_equal(
         (par_center[0][0].get_x(LEFT) + par_center[0][-1].get_x(RIGHT)) / 2,
         (par_center[2][0].get_x(LEFT) + par_center[2][-1].get_x(RIGHT)) / 2,
+        decimal=2,
     )


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview:
Added unit tests for Paragraph alignment. The changes implement a portion of features proposed in [issue 2839](https://github.com/ManimCommunity/manim/issues/2839), specifically tests for changes introduced in [Fixed bad text slicing for lines in :class:.Paragraph #2721 ](https://github.com/ManimCommunity/manim/pull/2721).



## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->



## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
We test for left alignment by getting the underlying `VMobjectFromSVGPath` for the first character of each line, and comparing them using a custom float comparison funcition.
```python
def test_paragraph_alignment():
    def float_eq(a: float, b: float, delta: float = 1e-2):
        return abs(a - b) <= delta

    # check paragraph left alignment
    par_left = Paragraph("This is", "a left-aligned", "paragraph", alignment="left")
    assert float_eq(par_left[0][0].get_x(LEFT), par_left[1][0].get_x(LEFT))
    assert float_eq(par_left[0][0].get_x(LEFT), par_left[2][0].get_x(LEFT))
```
Similarly when testing for right alignment, we compare the last letter of each line.
```python
    # check paragraph right alignment
    par_right = Paragraph("This is", "a right-aligned", "paragraph", alignment="right")
    assert float_eq(par_right[0][-1].get_x(RIGHT), par_right[1][-1].get_x(RIGHT))
    assert float_eq(par_right[0][-1].get_x(RIGHT), par_right[2][-1].get_x(RIGHT))
```
When testing for center alignment, we compute the average of the left of the first character and the right of the last character in each line. This is supposed to give us an estimate of where the middle of the line is. We then compare them for each line.
```python
    par_center = Paragraph(
        "This is", "a center-aligned", "paragraph", alignment="center"
    )
    assert float_eq(
        (par_center[0][0].get_x(LEFT) + par_center[0][-1].get_x(RIGHT)) / 2,
        (par_center[1][0].get_x(LEFT) + par_center[1][-1].get_x(RIGHT)) / 2,
    )
    assert float_eq(
        (par_center[0][0].get_x(LEFT) + par_center[0][-1].get_x(RIGHT)) / 2,
        (par_center[2][0].get_x(LEFT) + par_center[2][-1].get_x(RIGHT)) / 2,
    )
```


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
