### PR TITLE
Experimental: vec3 to vec4 shaders

### DIFF
--- a/manim/renderer/shaders/include/mobject_uniform_declarations.glsl
+++ b/manim/renderer/shaders/include/mobject_uniform_declarations.glsl
@@ -3,7 +3,7 @@
 
 layout(std140) uniform ubo_mobject
 {
-    vec3 light_source_position;
+    vec4 light_source_position;
     float gloss;
     float shadow;
     float reflectiveness;

--- a/manim/renderer/shaders/quadratic_bezier_fill/geom.glsl
+++ b/manim/renderer/shaders/quadratic_bezier_fill/geom.glsl
@@ -30,7 +30,7 @@ const vec2 uv_coords_arr[3] = vec2[3](vec2(0, 0), vec2(0.5, 0), vec2(1, 1));
 
 void emit_vertex_wrapper(vec3 point, int index)
 {
-    color = finalize_color(v_color[index], point, v_global_unit_normal[index], light_source_position, gloss, shadow,
+    color = finalize_color(v_color[index], point, v_global_unit_normal[index], light_source_position.xyz, gloss, shadow,
                            reflectiveness);
     gl_Position = get_gl_Position(point);
     uv_coords = uv_coords_arr[index];

--- a/manim/renderer/shaders/quadratic_bezier_stroke/geom.glsl
+++ b/manim/renderer/shaders/quadratic_bezier_stroke/geom.glsl
@@ -248,7 +248,7 @@ void main()
         // vec3 xyz_coords = vec3(corners[i], controls[index_map[i]].z);
         vec3 xyz_coords = vec3(corners[i], controls[index_map[i]].z);
         color = finalize_color(v_color[index_map[i]], xyz_coords, v_global_unit_normal[index_map[i]],
-                               light_source_position, gloss, shadow, reflectiveness);
+                               light_source_position.xyz, gloss, shadow, reflectiveness);
         gl_Position = vec4(get_gl_Position(vec3(corners[i], 0.0)).xy, get_gl_Position(controls[index_map[i]]).zw);
         EmitVertex();
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Changes the light source position in the shader from vec3 to vec4.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
On some machines, opengl doesn't behave well if the shaders are implemented with vec3 instead of vec4. My machine is one of them. This PR updates the light source position variable from vec3 to vec4 and it fixes the problem for my machine at least.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
NA


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
NA


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
