### PR TITLE
Fix Line.add_tip() distorting polyline paths

### DIFF
--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -26,6 +26,7 @@ from manim.mobject.mobject import Mobject
 from manim.mobject.opengl.opengl_compatibility import ConvertToOpenGL
 from manim.mobject.opengl.opengl_mobject import OpenGLMobject
 from manim.mobject.types.vectorized_mobject import DashedVMobject, VGroup, VMobject
+from manim.utils.bezier import partial_bezier_points
 from manim.utils.color import WHITE
 from manim.utils.space_ops import angle_of_vector, line_intersection, normalize
 
@@ -233,6 +234,49 @@ class Line(TipableVMobject):
             self.end = np.asarray(end)
             self.generate_points()
         return super().put_start_and_end_on(start, end)
+
+    def _trim_path_with_tip_base(
+        self,
+        point: Point3DLike,
+        at_start: bool,
+    ) -> bool:
+        if self.path_arc != 0 or self.get_num_curves() <= 1:
+            return False
+
+        curve_index = 0 if at_start else self.get_num_curves() - 1
+        if curve_index < 0:
+            return False
+
+        curve_points = self.get_nth_curve_points(curve_index)
+        start_anchor = curve_points[0]
+        end_anchor = curve_points[-1]
+        segment = end_anchor - start_anchor
+        segment_length_sq = float(np.dot(segment, segment))
+        if segment_length_sq == 0:
+            return False
+
+        residue = float(
+            np.clip(
+                np.dot(np.asarray(point) - start_anchor, segment) / segment_length_sq,
+                0,
+                1,
+            )
+        )
+        nppc = self.n_points_per_curve
+        if at_start:
+            self.points[:nppc] = partial_bezier_points(curve_points, residue, 1)
+        else:
+            self.points[-nppc:] = partial_bezier_points(curve_points, 0, residue)
+        return True
+
+    def reset_endpoints_based_on_tip(self, tip: ArrowTip, at_start: bool) -> Self:
+        if self.get_length() == 0:
+            return self
+
+        if self._trim_path_with_tip_base(tip.base, at_start):
+            return self
+
+        return super().reset_endpoints_based_on_tip(tip, at_start)
 
     def get_vector(self) -> Vector3D:
         return self.get_end() - self.get_start()

--- a/manim/mobject/opengl/opengl_geometry.py
+++ b/manim/mobject/opengl/opengl_geometry.py
@@ -21,6 +21,7 @@ from manim.typing import (
     Vector3D,
     Vector3DLike,
 )
+from manim.utils.bezier import partial_bezier_points
 from manim.utils.color import *
 from manim.utils.iterables import adjacent_n_tuples, adjacent_pairs
 from manim.utils.simple_functions import clip
@@ -552,6 +553,45 @@ class OpenGLLine(OpenGLTipableVMobject):
         if (curr_start == curr_end).all():
             self.set_points_by_ends(start, end, self.path_arc)
         return super().put_start_and_end_on(start, end)
+
+    def _trim_path_with_tip_base(self, point: Point3DLike, at_start: bool) -> bool:
+        if self.path_arc != 0 or self.get_num_curves() <= 1:
+            return False
+
+        curve_index = 0 if at_start else self.get_num_curves() - 1
+        if curve_index < 0:
+            return False
+
+        curve_points = self.get_nth_curve_points(curve_index)
+        start_anchor = curve_points[0]
+        end_anchor = curve_points[-1]
+        segment = end_anchor - start_anchor
+        segment_length_sq = float(np.dot(segment, segment))
+        if segment_length_sq == 0:
+            return False
+
+        residue = float(
+            np.clip(
+                np.dot(np.asarray(point) - start_anchor, segment) / segment_length_sq,
+                0,
+                1,
+            )
+        )
+        nppc = self.n_points_per_curve
+        if at_start:
+            self.points[:nppc] = partial_bezier_points(curve_points, residue, 1)
+        else:
+            self.points[-nppc:] = partial_bezier_points(curve_points, 0, residue)
+        return True
+
+    def reset_endpoints_based_on_tip(self, tip: OpenGLArrowTip, at_start: bool) -> Self:
+        if self.get_length() == 0:
+            return self
+
+        if self._trim_path_with_tip_base(tip.get_base(), at_start):
+            return self
+
+        return super().reset_endpoints_based_on_tip(tip, at_start)
 
     def get_vector(self) -> Vector3D:
         return self.get_end() - self.get_start()

--- a/tests/module/mobject/geometry/test_unit_geometry.py
+++ b/tests/module/mobject/geometry/test_unit_geometry.py
@@ -217,6 +217,50 @@ def test_line_with_buff_and_path_arc():
     np.testing.assert_allclose(line.points, expected_points)
 
 
+def test_add_tip_preserves_polyline_corner():
+    line = Line()
+    line.set_points_as_corners(
+        [
+            np.array([0.0, 0.0, 0.0]),
+            np.array([0.0, 2.0, 0.0]),
+            np.array([3.0, 2.0, 0.0]),
+        ]
+    )
+    original_first_curve = line.points[:4].copy()
+
+    line.add_tip(tip_length=0.5)
+
+    np.testing.assert_allclose(line.points[:4], original_first_curve)
+    np.testing.assert_allclose(line.points[3], np.array([0.0, 2.0, 0.0]))
+    np.testing.assert_allclose(line.points[4], np.array([0.0, 2.0, 0.0]))
+    np.testing.assert_allclose(line.points[-1], line.tip.base)
+    np.testing.assert_allclose(line.tip.base, np.array([2.5, 2.0, 0.0]))
+
+
+def test_add_start_tip_preserves_polyline_corner():
+    line = Line()
+    line.set_points_as_corners(
+        [
+            np.array([0.0, 0.0, 0.0]),
+            np.array([0.0, 2.0, 0.0]),
+            np.array([3.0, 2.0, 0.0]),
+        ]
+    )
+    original_last_curve = line.points[-4:].copy()
+
+    line.add_tip(at_start=True, tip_length=0.5)
+
+    np.testing.assert_allclose(line.points[-4:], original_last_curve)
+    np.testing.assert_allclose(line.points[3], np.array([0.0, 2.0, 0.0]))
+    np.testing.assert_allclose(line.points[4], np.array([0.0, 2.0, 0.0]))
+    np.testing.assert_allclose(line.points[0], line.start_tip.base, atol=1e-12)
+    np.testing.assert_allclose(
+        line.start_tip.base,
+        np.array([0.0, 0.5, 0.0]),
+        atol=1e-12,
+    )
+
+
 def test_Circle_point_at_angle():
     from manim import TAU
 


### PR DESCRIPTION
Fixes #4444

## Overview: What does this pull request change?

This PR fixes a geometry bug in `Line.add_tip()` / `OpenGLLine.add_tip()` when working with polylines created via `set_points_as_corners(...)`, as reported in #4444 by [@tobiasBora](https://github.com/tobiasBora).

Before this patch, adding a tip shortened the path by resetting the whole line's start and end points. That behavior is fine for a single straight segment, but for multi-segment polylines it remaps the entire path and shifts interior corners.

With this patch, plain `Line` / `OpenGLLine` paths with `path_arc == 0` trim only the first or last boundary segment to the tip base, so the existing elbow geometry stays intact.

## Motivation and Explanation: Why and how do your changes improve the library?

An example is:

```py
from manim import *

class BrokenElbow(Scene):
    def construct(self):
        line = Line()
        line.set_points_as_corners(
            [
                [-3, -1, 0],
                [-3, 1, 0],
                [1, 1, 0],
            ]
        ).add_tip(tip_length=0.4)

        self.add(NumberPlane(), line)
```

Expected behavior:

- the corner at `(-3, 1, 0)` stays fixed
- only the last horizontal segment is shortened to make room for the tip

Actual behavior before this patch:

- the whole polyline is remapped when the tip is added
- the elbow corner shifts away from its original location

To fix this, `Line` and `OpenGLLine` now trim only the boundary segment when `path_arc == 0`, while other cases still fall back to the existing generic implementation.

I also added regression tests covering both end tips and start tips preserving the polyline corner.

## Links to added or changed documentation pages

No documentation pages were changed.

## Further Information and Comments

Local tests run:

- `python -m pytest -o addopts='' tests/module/mobject/geometry/test_unit_geometry.py -q`

I also ran targeted checks locally for:

- straight lines with tips
- both start and end tips
- `Arrow` / `DoubleArrow`
- zero-length `Line`
- `path_arc != 0`
- `OpenGLLine`

Visual comparison:

The red dot marks the intended elbow corner. Before this patch, `add_tip()` remaps the whole polyline when shortening it for the tip. After the patch, the corner stays fixed and only the boundary segment is trimmed.

<img width="1920" height="1080" alt="Issue4444Comparison_ManimCE_v0 20 1" src="https://github.com/user-attachments/assets/de9a6e77-e793-4328-a460-447b34564db8" />

Animated comparison video:

https://github.com/user-attachments/assets/82b84bef-60f9-412b-86f8-021a519926be


## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
