### PR TITLE
add get_entry and get_entry_without_label to table

### DIFF
--- a/manim/mobject/table.py
+++ b/manim/mobject/table.py
@@ -611,6 +611,38 @@ class Table(VGroup):
         else:
             return self.elements
 
+    def get_entry(self, pos: Sequence[int]) -> VMobject:
+        """Return one specific entry of the table (including labels).
+
+        Parameters
+        ----------
+        pos
+            The position of a specific entry on the table. ``(1,1)`` being the top left entry
+            of the table.
+
+        Returns
+        -------
+        :class:`~.VMobject`
+            The :class:`~.VMobject` at the given position.
+
+        Examples
+        --------
+
+        .. manim:: GetEntryExample
+            :save_last_frame:
+
+            class GetEntryExample(Scene):
+                def construct(self):
+                    table = Table(
+                        [["First", "Second"],
+                        ["Third","Fourth"]],
+                        row_labels=[Text("R1"), Text("R2")],
+                        col_labels=[Text("C1"), Text("C2")])
+                    table.get_entry((2,2)).rotate(PI)
+                    self.add(table)
+        """
+        return self.get_entries(pos)
+
     def get_entries_without_labels(
         self,
         pos: Sequence[int] | None = None,
@@ -655,6 +687,38 @@ class Table(VGroup):
             return self.elements_without_labels[index]
         else:
             return self.elements_without_labels
+
+    def get_entry_without_label(self, pos: Sequence[int]) -> VMobject:
+        """Return one specific entry of the table (without labels).
+
+        Parameters
+        ----------
+        pos
+            The position of a specific entry on the table. ``(1,1)`` being the top left entry
+            of the table (without labels).
+
+        Returns
+        -------
+        :class:`~.VMobject`
+            The :class:`~.VMobject` at the given position.
+
+        Examples
+        --------
+
+        .. manim:: GetEntryWithoutLabelExample
+            :save_last_frame:
+
+            class GetEntryWithoutLabelExample(Scene):
+                def construct(self):
+                    table = Table(
+                        [["First", "Second"],
+                        ["Third","Fourth"]],
+                        row_labels=[Text("R1"), Text("R2")],
+                        col_labels=[Text("C1"), Text("C2")])
+                    table.get_entry_without_label((2,2)).rotate(PI)
+                    self.add(table)
+        """
+        return self.get_entries_without_labels(pos)
 
     def get_row_labels(self) -> VGroup:
         """Return the row labels of the table.


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

hey, trying to fix #2051

added two new methods to the Table class -- `get_entry(pos)` and `get_entry_without_label(pos)` -- that return a single VMobject at the given position. they just delegate to the existing `get_entries` and `get_entries_without_labels` methods so nothing breaks, but now you have dedicated single-entry methods with proper explicit return types instead of the weird union return on the plural methods. the original methods are untouched for backward compat.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
