### PR TITLE
Refactor set_color_by_radial_gradient & set_submobject_colors_by_radial_gradient

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2059,13 +2059,34 @@ class Mobject:
     def set_colors_by_radial_gradient(
         self,
         center: Point3DLike | None = None,
-        radius: float = 1,
+        inner_radius: float | None = None,
+        outer_radius: float | None = None,
         inner_color: ParsableManimColor = WHITE,
         outer_color: ParsableManimColor = BLACK,
     ) -> Self:
+        """
+        Sets the color of each submobject according to its distance from the given point: center,
+        interpolating between ``inner_color`` (which starts from ``inner_radius``), 
+        and ``outer_color`` which is at the boundary defined by ``outer_radius``.
+
+        Parameters
+        ----------
+        center
+            The center point of the gradient. Defaults to center of the mobject.
+        inner_radius
+            The radius from where ``inner_color`` starts colouring. Defaults to 0.0.
+        outer_radius
+            The radius at which ``outer_color`` is reached. Defaults to the distance
+            from the mobject's center to the corner of the bounding box, including all submobjects.
+        inner_color
+            The color at the inner boundary of the gradient.
+        outer_color
+            The color at the outer boundary of the gradient. 
+        """
         self.set_submobject_colors_by_radial_gradient(
             center,
-            radius,
+            inner_radius,
+            outer_radius,
             inner_color,
             outer_color,
         )
@@ -2087,40 +2108,36 @@ class Mobject:
     def set_submobject_colors_by_radial_gradient(
         self,
         center: Point3DLike | None = None,
-        radius: float | None = None,
+        inner_radius: float | None = None,
+        outer_radius: float | None = None,
         inner_color: ParsableManimColor = WHITE,
         outer_color: ParsableManimColor = BLACK,
     ) -> Self:
         """
-        Sets the color of each submobject according to its distance from the given point: center,
-        interpolating between ``inner_color`` at the center and ``outer_color`` at
-        the boundary defined by ``radius``.
-
-        Parameters
-        ----------
-        center
-            The center point of the gradient. Defaults to the center of the mobject.
-        radius
-            The radius at which ``outer_color`` is reached. Defaults to the distance
-            from the center to the corner of the bounding box, including all submobjects.
-        inner_color
-            The color at the center of the gradient.
-        outer_color
-            The color at the outer boundary of the gradient. 
+        See :meth: `set_colors_by_radial_gradient`.
         """
         if center is None:
             center = self.get_center()
 
-        if radius is None: 
-            radius = np.linalg.norm(self.get_corner(UR) - self.get_center())
+        if inner_radius is None:
+            inner_radius = 0.0
+
+        if outer_radius is None:
+            outer_radius = max(
+                np.linalg.norm(mob.get_center() - center)
+                for mob in self.family_members_with_points()
+            )
+
+        if np.isclose(inner_radius, outer_radius):
+            return self
 
         for mob in self.family_members_with_points():
-            t = np.linalg.norm(mob.get_center() - center) / radius
-            t = min(t, 1)
-            mob_color = interpolate_color(
-                ManimColor(inner_color), ManimColor(outer_color), t
-            )
-            mob.set_color(mob_color, family=False)
+            distance = np.linalg.norm(mob.get_center() - center)
+            if distance < inner_radius and not np.isclose(distance, inner_radius):
+                continue
+            t = (distance - inner_radius) / (outer_radius - inner_radius)        
+            mob_color = interpolate_color(ManimColor(inner_color), ManimColor(outer_color), t)
+            mob.set_color(mob_color, family = False)
 
         return self
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2128,6 +2128,11 @@ class Mobject:
                 for mob in self.family_members_with_points()
             )
 
+        if inner_radius > outer_radius:
+            raise ValueError(
+                f"inner_radius ({inner_radius}) should be less than outer_radius ({outer_radius})"
+            )
+
         if np.isclose(inner_radius, outer_radius):
             return self
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2087,12 +2087,32 @@ class Mobject:
     def set_submobject_colors_by_radial_gradient(
         self,
         center: Point3DLike | None = None,
-        radius: float = 1,
+        radius: float | None = None,
         inner_color: ParsableManimColor = WHITE,
         outer_color: ParsableManimColor = BLACK,
     ) -> Self:
+        """
+        Sets the color of each submobject according to its distance from the given point: center,
+        interpolating between ``inner_color`` at the center and ``outer_color`` at
+        the boundary defined by ``radius``.
+
+        Parameters
+        ----------
+        center
+            The center point of the gradient. Defaults to the center of the mobject.
+        radius
+            The radius at which ``outer_color`` is reached. Defaults to the distance
+            from the center to the corner of the bounding box, including all submobjects.
+        inner_color
+            The color at the center of the gradient.
+        outer_color
+            The color at the outer boundary of the gradient. 
+        """
         if center is None:
             center = self.get_center()
+
+        if radius is None: 
+            radius = np.linalg.norm(self.get_corner(UR) - self.get_center())
 
         for mob in self.family_members_with_points():
             t = np.linalg.norm(mob.get_center() - center) / radius

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2113,9 +2113,8 @@ class Mobject:
         inner_color: ParsableManimColor = WHITE,
         outer_color: ParsableManimColor = BLACK,
     ) -> Self:
-        """
-        See :meth: `set_colors_by_radial_gradient`.
-        """
+        """See :meth:`set_colors_by_radial_gradient`."""
+        
         if center is None:
             center = self.get_center()
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2066,7 +2066,7 @@ class Mobject:
     ) -> Self:
         """
         Sets the color of each submobject according to its distance from the given point: center,
-        interpolating between ``inner_color`` (which starts from ``inner_radius``), 
+        interpolating between ``inner_color`` (which starts from ``inner_radius``),
         and ``outer_color`` which is at the boundary defined by ``outer_radius``.
 
         Parameters
@@ -2081,7 +2081,7 @@ class Mobject:
         inner_color
             The color at the inner boundary of the gradient.
         outer_color
-            The color at the outer boundary of the gradient. 
+            The color at the outer boundary of the gradient.
         """
         self.set_submobject_colors_by_radial_gradient(
             center,
@@ -2140,9 +2140,11 @@ class Mobject:
             distance = np.linalg.norm(mob.get_center() - center)
             if distance < inner_radius and not np.isclose(distance, inner_radius):
                 continue
-            t = (distance - inner_radius) / (outer_radius - inner_radius)        
-            mob_color = interpolate_color(ManimColor(inner_color), ManimColor(outer_color), t)
-            mob.set_color(mob_color, family = False)
+            t = (distance - inner_radius) / (outer_radius - inner_radius)
+            mob_color = interpolate_color(
+                ManimColor(inner_color), ManimColor(outer_color), t
+            )
+            mob.set_color(mob_color, family=False)
 
         return self
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2114,7 +2114,6 @@ class Mobject:
         outer_color: ParsableManimColor = BLACK,
     ) -> Self:
         """See :meth:`set_colors_by_radial_gradient`."""
-        
         if center is None:
             center = self.get_center()
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2138,6 +2138,8 @@ class Mobject:
             distance = np.linalg.norm(mob.get_center() - center)
             if distance < inner_radius and not np.isclose(distance, inner_radius):
                 continue
+            if distance > outer_radius and not np.isclose(distance, outer_radius):
+                continue
             t = (distance - inner_radius) / (outer_radius - inner_radius)
             mob_color = interpolate_color(
                 ManimColor(inner_color), ManimColor(outer_color), t


### PR DESCRIPTION
## Overview: What does this pull request change?
This PR changes 2 methods of mobject.py:
(1) set_colors_by_radial_gradient
(2) set_submobject_colors_by_radial_gradient
to include inner_radius and outer_radius. 
This PR also writes docstring for the method set_colors_by_radial_gradient which was not there previosly.

## Motivation and Explanation: Why and how do your changes improve the library?
In the main branch, in set_submobject_colors_by_radial_gradient, there was no provision to set the inner_radius from which the colouring will start, it was set to be centre of the mobject, which was not much helpful. In the PR, the default is the set to the mobject's centre, but the user can set an inner radius of choosing, from where to begin colouring radially outwards.

See the output:

This is code for and output from the main branch:
```py
class RadialGradientDemo(Scene):
    def construct(self):
        dots = VGroup()

        for r in np.arange(0.25, 4, 0.5):
            for angle in np.linspace(0, TAU, 12, endpoint = False):
                dots.add(Dot(radius = max(0.05*r, 0.06)).move_to([r * np.cos(angle), r * np.sin(angle), 0]))

        dots.add(Dot(radius=0.05))
        radius = float(min(np.linalg.norm(dots.get_corner(UR) - dots.get_center()), 3.75))
        dots.set_colors_by_radial_gradient(
            inner_color = RED,
            outer_color = PURE_YELLOW,
            radius = radius
        )
        self.add(dots)
```
Output: 
<img width="1920" height="1080" alt="main" src="https://github.com/user-attachments/assets/75c7a77e-552a-47ba-b50b-d573f8e54aaf" />


This is the code for and output from the PR branch:
```py
class RadialGradientDemo(Scene):
    def construct(self):
        dots = VGroup()

        for r in np.arange(0.25, 4, 0.5):
            for angle in np.linspace(0, TAU, 12, endpoint = False):
                dots.add(Dot(radius = max(0.05*r, 0.06)).move_to([r * np.cos(angle), r * np.sin(angle), 0]))

        dots.add(Dot(radius=0.05))
        dots.set_colors_by_radial_gradient(
            inner_radius = 1.25,
            inner_color = RED,
            outer_color = PURE_YELLOW,
             
            
        )
        self.add(dots)
```
output when inner_radius = 1.25: 
<img width="1920" height="1080" alt="1" src="https://github.com/user-attachments/assets/cb19b2e1-c7e8-4296-9de7-fba4fc7e7f42" />


Output when inner_radius = 0.0:
<img width="1920" height="1080" alt="2" src="https://github.com/user-attachments/assets/3dbc90c0-62fc-4296-8a15-441c9ed87775" />

Output when inner_radius = 1.5 and outer_radius = 2.75:
<img width="1920" height="1080" alt="final" src="https://github.com/user-attachments/assets/e4861eed-8141-47ac-a7e7-11249f8f9db2" />


## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
