### PR TITLE
Fix multi-line strings in Tex and MathTex

### DIFF
--- a/manim/mobject/text/tex_mobject.py
+++ b/manim/mobject/text/tex_mobject.py
@@ -338,12 +338,16 @@ class MathTex(SingleStringMathTex):
         tex_strings_validated = [
             string if isinstance(string, str) else str(string) for string in tex_strings
         ]
+        # Remove Python line breaks when strings are spread over multiple lines
+        tex_strings_validated_one = [
+            tex.replace("\n", " ") for tex in tex_strings_validated
+        ]
         # Locate double curly bracers and split on them.
         tex_strings_validated_two = []
-        for tex_string in tex_strings_validated:
+        for tex_string in tex_strings_validated_one:
             split = self._split_double_braces(tex_string)
             tex_strings_validated_two.extend(split)
-        if len(tex_strings_validated_two) > len(tex_strings_validated):
+        if len(tex_strings_validated_two) > len(tex_strings_validated_one):
             self.brace_notation_split_occurred = True
         return [string for string in tex_strings_validated_two if len(string) > 0]
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Fixes Issue #4617.  Prior to PR #4515 newlines within a Python string would be stripped by Latex.  Since the PR processes the string prior to sending it to Latex, the Python string needs to be stripped of new lines prior to processing (this does not affect Latex new lines, only Python new lines).

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
To allow for multi-line strings when using `Tex` and `MathTex` for code readability.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
N/A

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
I implemented this by replacing Python new lines with spaces, should I have used `self.arg_separator` instead of a space?  I assumed that users would expect a Python new line to result in a space in the final Latex written to the screen.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
