### PR TITLE
Fix `set_to_default_angled_camera_orientation()` raising `AttributeError`

### DIFF
--- a/manim/scene/three_d_scene.py
+++ b/manim/scene/three_d_scene.py
@@ -428,8 +428,8 @@ class ThreeDScene(Scene):
             which have the same meaning as the parameters in set_camera_orientation.
         """
         config = dict(
-            self.default_camera_orientation_kwargs,
-        )  # Where doe this come from?
+            self.default_angled_camera_orientation_kwargs,
+        )
         config.update(kwargs)
         self.set_camera_orientation(**config)
 

--- a/tests/module/scene/test_threed_scene.py
+++ b/tests/module/scene/test_threed_scene.py
@@ -1,4 +1,4 @@
-from manim import Circle, Square, ThreeDScene
+from manim import DEGREES, Circle, Square, ThreeDScene
 
 
 def test_fixed_mobjects():
@@ -15,3 +15,12 @@ def test_fixed_mobjects():
     assert set(scene.camera.fixed_orientation_mobjects) == {s}
     scene.remove_fixed_orientation_mobjects(s)
     assert len(scene.camera.fixed_orientation_mobjects) == 0
+
+
+def test_set_to_default_angled_camera_orientation():
+    scene = ThreeDScene()
+
+    scene.set_to_default_angled_camera_orientation(phi=45 * DEGREES)
+
+    assert scene.camera.get_phi() == 45 * DEGREES
+    assert scene.camera.get_theta() == -135 * DEGREES


### PR DESCRIPTION
## Overview: What does this pull request change?

Fixes `ThreeDScene.set_to_default_angled_camera_orientation()` so it uses the stored default angled camera orientation kwargs, and adds a regression test for the method.

## Motivation and Explanation: Why and how do your changes improve the library?

`ThreeDScene.__init__` stores the defaults in `self.default_angled_camera_orientation_kwargs`, but `set_to_default_angled_camera_orientation()` was reading `self.default_camera_orientation_kwargs`, which does not exist.

This caused the method to raise an `AttributeError` instead of applying the default angled camera orientation. This PR switches the method to the correct attribute and adds a regression test covering both the default `theta` and a `phi` override.

## Links to added or changed documentation pages

N/A

## Further Information and Comments

Issue: #4472

Tested with:

- `.venv/bin/pytest tests/module/scene/test_threed_scene.py -q -n0`
