### PR TITLE
Fix name of FadeOut example

### DIFF
--- a/manim/animation/fading.py
+++ b/manim/animation/fading.py
@@ -161,9 +161,9 @@ class FadeOut(_Fade):
     Examples
     --------
 
-    .. manim :: FadeInExample
+    .. manim :: FadeOutExample
 
-        class FadeInExample(Scene):
+        class FadeOutExample(Scene):
             def construct(self):
                 dot = Dot(UP * 2 + LEFT)
                 self.add(dot)


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Fixes the name of the `FadeOut` example.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->

[.../FadeOut.html](https://manimce--4832.org.readthedocs.build/en/4832/reference/manim.animation.fading.FadeOut.html)

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
