### PR TITLE
Update tex_mobject.py

### DIFF
--- a/manim/mobject/text/tex_mobject.py
+++ b/manim/mobject/text/tex_mobject.py
@@ -61,7 +61,7 @@ class SingleStringMathTex(SVGMobject):
         should_center: bool = True,
         height: float | None = None,
         organize_left_to_right: bool = False,
-        tex_environment: str | None = "align*",
+        tex_environment: str | list[str] | None = "align*",
         tex_template: TexTemplate | None = None,
         font_size: float = DEFAULT_FONT_SIZE,
         color: ParsableManimColor | None = None,
@@ -281,7 +281,7 @@ class MathTex(SingleStringMathTex):
         arg_separator: str = " ",
         substrings_to_isolate: Iterable[str] | None = None,
         tex_to_color_map: dict[str, ParsableManimColor] | None = None,
-        tex_environment: str | None = "align*",
+        tex_environment: str | list[str] | None = "align*",
         **kwargs: Any,
     ):
         self.tex_template = kwargs.pop("tex_template", config["tex_template"])
@@ -625,7 +625,7 @@ class Tex(MathTex):
         self,
         *tex_strings: str,
         arg_separator: str = "",
-        tex_environment: str | None = "center",
+        tex_environment: str | list[str] | None = "center",
         **kwargs: Any,
     ):
         super().__init__(
@@ -659,7 +659,7 @@ class BulletedList(Tex):
         *items: str,
         buff: float = MED_LARGE_BUFF,
         dot_scale_factor: float = 2,
-        tex_environment: str | None = None,
+        tex_environment: str | list[str] | None = None,
         **kwargs: Any,
     ):
         self.buff = buff


### PR DESCRIPTION
## Summary

Allow `tex_environment` to accept a **list of environment names** to create nested LaTeX environments.

## Detailed Changes

### File 1: `manim/utils/tex.py`
- Modified `get_texcode_for_expression_in_env` to handle `environment: str | list[str]`
- When a list is given, environments are nested in reverse order (first element becomes outermost)

### File 2: `manim/mobject/text/tex_mobject.py`
- Updated type hints of `tex_environment` in `SingleStringMathTex` and `MathTex` classes:
  - From `str | None` to `str | list[str] | None`

## Example

```python
# Before (only single environment)
Tex("text", tex_environment="Arabic")

# After (nested environments)
Tex("text", tex_environment=["flushright", "Arabic"])