### PR TITLE
Change `VMobject._bezier_t_values` typehint to `npt.NDArray[np.float64]`

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -155,7 +155,7 @@ class VMobject(Mobject):
         self.shade_in_3d: bool = shade_in_3d
         self.tolerance_for_point_equality: float = tolerance_for_point_equality
         self.n_points_per_cubic_curve: int = n_points_per_cubic_curve
-        self._bezier_t_values: npt.NDArray[float] = np.linspace(
+        self._bezier_t_values: npt.NDArray[np.float64] = np.linspace(
             0, 1, n_points_per_cubic_curve
         )
         self.cap_style: CapStyleType = cap_style


### PR DESCRIPTION
## Overview: What does this pull request change?
This PR changes the typehint for the attribute: _bezier_t_values in the __init__ of VMobject class. 
earlier: self._bezier_t_values: npt.NDArray[float] = np.linspace( 0, 1, n_points_per_cubic_curve)
now: self._bezier_t_values: npt.NDArray[np.float64] = np.linspace(0, 1, n_points_per_cubic_curve)

## Motivation and Explanation: Why and how do your changes improve the library?
It's a very minor modification, but apparently, makes the pylance check pass.



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
