### PR TITLE
[Experimental] Fix image test

### DIFF
--- a/manim/mobject/types/image_mobject.py
+++ b/manim/mobject/types/image_mobject.py
@@ -26,16 +26,12 @@ from ...utils.color import (
 )
 from ...utils.images import change_to_rgba_array, get_full_raster_image_path
 
-__all__ = ["ImageMobject", "ImageMobjectFromCamera"]
-
 if TYPE_CHECKING:
     from typing import Self
 
     import numpy.typing as npt
 
     from manim.typing import PixelArray, StrPath
-
-    from ...camera.moving_camera import MovingCamera
 
 
 class AbstractImageMobject(Mobject):

--- a/manim/mobject/types/image_mobject.py
+++ b/manim/mobject/types/image_mobject.py
@@ -216,6 +216,10 @@ class ImageMobject(AbstractImageMobject):
         """A simple getter method."""
         return self.pixel_array
 
+    def init_colors(self) -> None:
+        """Override base init_colors to avoid overwriting image pixels during init."""
+        return None
+
     def set_color(  # type: ignore[override]
         self,
         color: ParsableManimColor = YELLOW_C,

--- a/tests/module/mobject/test_image.py
+++ b/tests/module/mobject/test_image.py
@@ -7,7 +7,7 @@ from manim import ImageMobject
 @pytest.mark.parametrize("dtype", [np.uint8, np.uint16])
 def test_invert_image(dtype):
     rng = np.random.default_rng()
-    array = (255 * rng.random((10, 10, 4))).astype(dtype)
+    array = (np.iinfo(dtype).max * rng.random((10, 10, 4))).astype(dtype)
     image = ImageMobject(array, pixel_array_dtype=dtype, invert=True)
     assert image.pixel_array.dtype == dtype
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

Fixes `test_invert_image` in `tests/module/mobject/test_image.py` by overriding `ImageMobject.init_colors()`.
Progress towards completing #4592.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

The base `OpenGLMobject.__init__` calls `init_colors()` which in turn calls `set_color()`.  Because `init_colors()` runs after `ImageMobject` inverts the image, the inverted values in the pixel array are overwritten.

Furthermore, the test now select from the full range of values for 16 bit colors.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
