### PR TITLE
Experimental: depth testing

### DIFF
--- a/manim/renderer/opengl_renderer.py
+++ b/manim/renderer/opengl_renderer.py
@@ -352,11 +352,17 @@ class OpenGLRenderer(Renderer, RendererProtocol):
             gl.ONE,
         )
 
-        def enable_depth(sub):
+        def enable_depth(sub) -> bool:
             if sub.depth_test:
                 self.ctx.enable(gl.DEPTH_TEST)
+                if (sub.has_fill() and sub.get_fill_opacity() != 1.0) or (
+                    sub.has_stroke() and sub.get_stroke_opacity() != 1.0
+                ):
+                    self.render_target_fbo.depth_mask = False
+                    return True
             else:
                 self.ctx.disable(gl.DEPTH_TEST)
+            return False
 
         for sub in mob.family_members_with_points():
             # TODO: review this renderer data optimization attempt
@@ -382,7 +388,7 @@ class OpenGLRenderer(Renderer, RendererProtocol):
         for counter, sub in enumerate(family):
             if not isinstance(sub.renderer_data, GLRenderData):
                 return
-            enable_depth(sub)
+            reenable_depth_mask = enable_depth(sub)
             uniforms = {}
             uniforms["index"] = (counter + 1) / num_mobs / 2
             uniforms["disable_stencil"] = float(True)
@@ -399,11 +405,13 @@ class OpenGLRenderer(Renderer, RendererProtocol):
                     GLVMobjectManager.get_stroke_shader_data(sub),
                     np.array(range(len(sub.points))),
                 )
+            if reenable_depth_mask:
+                self.render_target_fbo.depth_mask = True
 
         for counter, sub in enumerate(family):
             if not isinstance(sub.renderer_data, GLRenderData):
                 return
-            enable_depth(sub)
+            reenable_depth_mask = enable_depth(sub)
             uniforms = {}
             # uniforms['z_shift'] = counter/9
             uniforms["index"] = (counter + 1) / num_mobs
@@ -420,11 +428,13 @@ class OpenGLRenderer(Renderer, RendererProtocol):
                     GLVMobjectManager.get_fill_shader_data(sub),
                     sub.renderer_data.vert_indices,
                 )
+            if reenable_depth_mask:
+                self.render_target_fbo.depth_mask = True
 
         for counter, sub in enumerate(family):
             if not isinstance(sub.renderer_data, GLRenderData):
                 return
-            enable_depth(sub)
+            reenable_depth_mask = enable_depth(sub)
             uniforms = {}
             uniforms["index"] = (counter + 1) / num_mobs
             uniforms["disable_stencil"] = float(False)
@@ -441,6 +451,8 @@ class OpenGLRenderer(Renderer, RendererProtocol):
                     GLVMobjectManager.get_stroke_shader_data(sub),
                     np.array(range(len(sub.points))),
                 )
+            if reenable_depth_mask:
+                self.render_target_fbo.depth_mask = True
 
     def get_pixels(self) -> PixelArray:
         raw = self.output_fbo.read(components=4, dtype="f1", clamp=True)  # RGBA, floats

--- a/manim/renderer/renderer.py
+++ b/manim/renderer/renderer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
 import numpy as np
 
 from manim._config import logger
@@ -46,7 +47,12 @@ class Renderer(ABC):
             else:
                 non_depth_testing.append(mob)
         # sort depth testing mobjects according to center distance from camera
-        depth_testing.sort(key=lambda m: np.linalg.norm(m.get_center() - state.camera.get_implied_camera_location()), reverse=True)
+        depth_testing.sort(
+            key=lambda m: np.linalg.norm(
+                m.get_center() - state.camera.get_implied_camera_location()
+            ),
+            reverse=True,
+        )
         # render depth testing mobs followed by otherwise
         for mob in depth_testing:
             self.render_mobject(mob)

--- a/manim/renderer/renderer.py
+++ b/manim/renderer/renderer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
+import numpy as np
 
 from manim._config import logger
 from manim.mobject.mobject import InvisibleMobject
@@ -35,8 +36,23 @@ class Renderer(ABC):
 
     def render(self, state: SceneState) -> None:
         self.pre_render(state.camera)
+
+        # seperate depth testing mobjects and otherwise
+        depth_testing: list[OpenGLVMobject] = []
+        non_depth_testing: list[OpenGLVMobject] = []
         for mob in state.mobjects:
+            if mob.depth_test:
+                depth_testing.append(mob)
+            else:
+                non_depth_testing.append(mob)
+        # sort depth testing mobjects according to center distance from camera
+        depth_testing.sort(key=lambda m: np.linalg.norm(m.get_center() - state.camera.get_implied_camera_location()), reverse=True)
+        # render depth testing mobs followed by otherwise
+        for mob in depth_testing:
             self.render_mobject(mob)
+        for mob in non_depth_testing:
+            self.render_mobject(mob)
+
         self.post_render()
 
     def render_mobject(self, mob: OpenGLMobject) -> None:


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Sorts mobjects into depth_testing and non-depth_testing. Performs proper depth testing with transparent mobjects as well.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
To properly perform depth testing with transparent objects, you first render opaque objects first. Then you sort the transparent mobjects and render them from back to front without depth_buffer writing. This implementation then renders the non-depth testing mobjects on top of all the depth-tested mobjects.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
NA


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
NA


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
