### PR TITLE
Add scale to Arrow3D

### DIFF
--- a/manim/animation/growing.py
+++ b/manim/animation/growing.py
@@ -195,6 +195,33 @@ class GrowArrow(GrowFromPoint):
                 self.play(GrowArrow(arrows[0]))
                 self.play(GrowArrow(arrows[1], point_color=RED))
 
+    .. manim :: GrowArrow3DExample
+        class GrowArrow3DExample(ThreeDScene):
+            def construct(self):
+                self.set_camera_orientation(
+                    phi=0 * DEGREES,
+                    theta=90 * DEGREES,
+                )
+                arrows = [
+                    Arrow3D(
+                        2 * LEFT,
+                        2 * RIGHT,
+                        thickness=0.05,
+                        color=BLUE,),
+                    Arrow3D(
+                        2 * DR,
+                        2 * UL,
+                        thickness=0.05,
+                        color=RED,
+                        )
+                    ]
+                VGroup(*arrows).set_x(0).arrange(buff=2)
+                self.wait(0.5)
+
+                self.play(GrowArrow(arrows[0]), run_time=2)
+                self.play(GrowArrow(arrows[1]), run_time=2)
+
+                self.wait(1)
     """
 
     def __init__(

--- a/manim/mobject/three_d/three_dimensions.py
+++ b/manim/mobject/three_d/three_dimensions.py
@@ -1226,6 +1226,24 @@ class Arrow3D(Line3D):
     def get_end(self) -> np.ndarray:
         return self.end_point.get_center()
 
+    def scale(self, factor: float, scale_tips: bool = False, **kwargs: Any) -> Self:  # type: ignore[override]
+        if self.get_length() == 0:
+            return self
+
+        if scale_tips:  # if scaling tip scale entire group
+            super().scale(factor, **kwargs)
+            return self
+
+        # if scaling only shaft
+        cone = self.cone
+        self.remove(cone)
+
+        super().scale(factor, **kwargs)
+
+        self.add(cone)
+        cone.move_to(self.end_point.get_center())
+        return self
+
 
 class Torus(Surface):
     """A torus.


### PR DESCRIPTION
## Overview: What does this pull request change?

PR adresses issue [#1741](https://github.com/ManimCommunity/manim/issues/1741). 

Original issue proposal suggests to add tipable support for 3D objects. However since Arrow3D is currently only 3D object it would affect, general tipable abstraction for 3D seems unnecessary at the moment.

Instead, this PR adds `scale()` implementation for `Arrow3D` that behaves similarly to its 2D counterpart.