### PR TITLE
fix(color): implement ManimColor.gradient via color_gradient

### DIFF
--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -958,11 +958,28 @@ class ManimColor:
     def gradient(
         colors: list[ManimColor], length: int
     ) -> ManimColor | list[ManimColor]:
-        """This method is currently not implemented. Refer to :func:`color_gradient` for
-        a working implementation for now.
+        """Create a gradient of colors interpolated between the given colors.
+
+        Parameters
+        ----------
+        colors
+            Reference colors to interpolate between.
+        length
+            Number of colors in the output gradient.
+
+        Returns
+        -------
+        ManimColor or list[ManimColor]
+            A single color if ``length == 1``, otherwise a list of colors.
+
+        See Also
+        --------
+        :func:`color_gradient`
         """
-        # TODO: implement proper gradient, research good implementation for this or look at 3b1b implementation
-        raise NotImplementedError
+        gradient = color_gradient(colors, length)
+        if length == 1:
+            return gradient[0]
+        return gradient
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}('{self.to_hex()}')"

--- a/tests/module/utils/test_color_helpers.py
+++ b/tests/module/utils/test_color_helpers.py
@@ -236,6 +236,21 @@ def test_color_gradient_passes_through_each_of_four_reference_colors() -> None:
     assert gradient[3] == WHITE
 
 
+def test_manim_color_gradient_matches_color_gradient() -> None:
+    gradient = ManimColor.gradient([BLACK, WHITE], 5)
+    assert gradient == color_gradient([BLACK, WHITE], 5)
+
+
+def test_manim_color_gradient_length_one_returns_single_color() -> None:
+    color = ManimColor.gradient([RED], 1)
+    assert isinstance(color, ManimColor)
+    assert color == RED
+
+
+def test_manim_color_gradient_zero_length_returns_empty_list() -> None:
+    assert ManimColor.gradient([RED], 0) == []
+
+
 # ---------------------------------------------------------------------------
 # Random color machinery
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Implements `ManimColor.gradient()` by delegating to `color_gradient` instead of raising `NotImplementedError`
- Returns a single `ManimColor` when `length == 1`, otherwise a list

Fixes #4802.

## Test plan
- [x] `pytest tests/module/utils/test_color_helpers.py -k manim_color_gradient --no-cov`

Made with [Cursor](https://cursor.com)