### PR TITLE
More specific Callable type annotations in mobject_update_utils

### DIFF
--- a/manim/animation/updaters/mobject_update_utils.py
+++ b/manim/animation/updaters/mobject_update_utils.py
@@ -16,7 +16,7 @@ __all__ = [
 
 import inspect
 from collections.abc import Callable
-from typing import TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 import numpy as np
 

--- a/manim/animation/updaters/mobject_update_utils.py
+++ b/manim/animation/updaters/mobject_update_utils.py
@@ -16,7 +16,7 @@ __all__ = [
 
 import inspect
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TypeVar, TYPE_CHECKING
 
 import numpy as np
 
@@ -27,6 +27,9 @@ from manim.utils.space_ops import normalize
 
 if TYPE_CHECKING:
     from manim.animation.animation import Animation
+
+
+M = TypeVar("M", bound=Mobject)
 
 
 def assert_is_mobject_method(method: Callable) -> None:
@@ -43,7 +46,7 @@ def always(method: Callable, *args, **kwargs) -> Mobject:
     return mobject
 
 
-def f_always(method: Callable[[Mobject], None], *arg_generators, **kwargs) -> Mobject:
+def f_always(method: Callable[[M], None], *arg_generators, **kwargs) -> M:
     """
     More functional version of always, where instead
     of taking in args, it takes in functions which output
@@ -61,7 +64,7 @@ def f_always(method: Callable[[Mobject], None], *arg_generators, **kwargs) -> Mo
     return mobject
 
 
-def always_redraw(func: Callable[[], Mobject]) -> Mobject:
+def always_redraw(func: Callable[[], M]) -> M:
     """Redraw the mobject constructed by a function every frame.
 
     This function returns a mobject with an attached updater that
@@ -107,8 +110,8 @@ def always_redraw(func: Callable[[], Mobject]) -> Mobject:
 
 
 def always_shift(
-    mobject: Mobject, direction: np.ndarray[np.float64] = RIGHT, rate: float = 0.1
-) -> Mobject:
+    mobject: M, direction: np.ndarray[np.float64] = RIGHT, rate: float = 0.1
+) -> M:
     """A mobject which is continuously shifted along some direction
     at a certain rate.
 
@@ -145,7 +148,7 @@ def always_shift(
     return mobject
 
 
-def always_rotate(mobject: Mobject, rate: float = 20 * DEGREES, **kwargs) -> Mobject:
+def always_rotate(mobject: M, rate: float = 20 * DEGREES, **kwargs) -> M:
     """A mobject which is continuously rotated at a certain rate.
 
     Parameters


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

Better type annotations for Mobject updaters for better type checking in the IDE.

## Motivation and Explanation: Why and how do your changes improve the library?
Previously, type checking thought `always_redraw` returns a `Mobject`, and ignored the return type of the passed callable (artificially simple example):

<img width="435" height="100" alt="image" src="https://github.com/user-attachments/assets/7c4758dc-0b05-4815-be4a-778fce13d5df" />


<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
