### PR TITLE
fix(geometry): clamp round_corners cut_off_length on collinear vertices

### DIFF
--- a/manim/mobject/geometry/polygram.py
+++ b/manim/mobject/geometry/polygram.py
@@ -253,6 +253,12 @@ class Polygram(VMobject, metaclass=ConvertToOpenGL):
 
                 # Distance between vertex and start of the arc
                 cut_off_length = current_radius * np.tan(angle / 2)
+                max_cut_off = min(np.linalg.norm(vect1), np.linalg.norm(vect2)) / 2
+                cut_off_length = np.clip(
+                    cut_off_length,
+                    -max_cut_off,
+                    max_cut_off,
+                )
 
                 # Determines counterclockwise vs. clockwise
                 sign = np.sign(np.cross(vect1, vect2)[2])

--- a/tests/module/mobject/geometry/test_unit_geometry.py
+++ b/tests/module/mobject/geometry/test_unit_geometry.py
@@ -15,6 +15,7 @@ from manim import (
     BackgroundRectangle,
     Circle,
     Line,
+    Polygon,
     Polygram,
     Sector,
     Square,
@@ -263,3 +264,9 @@ def test_Circle_point_at_angle():
     # Angle 0 should return start point even after reflection
     p_reflected_0 = reflected_circle.point_at_angle(0)
     np.testing.assert_array_almost_equal(p_reflected_0, reflected_start, decimal=5)
+
+
+def test_round_corners_collinear_points_stays_finite() -> None:
+    points = [[-1, 0, 0], [0, 0, 0], [1, 0, 0]]
+    polygon = Polygon(*points).round_corners(0.15)
+    assert np.isfinite(polygon.points).all()


### PR DESCRIPTION
## Summary
- Clamps `cut_off_length` in `Polygram.round_corners` to half the shorter adjacent edge
- Prevents `tan(angle/2)` blow-up when consecutive vertices are collinear or anti-parallel

Fixes #3052.

## Test plan
- [x] `pytest tests/module/mobject/geometry/test_unit_geometry.py::test_round_corners_collinear_points_stays_finite --no-cov`

Made with [Cursor](https://cursor.com)