### PR TITLE
Fix OpenGL crashes in `arrange_in_grid()` and `get_location()`

### DIFF
--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -1222,7 +1222,7 @@ class OpenGLMobject:
         ) -> Sequence[Vector3D]:
             if str_alignments is None:
                 # Use cell_alignment as fallback
-                return [cast(Vector3D, cell_alignment * direction)] * num
+                return [cast("Vector3D", cell_alignment * direction)] * num
             if len(str_alignments) != num:
                 raise ValueError(f"{name}_alignments has a mismatching size.")
             return [mapping[letter] for letter in str_alignments]
@@ -3037,7 +3037,7 @@ class OpenGLPoint(OpenGLMobject):
         return self.artificial_height
 
     def get_location(self) -> Point3D:
-        return cast(Point3D, self.points[0]).copy()
+        return cast("Point3D", self.points[0]).copy()
 
     @override
     def get_bounding_box_point(self, *args: object, **kwargs: Any) -> Point3D:


### PR DESCRIPTION
Fixes #4550 

Added quotes to Vector3D and to Point3D to match other calls to `cast`, such has Chopan suggested

## Overview: What does this pull request change?

Add quotes to types in `cast("Vector3D", ...)` to solve the "NameError: name 'Vector3D' is not defined" issue.
A similar issue could have happened without quoting `cast("Point3D", ...)`.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

Quoting these types allows to prevent always importing `Vector3D` and `Point3D`.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->

These modifications don't require any changes in the documentation.

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

This is my first PR for manim, and thank you to Chopan for the help! :)

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
