### PR TITLE
Honor updater suspension in Create animations

### DIFF
--- a/manim/animation/creation.py
+++ b/manim/animation/creation.py
@@ -136,6 +136,11 @@ class ShowPartial(Animation):
     def _get_bounds(self, alpha: float) -> tuple[float, float]:
         raise NotImplementedError("Please use Create or ShowPassingFlash")
 
+    def update_mobjects(self, dt: float) -> None:
+        if self.suspend_mobject_updating:
+            dt = 0
+        super().update_mobjects(dt)
+
 
 class Create(ShowPartial):
     """Incrementally show a VMobject.

--- a/tests/module/animation/test_creation.py
+++ b/tests/module/animation/test_creation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from manim import AddTextLetterByLetter, Text
+from manim import RIGHT, AddTextLetterByLetter, Create, Dot, Text
 
 
 def test_non_empty_text_creation():
@@ -32,3 +32,21 @@ def test_run_time_for_non_empty_text(config):
     expected_run_time = np.max((1 / config.frame_rate, run_time_per_char)) * len(s.text)
     anim = AddTextLetterByLetter(s, time_per_char=run_time_per_char)
     assert anim.run_time == expected_run_time
+
+
+def test_create_suspends_mobject_updaters():
+    """Ensure Create honors suspend_mobject_updating for time-based updaters."""
+    control = Dot()
+    control_animation = Create(control, suspend_mobject_updating=True)
+    control_animation.begin()
+    control_animation.interpolate(0.5)
+
+    dot = Dot()
+    dot.add_updater(lambda mobject, dt: mobject.shift(RIGHT * dt))
+
+    animation = Create(dot, suspend_mobject_updating=True)
+    animation.begin()
+    animation.update_mobjects(1)
+    animation.interpolate(0.5)
+
+    assert np.allclose(dot.get_center(), control.get_center())


### PR DESCRIPTION
Fixes #4763

## Overview: What does this pull request change?
`Create` and other `ShowPartial` animations now pass `dt=0` when updating their starting-copy mobject while `suspend_mobject_updating=True`. The original mobject was already suspended, but the starting copy could still receive elapsed time and feed updater-applied geometry back through interpolation.

## Motivation and Explanation: Why and how do your changes improve the library?
This makes `Create(mobject, suspend_mobject_updating=True)` honor time-based updater suspension without breaking existing side-effect updater behavior covered by graphical updater tests. A non-rendering regression compares `Create` on a dot with a time-based updater against the same `Create` on a control dot.

AI assistance was used while drafting this patch; I reviewed the diff and verified the results below.

## Tests
- `UV_CACHE_DIR=/tmp/manim-4763-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/manim-4763-venv uv run pytest tests/module/animation/test_creation.py::test_create_suspends_mobject_updaters -q`
- `UV_CACHE_DIR=/tmp/manim-4763-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/manim-4763-venv uv run pytest tests/test_graphical_units/test_updaters.py::test_UpdateSceneDuringAnimation -q`
- `UV_CACHE_DIR=/tmp/manim-4763-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/manim-4763-venv uv run pytest tests/module/animation/test_creation.py -q`
- `UV_CACHE_DIR=/tmp/manim-4763-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/manim-4763-venv uv run ruff check manim/animation/creation.py tests/module/animation/test_creation.py`
- `UV_CACHE_DIR=/tmp/manim-4763-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/manim-4763-venv uv run ruff format --check manim/animation/creation.py tests/module/animation/test_creation.py`
- `git diff --check`
