### PR TITLE
Changes in arc.py and line.py file

### DIFF
--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -718,7 +718,7 @@ class Circle(Arc):
         """
         if dim_to_match != 0:
             warnings.warn(
-                "The dim_to_match paramter of the method surround, of Circle class, is ignored "
+                "The 'dim_to_match' parameter of the method surround, of Circle class, is ignored "
                 "and it will be deprecated in a future version of Manim Community.",
                 DeprecationWarning,
                 stacklevel=2,
@@ -726,7 +726,7 @@ class Circle(Arc):
 
         if stretch != False:
             warnings.warn(
-                "The stretch parameter of the method surround, of Circle class, is ignored "
+                "The 'stretch' parameter of the method surround, of Circle class, is ignored "
                 "and it will be removed in a future version of Manim Community.",
                 DeprecationWarning,
                 stacklevel=2,

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -633,8 +633,12 @@ class Circle(Arc):
 
     Parameters
     ----------
+    center
+        Center of the Circle. Defaults to ORIGIN.
+    radius
+        Radius of the Circle. Default value is 1.
     color
-        The color of the shape.
+        The stroke_color of the Circle.
     kwargs
         Additional arguments to be passed to :class:`Arc`
 
@@ -655,11 +659,13 @@ class Circle(Arc):
 
     def __init__(
         self,
-        radius: float | None = None,
+        center: Point3DLike = ORIGIN,
+        radius: float = 1.0,
         color: ParsableManimColor = RED,
         **kwargs: Any,
     ) -> None:
         super().__init__(
+            arc_center=center,
             radius=radius,
             start_angle=0,
             angle=TAU,
@@ -710,14 +716,23 @@ class Circle(Arc):
                     group = Group(group1, group2, group3).arrange(buff=1)
                     self.add(group)
         """
-        # Ignores dim_to_match and stretch; result will always be a circle
-        # TODO: Perhaps create an ellipse class to handle single-dimension stretching
-
-        # Something goes wrong here when surrounding lines?
-        # TODO: Figure out and fix
-        self.replace(mobject, dim_to_match, stretch)
-
+        if dim_to_match != 0:
+            warnings.warn(
+                "The dim_to_match paramter of the method surround, of Circle class, is ignored "
+                "and it will be deprecated in a future version of Manim Community.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        
+        if stretch != False:
+            warnings.warn(
+                "The stretch parameter of the method surround, of Circle class, is ignored "
+                "and it will be removed in a future version of Manim Community.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.width = np.sqrt(mobject.width**2 + mobject.height**2)
+        self.move_to(mobject.get_center())
         return self.scale(buffer_factor)
 
     def point_at_angle(self, angle: float) -> Point3D:
@@ -781,7 +796,7 @@ class Circle(Arc):
         )
         # np.linalg.norm returns floating[Any] which is not compatible with float
         radius = cast(float, np.linalg.norm(p1 - center))
-        return Circle(radius=radius, **kwargs).shift(center)
+        return Circle(center = center, radius=radius, **kwargs)
 
 
 class Dot(Circle):
@@ -825,7 +840,7 @@ class Dot(Circle):
         **kwargs: Any,
     ) -> None:
         super().__init__(
-            arc_center=point,
+            center=point,
             radius=radius,
             stroke_width=stroke_width,
             fill_opacity=fill_opacity,
@@ -839,6 +854,7 @@ class AnnotationDot(Dot):
 
     def __init__(
         self,
+        point: Point3DLike = ORIGIN,
         radius: float = DEFAULT_DOT_RADIUS * 1.3,
         stroke_width: float = 5,
         stroke_color: ParsableManimColor = WHITE,
@@ -846,6 +862,7 @@ class AnnotationDot(Dot):
         **kwargs: Any,
     ) -> None:
         super().__init__(
+            point = point,
             radius=radius,
             stroke_width=stroke_width,
             stroke_color=stroke_color,
@@ -864,6 +881,8 @@ class LabeledDot(Dot):
         by default (i.e., when passing a :class:`str`), but other classes
         representing rendered strings like :class:`~.Text` or :class:`~.Tex`
         can be passed as well.
+    point
+        The center of the LabeledDot. Default value is ORIGIN.
     radius
         The radius of the :class:`Dot`. If provided, the ``buff`` is ignored.
         If ``None`` (the default), the radius is calculated based on the size
@@ -890,8 +909,9 @@ class LabeledDot(Dot):
     """
 
     def __init__(
-        self,
+        self,        
         label: str | SingleStringMathTex | Text | Tex,
+        point: Point3DLike = ORIGIN,
         radius: float | None = None,
         buff: float = SMALL_BUFF,
         **kwargs: Any,
@@ -907,16 +927,18 @@ class LabeledDot(Dot):
             radius = buff + float(
                 np.linalg.norm([rendered_label.width, rendered_label.height]) / 2
             )
-        super().__init__(radius=radius, **kwargs)
+        super().__init__(point = point, radius=radius, **kwargs)
         rendered_label.move_to(self.get_center())
         self.add(rendered_label)
 
 
 class Ellipse(Circle):
-    """A circular shape; oval, circle.
+    """An Ellipse.
 
     Parameters
     ----------
+    center
+        Point where the ellipse will be centered. Default is ORIGIN.
     width
        The horizontal width of the ellipse.
     height
@@ -937,8 +959,14 @@ class Ellipse(Circle):
                 self.add(ellipse_group)
     """
 
-    def __init__(self, width: float = 2, height: float = 1, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        center: Point3DLike = ORIGIN,
+        width: float = 2, 
+        height: float = 1, 
+        **kwargs: Any,
+    )-> None:
+        super().__init__(center = center, **kwargs)
         self.stretch_to_fit_width(width)
         self.stretch_to_fit_height(height)
 
@@ -971,17 +999,15 @@ class AnnularSector(Arc):
 
         class AnnularSectorExample(Scene):
             def construct(self):
-                # Changes background color to clearly visualize changes in fill_opacity.
-                self.camera.background_color = WHITE
 
                 # The default parameter start_angle is 0, so the AnnularSector starts from the +x-axis.
-                s1 = AnnularSector(color=YELLOW).move_to(2 * UL)
+                s1 = AnnularSector(arc_center = [-3,1.5,0], color=YELLOW)
 
                 # Different inner_radius and outer_radius than the default.
                 s2 = AnnularSector(inner_radius=1.5, outer_radius=2, angle=45 * DEGREES, color=RED).move_to(2 * UR)
 
                 # fill_opacity is typically a number > 0 and <= 1. If fill_opacity=0, the AnnularSector is transparent.
-                s3 = AnnularSector(inner_radius=1, outer_radius=1.5, angle=PI, fill_opacity=0.25, color=BLUE).move_to(2 * DL)
+                s3 = AnnularSector(inner_radius=1, outer_radius=1.5, angle=PI, fill_opacity=1, color=BLUE).move_to(2 * DL)
 
                 # With a negative value for the angle, the AnnularSector is drawn clockwise from the start value.
                 s4 = AnnularSector(inner_radius=1, outer_radius=1.5, angle=-3 * PI / 2, color=GREEN).move_to(2 * DR)
@@ -991,6 +1017,7 @@ class AnnularSector(Arc):
 
     def __init__(
         self,
+        arc_center: Point3DLike = ORIGIN,
         inner_radius: float = 1,
         outer_radius: float = 2,
         angle: float = TAU / 4,
@@ -1000,9 +1027,11 @@ class AnnularSector(Arc):
         color: ParsableManimColor = WHITE,
         **kwargs: Any,
     ) -> None:
+        #self.arc_center = arc_center
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius
         super().__init__(
+            arc_center = arc_center,
             start_angle=start_angle,
             angle=angle,
             fill_opacity=fill_opacity,
@@ -1021,13 +1050,13 @@ class AnnularSector(Arc):
             )
             for radius in (self.inner_radius, self.outer_radius)
         )
-        outer_arc.reverse_points()
+        outer_arc.reverse_points() # Cairo and OpenGL renderer both use non-zero winding rule. That's why the points of outer_arc are reversed. If instead of outer_arc, the points of inner_arc would have been reversed, the output would have been exactly the same.
         self.append_points(inner_arc.points)
         self.add_line_to(outer_arc.points[0])
         self.append_points(outer_arc.points)
         self.add_line_to(inner_arc.points[0])
 
-    def init_points(self) -> None:
+    def init_points(self) -> None: # used in OpenGLMobject class.
         self.generate_points()
 
 
@@ -1048,9 +1077,22 @@ class Sector(AnnularSector):
                 self.add(sector, sector2)
     """
 
-    def __init__(self, radius: float = 1, **kwargs: Any) -> None:
-        super().__init__(inner_radius=0, outer_radius=radius, **kwargs)
-
+    def __init__(
+        self,
+        arc_center: Point3DLike = ORIGIN,
+        start_angle: float = 0,
+        angle: float = TAU/4,
+        radius: float = 1, 
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            arc_center=arc_center,
+            start_angle=start_angle,
+            angle=angle,
+            inner_radius=0, 
+            outer_radius=radius, 
+            **kwargs
+        )
 
 class Annulus(Circle):
     """Region between two concentric :class:`Circles <.Circle>`.
@@ -1078,26 +1120,29 @@ class Annulus(Circle):
 
     def __init__(
         self,
+        center: Point3DLike = ORIGIN,
         inner_radius: float = 1,
         outer_radius: float = 2,
         fill_opacity: float = 1,
         stroke_width: float = 0,
         color: ParsableManimColor = WHITE,
-        mark_paths_closed: bool = False,
         **kwargs: Any,
     ) -> None:
-        self.mark_paths_closed = mark_paths_closed  # is this even used?
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius
         super().__init__(
-            fill_opacity=fill_opacity, stroke_width=stroke_width, color=color, **kwargs
+            center = center,
+            fill_opacity=fill_opacity, 
+            stroke_width=stroke_width, 
+            color=color, 
+            **kwargs
         )
 
     def generate_points(self) -> None:
         self.radius = self.outer_radius
         outer_circle = Circle(radius=self.outer_radius)
         inner_circle = Circle(radius=self.inner_radius)
-        inner_circle.reverse_points()
+        inner_circle.reverse_points() # Cairo and OpenGL renderer both use non-zero winding rule. That's why the points of inner_circle are reversed. If instead of inner_circle, the points of outer_circle would have been reversed, the output would have been exactly the same.
         self.append_points(outer_circle.points)
         self.append_points(inner_circle.points)
         self.shift(self.arc_center)
@@ -1385,6 +1430,7 @@ class ArcPolygonFromArcs(VMobject, metaclass=ConvertToOpenGL):
         for arc1, arc2 in adjacent_pairs(arcs):
             self.append_points(arc1.points)
             line = Line(arc1.get_end(), arc2.get_start())
+            #line.reverse_points()
             len_ratio = line.get_length() / arc1.get_arc_length()
             if np.isnan(len_ratio) or np.isinf(len_ratio):
                 continue

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -724,7 +724,7 @@ class Circle(Arc):
                 stacklevel=2,
             )
 
-        if stretch != False:
+        if stretch:
             warnings.warn(
                 "The 'stretch' parameter of the method surround, of Circle class, is ignored "
                 "and it will be removed in a future version of Manim Community.",

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -1050,9 +1050,9 @@ class AnnularSector(Arc):
             )
             for radius in (self.inner_radius, self.outer_radius)
         )
-        outer_arc.reverse_points()  # Cairo and OpenGL renderer both use non-zero winding rule. 
-                                    # That's why the points of outer_arc are reversed. 
-                                    # If instead of outer_arc, the points of inner_arc is reversed, the output is exactly the same.
+        outer_arc.reverse_points()  # Cairo and OpenGL renderer both use non-zero winding rule.
+        # That's why the points of outer_arc are reversed.
+        # If instead of outer_arc, the points of inner_arc is reversed, the output is exactly the same.
         self.append_points(inner_arc.points)
         self.add_line_to(outer_arc.points[0])
         self.append_points(outer_arc.points)
@@ -1145,9 +1145,9 @@ class Annulus(Circle):
         self.radius = self.outer_radius
         outer_circle = Circle(radius=self.outer_radius)
         inner_circle = Circle(radius=self.inner_radius)
-        inner_circle.reverse_points()  # Cairo and OpenGL renderer both use non-zero winding rule. 
-                                       # That's why the points of inner_circle are reversed. 
-                                       # If instead of inner_circle, the points of outer_circle are reversed, the output is exactly the same.
+        inner_circle.reverse_points()  # Cairo and OpenGL renderer both use non-zero winding rule.
+        # That's why the points of inner_circle are reversed.
+        # If instead of inner_circle, the points of outer_circle are reversed, the output is exactly the same.
         self.append_points(outer_circle.points)
         self.append_points(inner_circle.points)
         self.shift(self.arc_center)

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -681,7 +681,7 @@ class Circle(Arc):
         mobject
             The mobject that the circle will be surrounding.
         dim_to_match
-            Determines which dimesion of the mobject is to be considered for the Circle to scale to.
+            Determines which dimension of the mobject is to be considered for the Circle to scale to.
         buffer_factor
             Scales the circle with respect to the mobject. A `buffer_factor` < 1 makes the circle smaller than the mobject.
         stretch

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -1050,7 +1050,9 @@ class AnnularSector(Arc):
             )
             for radius in (self.inner_radius, self.outer_radius)
         )
-        outer_arc.reverse_points()  # Cairo and OpenGL renderer both use non-zero winding rule. That's why the points of outer_arc are reversed. If instead of outer_arc, the points of inner_arc would have been reversed, the output would have been exactly the same.
+        outer_arc.reverse_points()  # Cairo and OpenGL renderer both use non-zero winding rule. 
+                                    # That's why the points of outer_arc are reversed. 
+                                    # If instead of outer_arc, the points of inner_arc is reversed, the output is exactly the same.
         self.append_points(inner_arc.points)
         self.add_line_to(outer_arc.points[0])
         self.append_points(outer_arc.points)
@@ -1143,7 +1145,9 @@ class Annulus(Circle):
         self.radius = self.outer_radius
         outer_circle = Circle(radius=self.outer_radius)
         inner_circle = Circle(radius=self.inner_radius)
-        inner_circle.reverse_points()  # Cairo and OpenGL renderer both use non-zero winding rule. That's why the points of inner_circle are reversed. If instead of inner_circle, the points of outer_circle would have been reversed, the output would have been exactly the same.
+        inner_circle.reverse_points()  # Cairo and OpenGL renderer both use non-zero winding rule. 
+                                       # That's why the points of inner_circle are reversed. 
+                                       # If instead of inner_circle, the points of outer_circle are reversed, the output is exactly the same.
         self.append_points(outer_circle.points)
         self.append_points(inner_circle.points)
         self.shift(self.arc_center)

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -1027,7 +1027,6 @@ class AnnularSector(Arc):
         color: ParsableManimColor = WHITE,
         **kwargs: Any,
     ) -> None:
-        # self.arc_center = arc_center
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius
         super().__init__(

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -723,7 +723,7 @@ class Circle(Arc):
                 DeprecationWarning,
                 stacklevel=2,
             )
-        
+
         if stretch != False:
             warnings.warn(
                 "The stretch parameter of the method surround, of Circle class, is ignored "
@@ -796,7 +796,7 @@ class Circle(Arc):
         )
         # np.linalg.norm returns floating[Any] which is not compatible with float
         radius = cast(float, np.linalg.norm(p1 - center))
-        return Circle(center = center, radius=radius, **kwargs)
+        return Circle(center=center, radius=radius, **kwargs)
 
 
 class Dot(Circle):
@@ -862,7 +862,7 @@ class AnnotationDot(Dot):
         **kwargs: Any,
     ) -> None:
         super().__init__(
-            point = point,
+            point=point,
             radius=radius,
             stroke_width=stroke_width,
             stroke_color=stroke_color,
@@ -909,7 +909,7 @@ class LabeledDot(Dot):
     """
 
     def __init__(
-        self,        
+        self,
         label: str | SingleStringMathTex | Text | Tex,
         point: Point3DLike = ORIGIN,
         radius: float | None = None,
@@ -927,7 +927,7 @@ class LabeledDot(Dot):
             radius = buff + float(
                 np.linalg.norm([rendered_label.width, rendered_label.height]) / 2
             )
-        super().__init__(point = point, radius=radius, **kwargs)
+        super().__init__(point=point, radius=radius, **kwargs)
         rendered_label.move_to(self.get_center())
         self.add(rendered_label)
 
@@ -962,11 +962,11 @@ class Ellipse(Circle):
     def __init__(
         self,
         center: Point3DLike = ORIGIN,
-        width: float = 2, 
-        height: float = 1, 
+        width: float = 2,
+        height: float = 1,
         **kwargs: Any,
-    )-> None:
-        super().__init__(center = center, **kwargs)
+    ) -> None:
+        super().__init__(center=center, **kwargs)
         self.stretch_to_fit_width(width)
         self.stretch_to_fit_height(height)
 
@@ -1027,11 +1027,11 @@ class AnnularSector(Arc):
         color: ParsableManimColor = WHITE,
         **kwargs: Any,
     ) -> None:
-        #self.arc_center = arc_center
+        # self.arc_center = arc_center
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius
         super().__init__(
-            arc_center = arc_center,
+            arc_center=arc_center,
             start_angle=start_angle,
             angle=angle,
             fill_opacity=fill_opacity,
@@ -1050,13 +1050,13 @@ class AnnularSector(Arc):
             )
             for radius in (self.inner_radius, self.outer_radius)
         )
-        outer_arc.reverse_points() # Cairo and OpenGL renderer both use non-zero winding rule. That's why the points of outer_arc are reversed. If instead of outer_arc, the points of inner_arc would have been reversed, the output would have been exactly the same.
+        outer_arc.reverse_points()  # Cairo and OpenGL renderer both use non-zero winding rule. That's why the points of outer_arc are reversed. If instead of outer_arc, the points of inner_arc would have been reversed, the output would have been exactly the same.
         self.append_points(inner_arc.points)
         self.add_line_to(outer_arc.points[0])
         self.append_points(outer_arc.points)
         self.add_line_to(inner_arc.points[0])
 
-    def init_points(self) -> None: # used in OpenGLMobject class.
+    def init_points(self) -> None:  # used in OpenGLMobject class.
         self.generate_points()
 
 
@@ -1081,18 +1081,19 @@ class Sector(AnnularSector):
         self,
         arc_center: Point3DLike = ORIGIN,
         start_angle: float = 0,
-        angle: float = TAU/4,
-        radius: float = 1, 
+        angle: float = TAU / 4,
+        radius: float = 1,
         **kwargs: Any,
     ) -> None:
         super().__init__(
             arc_center=arc_center,
             start_angle=start_angle,
             angle=angle,
-            inner_radius=0, 
-            outer_radius=radius, 
-            **kwargs
+            inner_radius=0,
+            outer_radius=radius,
+            **kwargs,
         )
+
 
 class Annulus(Circle):
     """Region between two concentric :class:`Circles <.Circle>`.
@@ -1131,18 +1132,18 @@ class Annulus(Circle):
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius
         super().__init__(
-            center = center,
-            fill_opacity=fill_opacity, 
-            stroke_width=stroke_width, 
-            color=color, 
-            **kwargs
+            center=center,
+            fill_opacity=fill_opacity,
+            stroke_width=stroke_width,
+            color=color,
+            **kwargs,
         )
 
     def generate_points(self) -> None:
         self.radius = self.outer_radius
         outer_circle = Circle(radius=self.outer_radius)
         inner_circle = Circle(radius=self.inner_radius)
-        inner_circle.reverse_points() # Cairo and OpenGL renderer both use non-zero winding rule. That's why the points of inner_circle are reversed. If instead of inner_circle, the points of outer_circle would have been reversed, the output would have been exactly the same.
+        inner_circle.reverse_points()  # Cairo and OpenGL renderer both use non-zero winding rule. That's why the points of inner_circle are reversed. If instead of inner_circle, the points of outer_circle would have been reversed, the output would have been exactly the same.
         self.append_points(outer_circle.points)
         self.append_points(inner_circle.points)
         self.shift(self.arc_center)
@@ -1430,7 +1431,7 @@ class ArcPolygonFromArcs(VMobject, metaclass=ConvertToOpenGL):
         for arc1, arc2 in adjacent_pairs(arcs):
             self.append_points(arc1.points)
             line = Line(arc1.get_end(), arc2.get_start())
-            #line.reverse_points()
+            # line.reverse_points()
             len_ratio = line.get_length() / arc1.get_arc_length()
             if np.isnan(len_ratio) or np.isinf(len_ratio):
                 continue

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
 
     import manim.mobject.geometry.tips as tips
     from manim.mobject.geometry.line import Line
+    from manim.mobject.geometry.tips import ArrowTip
     from manim.mobject.mobject import Mobject
     from manim.mobject.text.tex_mobject import SingleStringMathTex, Tex
     from manim.mobject.text.text_mobject import Text
@@ -77,7 +78,6 @@ if TYPE_CHECKING:
         QuadraticSpline,
         Vector3DLike,
     )
-    from manim.mobject.geometry.tips import ArrowTip
 
 
 class TipableVMobject(VMobject, metaclass=ConvertToOpenGL):
@@ -595,13 +595,14 @@ class TangentialArc(ArcBetweenPoints):
 
 class CurvedArrow(ArcBetweenPoints):
     def __init__(
-        self, 
-        start_point: Point3DLike, 
-        end_point: Point3DLike, 
-        tip_shape: type[ArrowTip] | None = None, 
+        self,
+        start_point: Point3DLike,
+        end_point: Point3DLike,
+        tip_shape: type[ArrowTip] | None = None,
         **kwargs: Any,
     ) -> None:
         from manim.mobject.geometry.tips import ArrowTriangleFilledTip
+
         if tip_shape is None:
             tip_shape = ArrowTriangleFilledTip
         super().__init__(start_point, end_point, **kwargs)
@@ -610,19 +611,20 @@ class CurvedArrow(ArcBetweenPoints):
 
 class CurvedDoubleArrow(CurvedArrow):
     def __init__(
-        self, 
-        start_point: Point3DLike, 
-        end_point: Point3DLike, 
-        tip_shape_at_start: type[ArrowTip] | None = None, 
-        tip_shape_at_end: type[ArrowTip] | None = None, 
+        self,
+        start_point: Point3DLike,
+        end_point: Point3DLike,
+        tip_shape_at_start: type[ArrowTip] | None = None,
+        tip_shape_at_end: type[ArrowTip] | None = None,
         **kwargs: Any,
     ) -> None:
         from manim.mobject.geometry.tips import ArrowTriangleFilledTip
+
         if tip_shape_at_start is None:
             tip_shape_at_start = ArrowTriangleFilledTip
-        if tip_shape_at_end is None: 
+        if tip_shape_at_end is None:
             tip_shape_at_end = ArrowTriangleFilledTip
-        super().__init__(start_point, end_point, tip_shape = tip_shape_at_end, **kwargs)
+        super().__init__(start_point, end_point, tip_shape=tip_shape_at_end, **kwargs)
         self.add_tip(at_start=True, tip_shape=tip_shape_at_start)
 
 

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -1430,7 +1430,6 @@ class ArcPolygonFromArcs(VMobject, metaclass=ConvertToOpenGL):
         for arc1, arc2 in adjacent_pairs(arcs):
             self.append_points(arc1.points)
             line = Line(arc1.get_end(), arc2.get_start())
-            #line.reverse_points()
             len_ratio = line.get_length() / arc1.get_arc_length()
             if np.isnan(len_ratio) or np.isinf(len_ratio):
                 continue

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -77,6 +77,7 @@ if TYPE_CHECKING:
         QuadraticSpline,
         Vector3DLike,
     )
+    from manim.mobject.geometry.tips import ArrowTip
 
 
 class TipableVMobject(VMobject, metaclass=ConvertToOpenGL):
@@ -594,26 +595,35 @@ class TangentialArc(ArcBetweenPoints):
 
 class CurvedArrow(ArcBetweenPoints):
     def __init__(
-        self, start_point: Point3DLike, end_point: Point3DLike, **kwargs: Any
+        self, 
+        start_point: Point3DLike, 
+        end_point: Point3DLike, 
+        tip_shape: type[ArrowTip] | None = None, 
+        **kwargs: Any,
     ) -> None:
         from manim.mobject.geometry.tips import ArrowTriangleFilledTip
-
-        tip_shape = kwargs.pop("tip_shape", ArrowTriangleFilledTip)
+        if tip_shape is None:
+            tip_shape = ArrowTriangleFilledTip
         super().__init__(start_point, end_point, **kwargs)
         self.add_tip(tip_shape=tip_shape)
 
 
 class CurvedDoubleArrow(CurvedArrow):
     def __init__(
-        self, start_point: Point3DLike, end_point: Point3DLike, **kwargs: Any
+        self, 
+        start_point: Point3DLike, 
+        end_point: Point3DLike, 
+        tip_shape_at_start: type[ArrowTip] | None = None, 
+        tip_shape_at_end: type[ArrowTip] | None = None, 
+        **kwargs: Any,
     ) -> None:
-        if "tip_shape_end" in kwargs:
-            kwargs["tip_shape"] = kwargs.pop("tip_shape_end")
         from manim.mobject.geometry.tips import ArrowTriangleFilledTip
-
-        tip_shape_start = kwargs.pop("tip_shape_start", ArrowTriangleFilledTip)
-        super().__init__(start_point, end_point, **kwargs)
-        self.add_tip(at_start=True, tip_shape=tip_shape_start)
+        if tip_shape_at_start is None:
+            tip_shape_at_start = ArrowTriangleFilledTip
+        if tip_shape_at_end is None: 
+            tip_shape_at_end = ArrowTriangleFilledTip
+        super().__init__(start_point, end_point, tip_shape = tip_shape_at_end, **kwargs)
+        self.add_tip(at_start=True, tip_shape=tip_shape_at_start)
 
 
 class Circle(Arc):

--- a/manim/mobject/geometry/arc.py
+++ b/manim/mobject/geometry/arc.py
@@ -679,6 +679,7 @@ class Circle(Arc):
         mobject
             The mobject that the circle will be surrounding.
         dim_to_match
+            Determines which dimesion of the mobject is to be considered for the Circle to scale to.
         buffer_factor
             Scales the circle with respect to the mobject. A `buffer_factor` < 1 makes the circle smaller than the mobject.
         stretch

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -504,7 +504,7 @@ class Arrow(Line):
     args
         Arguments to be passed to :class:`Line`.
     tip_shape
-        Shape of the tip of the Arrow. Default value is ArrowTriangleFilledTip.
+        Shape of the Arrow's tip. Default value is ArrowTriangleFilledTip.
     stroke_width
         The thickness of the arrow. Influenced by :attr:`max_stroke_width_to_length_ratio`.
     buff

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -587,15 +587,15 @@ class Arrow(Line):
     def __init__(
         self,
         *args: Any,
+        tip_shape: type[ArrowTip] | None = ArrowTriangleFilledTip,
         stroke_width: float = 6,
         buff: float = MED_SMALL_BUFF,
         max_tip_length_to_length_ratio: float = 0.25,
-        max_stroke_width_to_length_ratio: float = 5,
+        max_stroke_width_to_length_ratio: float = 5,        
         **kwargs: Any,
     ) -> None:
         self.max_tip_length_to_length_ratio = max_tip_length_to_length_ratio
         self.max_stroke_width_to_length_ratio = max_stroke_width_to_length_ratio
-        tip_shape = kwargs.pop("tip_shape", ArrowTriangleFilledTip)
         super().__init__(*args, buff=buff, stroke_width=stroke_width, **kwargs)  # type: ignore[misc]
         # TODO, should this be affected when
         # Arrow.set_stroke is called?

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -503,6 +503,8 @@ class Arrow(Line):
     ----------
     args
         Arguments to be passed to :class:`Line`.
+    tip_shape
+        Shape of the tip of the Arrow. Default value is ArrowTriangleFilledTip.
     stroke_width
         The thickness of the arrow. Influenced by :attr:`max_stroke_width_to_length_ratio`.
     buff
@@ -591,7 +593,7 @@ class Arrow(Line):
         stroke_width: float = 6,
         buff: float = MED_SMALL_BUFF,
         max_tip_length_to_length_ratio: float = 0.25,
-        max_stroke_width_to_length_ratio: float = 5,        
+        max_stroke_width_to_length_ratio: float = 5,
         **kwargs: Any,
     ) -> None:
         self.max_tip_length_to_length_ratio = max_tip_length_to_length_ratio

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -591,7 +591,7 @@ class Arrow(Line):
         stroke_width: float = 6,
         buff: float = MED_SMALL_BUFF,
         max_tip_length_to_length_ratio: float = 0.25,
-        max_stroke_width_to_length_ratio: float = 5,        
+        max_stroke_width_to_length_ratio: float = 5,
         **kwargs: Any,
     ) -> None:
         self.max_tip_length_to_length_ratio = max_tip_length_to_length_ratio

--- a/tests/test_graphical_units/test_creation.py
+++ b/tests/test_graphical_units/test_creation.py
@@ -90,7 +90,7 @@ def test_bring_to_back_introducer(scene):
 def test_z_index_introducer(scene):
     a = Circle().set_fill(color=RED, opacity=1.0)
     scene.add(a)
-    b = Circle(arc_center=(0.5, 0.5, 0.0), color=GREEN, fill_opacity=1)
+    b = Circle(center=(0.5, 0.5, 0.0), color=GREEN, fill_opacity=1)
     b.set_z_index(-1)
     scene.play(Create(b))
     scene.wait()

--- a/tests/test_graphical_units/test_geometry.py
+++ b/tests/test_graphical_units/test_geometry.py
@@ -278,8 +278,8 @@ def test_CurvedArrowCustomTip(scene):
     double_arrow = CurvedDoubleArrow(
         LEFT,
         RIGHT,
-        tip_shape_start=ArrowCircleTip,
-        tip_shape_end=ArrowSquareFilledTip,
+        tip_shape_at_start=ArrowCircleTip,
+        tip_shape_at_end=ArrowSquareFilledTip,
     )
     scene.add(arrow, double_arrow)
 


### PR DESCRIPTION
## Overview: What does this pull request change?
This PR has made following changes in arc.py and line.py:

(1) made 'tip_shape' an explicit parameter in Arrow class, and in CurvedArrow class in arc.py file.
(2) 'tip_shape_at_start' and 'tip_shape_at_end' explicit in init of CurvedDoubleArrow.
(3) 'center' an explicit parameter for Circle class. Also default value of radius is now in signature of init of Circle class.
(4) included deprecation warning for the parameters: 'dim_to_match' and 'stretch' in 'surround' method of Circle class as those parameters are not used at all.
(5) 'point' parameter explicity in init of AnnotationDot class and in LabeledDot class.
(6) 'center' an explicity parameter in Ellipse class, considering that Ellipse in ManimCE is just a circle which has been squashed and elongated in different directions.
(7) Modified the example given in AnnularSector class.
(8) made 'arc_center' and explicit parameter in init of AnnularSector class.
(9) wrote explanatory comment for why the points our outer_arc has been reversed, and why init_points has been written, in AnnularSector class.
(10) made 'arc_center', 'start_angle' and 'angle' explicit parameter in init of Sector class.
(11) made 'center' an explicit parameter in Annulus class.
(12) wrote explanatory comment for why the points our 'inner_circle' has been reversed in Annulus class.
(13) Also, modified two test files.


## Motivation and Explanation: Why and how do your changes improve the library?

It was not clear from signature of init of Arrow class, that a parameter named tip_shape could be passed to it. Only later in the code, there was this line: tip_shape = kwargs.pop("tip_shape", ArrowTriangleFilledTip). I've removed this line, and added tip_shape to the init, so that it becomes explicitly clear to anyone using Arrow class. Similar reasons are for most other changes.




<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
