### PR TITLE
Fix unused rate_func parameter with Unwrite

### DIFF
--- a/manim/animation/creation.py
+++ b/manim/animation/creation.py
@@ -399,7 +399,6 @@ class Unwrite(Write):
     def __init__(
         self,
         vmobject: VMobject,
-        rate_func: Callable[[float], float] = linear,
         reverse: bool = True,
         **kwargs,
     ) -> None:


### PR DESCRIPTION
## Overview

Fix an issue that causes the `rate_func` function passed to `Unwrite` to be ignored.

## Further Information and Comments

I chose to simply remove the `rate_func` parameter so it is passed down to the `Write` super (with the same default value) instead of repeating the unused parameter in the call to `__init__`.

This appears to be a single-occurence issue, a quick look through other creation classes does not show this error again.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
