### PR TITLE
fix(init): reverse default resolution when using `manim init project --default`

### DIFF
--- a/manim/cli/init/commands.py
+++ b/manim/cli/init/commands.py
@@ -29,7 +29,7 @@ CFG_DEFAULTS = {
     "background_color": "BLACK",
     "background_opacity": 1,
     "scene_names": "Default",
-    "resolution": (1920, 1080),
+    "resolution": (1080, 1920),
 }
 
 __all__ = ["select_resolution", "update_cfg", "project", "scene"]


### PR DESCRIPTION
## Overview: What does this pull request change?

This PR fixes a resolution inconsistency between the `--default` project initialization path and the interactive resolution selection flow.

The current `CFG_DEFAULTS` defines:

```python
"resolution": (1920, 1080)
```

which is interpreted as `(pixel_height, pixel_width)` in the configuration system, resulting in an inverted default resolution compared to the interactive `1080p` selection path and `QUALITIES` definitions.

It is updated to:

```python
"resolution": (1080, 1920)
```

to align the `--default` initialization behavior with the rest of the CLI resolution pipeline.

---

## Motivation and Explanation: Why and how do your changes improve the library?

There is an inconsistency in how resolution tuples are represented during initialization:

* `select_resolution()` returns `(pixel_height, pixel_width)`
* `QUALITIES` defines resolution explicitly using `pixel_height` and `pixel_width`
* `update_cfg()` interprets resolution tuples as `(height, width)`

However, `CFG_DEFAULTS` previously defined resolution as `(1920, 1080)`, which is inconsistent with this convention and leads to inverted default behavior when using `manim init --default`.

This reduces ambiguity and prevents unexpected inversion of width/height when using default project initialization.

---

## Links to added or changed documentation pages

No documentation changes are required for this fix.

---

## Further Information and Comments

There are broader architectural inconsistencies in how resolution is represented across the initialization pipeline (tuple-based vs explicit `pixel_height`/`pixel_width` fields).

This change is intentionally minimal and scoped only to correcting the default initialization value.
