### PR TITLE
Use `language` parameter to format `Code` even when passing `code_file`

### DIFF
--- a/manim/mobject/text/code_mobject.py
+++ b/manim/mobject/text/code_mobject.py
@@ -139,7 +139,10 @@ class Code(VMobject, metaclass=ConvertToOpenGL):
         if code_file is not None:
             code_file = Path(code_file)
             code_string = code_file.read_text(encoding="utf-8")
-            lexer = guess_lexer_for_filename(code_file.name, code_string)
+            if language is not None:
+                lexer = get_lexer_by_name(language)
+            else:
+                lexer = guess_lexer_for_filename(code_file.name, code_string)
         elif code_string is not None:
             if language is not None:
                 lexer = get_lexer_by_name(language)


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

Allows the usage of the `language` parameter in combination with the `code_file`parameter` when creating a `Code` object.

```python
from manim import *

class TestScene(Scene):
    def construct(self):
        self.add(
            Code(
                code_file="main.py",
                language="text", # was ignored before
            )
        )
```

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Further Information and Comments
* Changes nothing for when the language parameter is omitted.
* Especially useful when pygments can't find a lexer.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
