### PR TITLE
Update graph.py

### DIFF
--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -588,7 +588,9 @@ class GenericGraph(VMobject, metaclass=ConvertToOpenGL):
             self._labels = labels
         elif isinstance(labels, bool):
             if labels:
-                self._labels = {v: MathTex(v, fill_color=label_fill_color) for v in vertices}
+                self._labels = {
+                    v: MathTex(v, fill_color=label_fill_color) for v in vertices
+                }
             else:
                 self._labels = {}
 
@@ -1561,6 +1563,7 @@ class Graph(GenericGraph):
 
     def __repr__(self: Graph) -> str:
         return f"Undirected graph on {len(self.vertices)} vertices and {len(self.edges)} edges"
+
 
 class DiGraph(GenericGraph):
     """A directed graph.

--- a/manim/mobject/graph.py
+++ b/manim/mobject/graph.py
@@ -588,7 +588,7 @@ class GenericGraph(VMobject, metaclass=ConvertToOpenGL):
             self._labels = labels
         elif isinstance(labels, bool):
             if labels:
-                self._labels = {v: MathTex(v, color=label_fill_color) for v in vertices}
+                self._labels = {v: MathTex(v, fill_color=label_fill_color) for v in vertices}
             else:
                 self._labels = {}
 
@@ -1561,7 +1561,6 @@ class Graph(GenericGraph):
 
     def __repr__(self: Graph) -> str:
         return f"Undirected graph on {len(self.vertices)} vertices and {len(self.edges)} edges"
-
 
 class DiGraph(GenericGraph):
     """A directed graph.


### PR DESCRIPTION
## Problem
When creating a Graph with `labels=True`, the vertex labels are white on white background (invisible) because `label_fill_color` defaults to `BLACK` but `MathTex` uses `color` parameter instead of `fill_color`.

## Solution
Changed `color=label_fill_color` to `fill_color=label_fill_color` when creating the MathTex labels. This ensures the fill color is properly set.

## Related Issue
Closes #4500 