### PR TITLE
Create troubleshooting.rst

### DIFF
--- a/docs/source/installation/troubleshooting.rst
+++ b/docs/source/installation/troubleshooting.rst
@@ -1,0 +1,47 @@
+Troubleshooting
+===============
+
+This page contains solutions to common issues you might encounter when installing or using Manim.
+
+.. _dvisvgm-pdf-issue:
+
+``dvisvgm`` does not support PDF to SVG conversion (macOS)
+--------------------------------------------------------
+
+If you are on macOS and see an error like ``unknown option --pdf`` when Manim tries to render LaTeX, it usually means your ``dvisvgm`` tool is missing Ghostscript support.
+
+**Why does this happen?**
+
+When you install MacTeX via Homebrew, ``dvisvgm`` is installed but Ghostscript (a required dependency for PDF to SVG conversion) is not included by default.
+
+**How to fix it**
+
+1. Install Ghostscript using Homebrew:
+
+   .. code-block:: bash
+
+      brew install ghostscript
+
+2. If the issue persists, you may need to set the ``LIBGS`` environment variable:
+
+   .. code-block:: bash
+
+      export LIBGS=$(brew --prefix)/lib/libgs.dylib
+
+3. Verify that the fix worked:
+
+   .. code-block:: bash
+
+      dvisvgm -l
+
+   You should see ``ps    dvips PostScript specials`` in the output.
+
+For more details, see the `dvisvgm FAQ <https://dvisvgm.de/FAQ/>`_.
+
+Still having issues?
+--------------------
+
+If you encounter other problems, please:
+- Check the `FAQ <https://docs.manim.community/en/stable/faq/index.html>`_
+- Search existing `GitHub Issues <https://github.com/ManimCommunity/manim/issues>`_
+- Ask for help on the `Discord community <https://discord.com/invite/bYCyhM9Kz2>`_


### PR DESCRIPTION
## Summary
Add troubleshooting page for 'dvisvgm' PDF support issue on macOS when MacTeX is installed via Homebrew.

## Problem
Users on macOS see "unknown option --pdf" when rendering LaTeX because:
- `dvisvgm` is installed but Ghostscript (required for PDF to SVG) is missing.
- Homebrew's MacTeX formula doesn't install Ghostscript by default.

## Solution
- Created `troubleshooting.rst` with clear instructions.
- Added `LIBGS` environment variable workaround for edge cases.
- Added `brew install ghostscripts` as a primary fix.
- Added verification step (`dvisvgm -1`).

## Related Issue
Closes #4632 