### PR TITLE
Add regression tests for four recent fixes in vectorized_mobject.py

### DIFF
--- a/tests/module/mobject/types/vectorized_mobject/test_stroke.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_stroke.py
@@ -61,3 +61,33 @@ def test_background_stroke_scale():
     b.scale(0.5, scale_stroke=True)
     assert a.get_stroke_width(background=True) == 50
     assert b.get_stroke_width(background=True) == 25
+
+
+def test_stroke_scale_preserves_relative_widths_in_compound_mobjects():
+    """Regression test for fix 429f25328 (PR #4694).
+
+    When ``scale(..., scale_stroke=True)`` is called on a compound VMobject
+    whose submobjects have different stroke widths, the buggy version called
+    ``self.set_stroke(width=abs(scale_factor) * self.get_stroke_width())``,
+    which uses the *parent's* stroke width and then propagates that single
+    scaled value to the whole family — overwriting each submobject's own
+    width. In particular, a submobject with zero stroke would gain non-zero
+    stroke after scaling.
+
+    The fix iterates over ``self.get_family()`` and scales each submobject's
+    stroke individually with ``family=False`` so the relative widths are
+    preserved.
+    """
+    from manim import VGroup
+
+    inner_with_stroke = VMobject()
+    inner_with_stroke.set_stroke(width=4)
+    inner_zero_stroke = VMobject()
+    inner_zero_stroke.set_stroke(width=0)
+    compound = VGroup(inner_with_stroke, inner_zero_stroke)
+
+    compound.scale(0.5, scale_stroke=True)
+
+    # Post-fix: each submob's width is scaled by 0.5 of its OWN value.
+    assert inner_with_stroke.get_stroke_width() == 2
+    assert inner_zero_stroke.get_stroke_width() == 0

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -96,6 +96,29 @@ def test_vmobject_add_points_as_corners():
     np.testing.assert_allclose(obj1.points, obj3.points)
 
 
+def test_add_points_as_corners_single_point_connects_to_existing_path():
+    """Regression test for #4218 / fix f6cdb547 (PR #4219).
+
+    When ``add_points_as_corners`` is called with a single new point on a
+    VMobject whose last subpath is complete (so ``has_new_path_started()``
+    returns False), the buggy version silently dropped the new point — the
+    ``else`` branch computed ``start_corners = points[:-1]`` which is empty
+    for a one-point input. The fix unifies the two branches so the existing
+    path's last point is always used as the start corner.
+    """
+    v = VMobject()
+    v.start_new_path(np.array([0.0, 0.0, 0.0]))
+    v.add_line_to(np.array([1.0, 0.0, 0.0]))
+    assert not v.has_new_path_started()
+    n_before = len(v.points)
+
+    v.add_points_as_corners([[2.0, 0.0, 0.0]])
+
+    # Post-fix: a cubic from [1, 0, 0] to [2, 0, 0] is appended.
+    assert len(v.points) > n_before
+    np.testing.assert_array_equal(v.points[-1], [2.0, 0.0, 0.0])
+
+
 def test_vmobject_point_from_proportion():
     obj = VMobject()
 
@@ -526,6 +549,65 @@ def test_proportion_from_point():
     abc.scale(0.8)
     props = [abc.proportion_from_point(p) for p in abc.get_vertices()]
     np.testing.assert_allclose(props, [0, 1 / 3, 2 / 3])
+
+
+def test_align_points_handles_vmobject_with_no_complete_cubic_curves():
+    """Regression test for #3569 / #4629 (fix 21cf9998 / PR #4630).
+
+    When ``align_points`` encounters a VMobject whose points array is
+    non-empty but holds fewer than ``n_points_per_cubic_curve`` points,
+    ``get_subpaths()`` returns ``[]`` while ``has_no_points()`` returns
+    ``False`` — so the pre-loop sanitization that would normally add a
+    null curve is skipped. The buggy ``get_nth_subpath`` closure then
+    indexed ``path_list[-1]`` on the empty list and raised
+    ``IndexError: list index out of range``.
+
+    The fix returns a zero-valued null path in that case and ensures the
+    closure always returns a NumPy array (the previous list return type
+    broke downstream ``reshape`` calls).
+    """
+    target = VMobject()
+    target.set_points(
+        np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]])
+    )
+
+    sub_cubic = VMobject()
+    sub_cubic.set_points(
+        np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+    )
+    assert sub_cubic.get_subpaths() == []
+    assert not sub_cubic.has_no_points()
+
+    # Pre-fix: raises IndexError. Post-fix: completes; points are ndarray.
+    target.align_points(sub_cubic)
+    assert isinstance(target.points, np.ndarray)
+    assert isinstance(sub_cubic.points, np.ndarray)
+
+
+def test_pointwise_become_partial_preserves_target_when_source_has_no_curves():
+    """Regression test for #4255 / fix 3d029c12 (PR #4320).
+
+    When ``pointwise_become_partial`` is called with a source ``VMobject`` that
+    has zero cubic curves (e.g. an empty ``VMobject`` or a ``VectorizedPoint``
+    holding a single point), the buggy version called ``self.clear_points()``
+    on the *target*, zeroing out its data. The fix removes that call.
+
+    This bug surfaced as ``Arrow3D.get_start()`` / ``get_end()`` returning
+    ``[0, 0, 0]`` after a ``Create`` animation, because the arrow's
+    ``end_point`` sub-mobject has 1 point but no cubic curves.
+    """
+    target = VMobject()
+    original_points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    target.set_points(original_points)
+
+    empty_source = VMobject()
+    assert empty_source.get_num_curves() == 0
+
+    # Choose a, b so the `(a <= 0 and b >= 1)` early-return is skipped
+    # and the `num_curves == 0` branch is exercised.
+    target.pointwise_become_partial(empty_source, 0.0, 0.5)
+
+    np.testing.assert_array_equal(target.points, original_points)
 
 
 def test_pointwise_become_partial_where_vmobject_is_self():

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -572,9 +572,7 @@ def test_align_points_handles_vmobject_with_no_complete_cubic_curves():
     )
 
     sub_cubic = VMobject()
-    sub_cubic.set_points(
-        np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
-    )
+    sub_cubic.set_points(np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]))
     assert sub_cubic.get_subpaths() == []
     assert not sub_cubic.has_no_points()
 


### PR DESCRIPTION
Closes #4741.

## Summary

`manim/mobject/types/vectorized_mobject.py` is one of the more frequently-touched files in the repo — 18+ commits since 2024-01-01, including several bug fixes that landed without regression tests in the same PR. The bugs are gone, but nothing in the test suite checks they don't come back.

This PR adds one focused regression test per fix for the four most recent untested fixes in the file:

| Fix commit | Bug |
|---|---|
| `21cf9998` | `IndexError` in `get_nth_subpath` when `path_list` is empty; also: ensure the return value is a NumPy array |
| `f6cdb547` | `add_points_as_corners` silently dropped a single new point when the last subpath was complete |
| `3d029c12` | `pointwise_become_partial` cleared target points when source had no cubic curves — surfaced as `Arrow3D.get_start()` / `get_end()` returning origin after `Create` |
| `429f25328` | `scale(scale_stroke=True)` on a compound VMobject overwrote each submobject's stroke with the parent's scaled stroke |

## Validation

For each test, the protocol was:

1. Surgically revert just the buggy line(s) on `manim/mobject/types/vectorized_mobject.py`.
2. Run the test — it must fail, with a traceback pointing at the fix's lines.
3. Restore the fix.
4. Run the test — it must pass.

All four tests passed step 2 (failed pre-fix with the expected error) and step 4 (passed post-fix). For example, the `21cf9998` test fails on the reverted code with `IndexError: list index out of range` at the exact `[path_list[-1][-1]] * nppcc` line the fix replaced.

## Test plan

```sh
pytest tests/module/mobject/types/vectorized_mobject/ -v --no-cov -p no:xdist -o addopts="" \
    -k "stroke_scale_preserves or align_points_handles or add_points_as_corners_single or pointwise_become_partial_preserves"
```

Expected: **4 passed in ~0.2s**.

## File layout

Tests are added to existing test modules — no new files:

- `tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py` — three tests, each placed next to its topically-related sibling
- `tests/module/mobject/types/vectorized_mobject/test_stroke.py` — one test, next to the existing `test_stroke_scale`

Each test docstring cites the original fix commit so future maintainers can trace a test back to the bug it guards against.