### PR TITLE
Update TinyTeX Windows/macOS installation in `ci.yml` to fix failing pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           $OriPath = $env:PATH
           echo "Install Tinytex"
           Invoke-WebRequest "https://github.com/rstudio/tinytex-releases/releases/download/daily/TinyTeX-1-windows.exe" -OutFile "$($env:TMP)\TinyTex.exe"
-          "$($env:TMP)\TinyTex.exe" -o"$($PWD)\ManimCache\LatexWindows"
+          .$env:TMP\TinyTex.exe -o"$($PWD)\ManimCache\LatexWindows"
           $env:Path = "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\windows;$($env:PATH)"
           tlmgr update --self
           tlmgr install $tinyTexPackages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
           oriPath=$PATH
           sudo mkdir -p $PWD/macos-cache
           echo "Install TinyTeX"
-          sudo curl -L -o "/tmp/TinyTeX.tgz" "https://github.com/yihui/tinytex-releases/releases/download/daily/TinyTeX-1.tgz"
-          sudo tar zxf "/tmp/TinyTeX.tgz" -C "$PWD/macos-cache"
+          sudo curl -L -o "/tmp/TinyTeX.tar.xz" "https://github.com/rstudio/tinytex-releases/releases/download/daily/TinyTeX-1-darwin.tar.xz"
+          sudo tar xJf "/tmp/TinyTeX.tar.xz" -C "$PWD/macos-cache"
           export PATH="$PWD/macos-cache/TinyTeX/bin/universal-darwin:$PATH"
           sudo tlmgr update --self
           for i in "${ttp[@]}"; do
@@ -137,8 +137,8 @@ jobs:
           $tinyTexPackages = $(python -c "import json;print(' '.join(json.load(open('.github/manimdependency.json'))['windows']['tinytex']))") -Split ' '
           $OriPath = $env:PATH
           echo "Install Tinytex"
-          Invoke-WebRequest "https://github.com/yihui/tinytex-releases/releases/download/daily/TinyTeX-1.zip" -OutFile "$($env:TMP)\TinyTex.zip"
-          Expand-Archive -LiteralPath "$($env:TMP)\TinyTex.zip" -DestinationPath "$($PWD)\ManimCache\LatexWindows"
+          Invoke-WebRequest "https://github.com/rstudio/tinytex-releases/releases/download/daily/TinyTeX-1-windows.exe" -OutFile "$($env:TMP)\TinyTex.exe"
+          "$($env:TMP)\TinyTex.exe" -o"$($PWD)\ManimCache\LatexWindows"
           $env:Path = "$($PWD)\ManimCache\LatexWindows\TinyTeX\bin\windows;$($env:PATH)"
           tlmgr update --self
           tlmgr install $tinyTexPackages


### PR DESCRIPTION
Recent PR pipelines have been failing because the daily TinyTex-1.zip for Windows and TinyTex-1.tgz for macOS are missing. According to [this tinytex-releases commit](https://github.com/rstudio/tinytex-releases/commit/50a59183136a63d4dc7a09efa5457ea38f226d17), they were replaced with TinyTex-1-windows.exe (which is a 7-Zip autoextractable file) and TinyTex-1-darwin.tar.xz, respectively.

This PR updates the URLs to download the new files and extract them properly. It also replaces yihui with rstudio in the URLs, respecting [the ownership transfer in 2022](https://github.com/rstudio/tinytex/commit/9fe4438d00f77a6611cb337111ef00a5f00a9050).

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
