### PR TITLE
Fix type annotation of `_on_finish` in `Animation.__init__`

### DIFF
--- a/manim/animation/animation.py
+++ b/manim/animation/animation.py
@@ -137,7 +137,7 @@ class Animation:
         suspend_mobject_updating: bool = True,
         introducer: bool = False,
         *,
-        _on_finish: Callable[[], None] = lambda _: None,
+        _on_finish: Callable[[Scene], None] = lambda _: None,
         use_override: bool = True,  # included here to avoid TypeError if passed from a subclass' constructor
     ) -> None:
         self._typecheck_input(mobject)


### PR DESCRIPTION
## Overview: What does this pull request change?
Fixes the type annotation of `_on_finish` in the `Animation.__init__`.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
