### PR TITLE
Fixed text center of rotation for add_fixed_orientation_mobjects()

### DIFF
--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -2841,11 +2841,16 @@ class OpenGLMobject:
         self.is_fixed_in_frame = 1.0
         return self
 
-    @affects_shader_info_id
     def fix_orientation(self) -> Self:
-        self.is_fixed_orientation = 1.0
-        self.fixed_orientation_center = tuple(self.get_center())
-        self.depth_test = True
+        # do not use @affects_shader_info_id: that invokes this once per family
+        # member with that member as self, so each submobject would use its own
+        # get_center(). simply share one pivot for the whole tree.
+        anchor = tuple(self.get_center())
+        for mob in self.get_family():
+            mob.is_fixed_orientation = 1.0
+            mob.fixed_orientation_center = anchor
+            mob.depth_test = True
+            mob.refresh_shader_wrapper_id()
         return self
 
     @affects_shader_info_id


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Modified the fix_orientation function under opengl_mobject.py to fix an error in center of rotation for text objects according to #4644 . The @affects_shader_info_id decorator called fix_orientation once per submobject, so each glyph used its own get_center() as the pivot instead of the whole label’s center. I changed it so that it computes a single anchor from the mobject fix_orientation is called on, then uses that one point for every part of the label (every submobject). This makes it so the whole string spins as a single unit around the text's real middle.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Bugfix.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
Added comment under the fix_orientation() function to detail why "@affects_shader_info_id" is not being used from this PR (since the surrounding functions use it).


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
Showing the text rotation works properly given the reproduction code/example from issue #4644 

<img width="774" height="451" alt="image" src="https://github.com/user-attachments/assets/4503eca6-6847-47c7-8c89-e2d99630574d" />
<img width="586" height="506" alt="image" src="https://github.com/user-attachments/assets/de307fbb-d0d4-44d6-9aa2-e917bad8e5ac" />
<img width="668" height="429" alt="image" src="https://github.com/user-attachments/assets/8cefcd9f-50fd-4577-a338-689205ab2888" />

This was also ran on the OpenGL renderer (like #4644 ) but on Windows 11.





<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
