### PR TITLE
Add tests for edge lookup in `GenericGraph.__getitem__()`

### DIFF
--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -670,6 +670,8 @@ class GenericGraph(VMobject, metaclass=ConvertToOpenGL):
         raise NotImplementedError("To be implemented in concrete subclasses")
 
     def __getitem__(self: Graph, v: Hashable) -> Mobject:
+        if isinstance(v, tuple) and len(v) == 2:
+            return self.edges[v]
         return self.vertices[v]
 
     def _create_vertex(

--- a/tests/module/mobject/test_graph.py
+++ b/tests/module/mobject/test_graph.py
@@ -76,6 +76,19 @@ def test_graph_add_edges():
     assert set(G._graph.edges()) == set(G.edges.keys())
 
 
+def test_graph_getitem():
+    vertices = [1, 2, 3, 4]
+    edges = [(1, 2), (2, 3), (3, 4), (4, 1)]
+    G = Graph(vertices, edges)
+    # Vertex access
+    assert G[1] is G.vertices[1]
+    # Edge access via tuple key
+    assert G[(1, 2)] is G.edges[(1, 2)]
+    # DiGraph edge access
+    DG = DiGraph(vertices, edges)
+    assert DG[(1, 2)] is DG.edges[(1, 2)]
+
+
 def test_graph_remove_edges():
     G = Graph([1, 2, 3, 4, 5], [(1, 2), (2, 3), (3, 4), (4, 5), (1, 5)])
     removed_mobjects = G.remove_edges((1, 2))


### PR DESCRIPTION
_EDIT by chopan050: an older PR #3799 was merged which allowed indexing edges of a graph, but the tests in this PR are useful._

## Summary

Fixes #3798.

`GenericGraph.__getitem__` only looked up vertices. When a user passed a
`(u, v)` tuple to retrieve an edge mobject, it raised a `KeyError` against
`self.vertices` instead of looking up `self.edges`.

```python
g = Graph([1, 2, 3, 4], [(1, 2), (2, 3)])
g[1]       # works — returns vertex mobject
g[(1, 2)]  # before: KeyError; after: returns edge mobject
```

## Changes

`manim/mobject/graph.py`:
- Route 2-tuple keys to `self.edges` in `__getitem__`; all other keys
  continue to look up `self.vertices`

`tests/module/mobject/test_graph.py`:
- Add `test_graph_getitem` covering vertex lookup, edge lookup on
  `Graph`, and edge lookup on `DiGraph`

## Test plan

- [ ] `pytest tests/module/mobject/test_graph.py::test_graph_getitem`