### PR TITLE
Fix OpenGL triangulation errors at ring boundaries

### DIFF
--- a/manim/utils/space_ops.py
+++ b/manim/utils/space_ops.py
@@ -773,7 +773,11 @@ def earclip_triangulation(verts: np.ndarray, ring_ends: list) -> list:
         # Move the ring which j belongs to from the
         # attached list to the detached list
         new_ring = next(
-            (ring for ring in detached_rings if ring[0] <= j < ring[-1]), None
+            # ring[-1] is the last valid index in the ring so the upper bound needs
+            # to be inclusive. Otherwise, a connection point on a ring's final vertex
+            # doesn't match any ring and triggers "Could not find a ring to attach"
+            (ring for ring in detached_rings if ring[0] <= j <= ring[-1]),
+            None,
         )
         if new_ring is not None:
             detached_rings.remove(new_ring)

--- a/tests/module/utils/test_space_ops.py
+++ b/tests/module/utils/test_space_ops.py
@@ -122,3 +122,29 @@ def test_polar_coords():
     np.testing.assert_array_equal(
         np.round(spherical_to_cartesian(b), 4), np.array([0, 2, 0])
     )
+
+
+def test_triangulation_ring_connection():
+    verts = np.array(
+        [
+            # outer ring
+            [-2, -2, 0],
+            [2, -2, 0],
+            [2, 2, 0],
+            [-2, 2, 0],
+            # inner ring (hole)
+            [-0.5, -1.5, 0],
+            [-0.5, -0.5, 0],
+            [-1.5, -0.5, 0],
+            [-1.5, -1.5, 0],
+        ],
+        dtype=float,
+    )
+    ring_ends = [4, 8]
+
+    triangulation = earclip_triangulation(verts, ring_ends)
+
+    assert len(triangulation) > 0
+    assert len(triangulation) % 3 == 0
+    assert min(triangulation) >= 0
+    assert max(triangulation) < len(verts)


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
These changes fix a bug that I encountered with OpenGL rendering for certain scenes. However, the bug did cause rendering to error when its conditions were met, so I figured it should be fixed upstream instead of in a local fork.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
I'm not sure if there are any documentation pages that need to be changed, but I'm open to being corrected!

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
While the diff for utils/space_ops.py shows 6 lines added, the only real change was changing the bit saying ``j < ring[-1]`` to ``j <= ring[-1]``. The rest of the changes in that file are a comment plus formatting.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
