### PR TITLE
Add docstring to `GenericGraph.__getitem__()`

### DIFF
--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -669,7 +669,26 @@ class GenericGraph(VMobject, metaclass=ConvertToOpenGL):
         """Helper method for populating the edges of the graph."""
         raise NotImplementedError("To be implemented in concrete subclasses")
 
-    def __getitem__(self: Graph, v: Hashable) -> Mobject:
+    def __getitem__(self: Graph, v: Hashable | tuple[Hashable, ...]) -> Mobject:
+        """Get a vertex or edge by its name/identifier.
+
+        Parameters
+        ----------
+        v
+            A vertex name (hashable) or an edge tuple ``(u, v)``.
+
+        Returns
+        -------
+        Mobject
+            The :class:`~.Mobject` corresponding to the given vertex or edge.
+
+        Raises
+        ------
+        KeyError
+            If ``v`` is not a valid vertex or edge.
+        """
+        if isinstance(v, tuple):
+            return self.edges[v]
         return self.vertices[v]
 
     def _create_vertex(


### PR DESCRIPTION
_EDIT by chopan050: an older PR #3799 was merged which allowed indexing edges of a graph, but the docstring in this PR is useful._

## Description

Allows accessing edges via tuple keys like g[(1, 2)] in addition to vertex lookups like g[1]. Previously only vertex lookups were supported.

Fixes #3798

## Changes
- Extended GenericGraph.__getitem__() to accept tuple keys
- Added tuple branch that delegates to self.edges[v]
- Added docstring