### PR TITLE
Preserve closed curves in `put_start_and_end_on()`

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1946,7 +1946,8 @@ class Mobject:
         if np.all(current_vector == 0):            
             warnings.warn(
                 "put_start_and_end_on has been called on a closed loop or zero-length mobject. "
-                f"{type(self).__name__} will be shifted to start point instead."
+                f"{type(self).__name__} will be shifted to start point instead.",
+                stacklevel=2,
             )
             self.shift(np.asarray(start) - current_start)
             return self

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1943,10 +1943,7 @@ class Mobject:
     def put_start_and_end_on(self, start: Point3DLike, end: Point3DLike) -> Self:
         current_start, current_end = self.get_start_and_end()
         current_vector = current_end - current_start
-        if np.all(current_vector == 0):
-            # Previously self.points = np.array(start) was used here, but it would have collapsed
-            # all points to a single Point3D instead of shifting the mobject.
-            # Fixed by using shift instead.
+        if np.all(current_vector == 0):            
             warnings.warn(
                 "put_start_and_end_on has been called on a closed loop or zero-length mobject. "
                 f"{type(self).__name__} will be shifted to start point instead."

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1943,7 +1943,7 @@ class Mobject:
     def put_start_and_end_on(self, start: Point3DLike, end: Point3DLike) -> Self:
         current_start, current_end = self.get_start_and_end()
         current_vector = current_end - current_start
-        if np.all(current_vector == 0):            
+        if np.all(current_vector == 0):
             warnings.warn(
                 "put_start_and_end_on has been called on a closed loop or zero-length mobject. "
                 f"{type(self).__name__} will be shifted to start point instead."

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1944,16 +1944,16 @@ class Mobject:
         current_start, current_end = self.get_start_and_end()
         current_vector = current_end - current_start
         if np.all(current_vector == 0):
-            # TODO: this looks broken. It makes self.points a Point3D instead
-            # of a Point3D_Array. However, modifying this breaks some tests
-            # where this is currently expected.
-            #self.points = np.array(start)
-
-            # Previously broken: self.points = np.array(start) would collapse
+            # Previously self.points = np.array(start) was used here, but it would have collapsed
             # all points to a single Point3D instead of shifting the mobject.
             # Fixed by using shift instead.
+            warnings.warn(
+                "put_start_and_end_on has been called on a closed loop or zero-length mobject. "
+                f"{type(self).__name__} will be shifted to start point instead."
+            )
             self.shift(np.asarray(start) - current_start)
             return self
+            
         target_vector = np.asarray(end) - np.asarray(start)
         axis = (
             normalize(np.cross(current_vector, target_vector))

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1953,7 +1953,7 @@ class Mobject:
             )
             self.shift(np.asarray(start) - current_start)
             return self
-            
+
         target_vector = np.asarray(end) - np.asarray(start)
         axis = (
             normalize(np.cross(current_vector, target_vector))

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -1941,30 +1941,35 @@ class Mobject:
         return self
 
     def put_start_and_end_on(self, start: Point3DLike, end: Point3DLike) -> Self:
-        curr_start, curr_end = self.get_start_and_end()
-        curr_vect = curr_end - curr_start
-        if np.all(curr_vect == 0):
+        current_start, current_end = self.get_start_and_end()
+        current_vector = current_end - current_start
+        if np.all(current_vector == 0):
             # TODO: this looks broken. It makes self.points a Point3D instead
             # of a Point3D_Array. However, modifying this breaks some tests
             # where this is currently expected.
-            self.points = np.array(start)
+            #self.points = np.array(start)
+
+            # Previously broken: self.points = np.array(start) would collapse
+            # all points to a single Point3D instead of shifting the mobject.
+            # Fixed by using shift instead.
+            self.shift(np.asarray(start) - current_start)
             return self
-        target_vect = np.asarray(end) - np.asarray(start)
+        target_vector = np.asarray(end) - np.asarray(start)
         axis = (
-            normalize(np.cross(curr_vect, target_vect))
-            if np.linalg.norm(np.cross(curr_vect, target_vect)) != 0
+            normalize(np.cross(current_vector, target_vector))
+            if np.linalg.norm(np.cross(current_vector, target_vector)) != 0
             else OUT
         )
         self.scale(
-            np.linalg.norm(target_vect) / np.linalg.norm(curr_vect),
-            about_point=curr_start,
+            np.linalg.norm(target_vector) / np.linalg.norm(current_vector),
+            about_point=current_start,
         )
         self.rotate(
-            angle_between_vectors(curr_vect, target_vect),
-            about_point=curr_start,
+            angle_between_vectors(current_vector, target_vector),
+            about_point=current_start,
             axis=axis,
         )
-        self.shift(start - curr_start)
+        self.shift(np.asarray(start) - current_start)
         return self
 
     # Background rectangle

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -2140,7 +2140,8 @@ class OpenGLMobject:
         if np.all(current_vector == 0):            
             warnings.warn(
                 "put_start_and_end_on has been called on a closed loop or zero-length mobject. "
-                f"{type(self).__name__} will be shifted to start point instead."
+                f"{type(self).__name__} will be shifted to start point instead.",
+                stacklevel=2,
             )
             self.shift(np.asarray(start) - current_start)
             return self

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -2146,7 +2146,7 @@ class OpenGLMobject:
             )
             self.shift(np.asarray(start) - current_start)
             return self
-            
+
         target_vector = np.asarray(end) - np.asarray(start)
         axis = (
             normalize(np.cross(current_vector, target_vector))
@@ -2164,7 +2164,6 @@ class OpenGLMobject:
         )
         self.shift(np.asarray(start) - current_start)
         return self
-
 
     # Color functions
 

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -2137,7 +2137,7 @@ class OpenGLMobject:
     def put_start_and_end_on(self, start: Point3DLike, end: Point3DLike) -> Self:
         current_start, current_end = self.get_start_and_end()
         current_vector = current_end - current_start
-        if np.all(current_vector == 0):            
+        if np.all(current_vector == 0):
             warnings.warn(
                 "put_start_and_end_on has been called on a closed loop or zero-length mobject. "
                 f"{type(self).__name__} will be shifted to start point instead."

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -2134,27 +2134,37 @@ class OpenGLMobject:
         return self
 
     def put_start_and_end_on(self, start: Point3DLike, end: Point3DLike) -> Self:
-        curr_start, curr_end = self.get_start_and_end()
-        curr_vect = curr_end - curr_start
-        if np.all(curr_vect == 0):
-            raise Exception("Cannot position endpoints of closed loop")
-        target_vect = np.array(end) - np.array(start)
+        current_start, current_end = self.get_start_and_end()
+        current_vector = current_end - current_start
+        if np.all(current_vector == 0):
+            # Previously self.points = np.array(start) was used here, but it would have collapsed
+            # all points to a single Point3D instead of shifting the mobject.
+            # Fixed by using shift instead.
+            warnings.warn(
+                "put_start_and_end_on has been called on a closed loop or zero-length mobject. "
+                f"{type(self).__name__} will be shifted to start point instead."
+            )
+            self.shift(np.asarray(start) - current_start)
+            return self
+            
+        target_vector = np.asarray(end) - np.asarray(start)
         axis = (
-            normalize(np.cross(curr_vect, target_vect))
-            if np.linalg.norm(np.cross(curr_vect, target_vect)) != 0
+            normalize(np.cross(current_vector, target_vector))
+            if np.linalg.norm(np.cross(current_vector, target_vector)) != 0
             else OUT
         )
         self.scale(
-            float(np.linalg.norm(target_vect) / np.linalg.norm(curr_vect)),
-            about_point=curr_start,
+            np.linalg.norm(target_vector) / np.linalg.norm(current_vector),
+            about_point=current_start,
         )
         self.rotate(
-            angle_between_vectors(curr_vect, target_vect),
-            about_point=curr_start,
+            angle_between_vectors(current_vector, target_vector),
+            about_point=current_start,
             axis=axis,
         )
-        self.shift(start - curr_start)
+        self.shift(np.asarray(start) - current_start)
         return self
+
 
     # Color functions
 

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -6,6 +6,7 @@ import itertools as it
 import random
 import sys
 import types
+import warnings
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from functools import partialmethod, wraps
 from math import ceil
@@ -2136,10 +2137,7 @@ class OpenGLMobject:
     def put_start_and_end_on(self, start: Point3DLike, end: Point3DLike) -> Self:
         current_start, current_end = self.get_start_and_end()
         current_vector = current_end - current_start
-        if np.all(current_vector == 0):
-            # Previously self.points = np.array(start) was used here, but it would have collapsed
-            # all points to a single Point3D instead of shifting the mobject.
-            # Fixed by using shift instead.
+        if np.all(current_vector == 0):            
             warnings.warn(
                 "put_start_and_end_on has been called on a closed loop or zero-length mobject. "
                 f"{type(self).__name__} will be shifted to start point instead."

--- a/tests/module/mobject/graphing/test_number_line.py
+++ b/tests/module/mobject/graphing/test_number_line.py
@@ -129,4 +129,4 @@ def test_start_and_end_at_same_point():
     line = DashedLine(np.zeros(3), np.zeros(3))
     line.put_start_and_end_on(np.zeros(3), np.array([0, 0, 0]))
 
-    np.testing.assert_array_equal(np.round(np.zeros(3), 4), np.round(line.points, 4))
+    np.testing.assert_array_equal(np.round(line.points, 4), np.round(np.zeros((4,3)),4))

--- a/tests/module/mobject/graphing/test_number_line.py
+++ b/tests/module/mobject/graphing/test_number_line.py
@@ -129,4 +129,6 @@ def test_start_and_end_at_same_point():
     line = DashedLine(np.zeros(3), np.zeros(3))
     line.put_start_and_end_on(np.zeros(3), np.array([0, 0, 0]))
 
-    np.testing.assert_array_equal(np.round(line.points, 4), np.round(np.zeros((4,3)),4))
+    np.testing.assert_array_equal(
+        np.round(line.points, 4), np.round(np.zeros((4, 3)), 4)
+    )


### PR DESCRIPTION
## Overview: What does this pull request change?
This PR refactors the method "put_start_and_end_on" in mobject.py and opengl_mobject.py: 

Replaces self.points = np.array(start) with self.shift(np.asarray(start) - current_start) in the case of a mobject whose start and end point are the same, in both mobject.py and opengl_mobject.py

Adds a warning that warns the user that the mobject which is calling this method is a loop, and it will be shifted.

Some variable names have been changed for better reading.

## Motivation and Explanation: Why and how do your changes improve the library?
The put_start_and_end_on method in both mobject.py and opengl_mobject.py previously used self.points = np.array(start) when the mobject had its start and end as the same point. This collapsed all of the mobject's points into a single Point3D, destroying its geometry entirely. For example, calling this method on a Circle or Square would reduce it to a single point, making it cease to exist visually.
This PR fixes the issue by replacing that line with self.shift(np.asarray(start) - current_start), which simply repositions the mobject to the start point while fully preserving its geometry.



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
