### PR TITLE
Fix incorrect terminology in quickstart docs

### DIFF
--- a/docs/source/tutorials/quickstart.rst
+++ b/docs/source/tutorials/quickstart.rst
@@ -195,7 +195,7 @@ Positioning ``Mobject``\s
 
 Next, let's go over some basic techniques for positioning ``Mobject``\s.
 
-1. Open ``scene.py``, and add the following code snippet below the ``SquareToCircle`` method:
+1. Open ``scene.py``, and add the following code snippet below the ``SquareToCircle`` class:
 
 .. code-block:: python
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

In the "Positioning Mobjects" section, "SquareToCircle method" was used,
but SquareToCircle is a class, not a method. Changed to "SquareToCircle class"
for accuracy and consistency with earlier sections.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
