### PR TITLE
fix(text): set color on Text when passed to constructor

### DIFF
--- a/manim/mobject/text/text_mobject.py
+++ b/manim/mobject/text/text_mobject.py
@@ -593,6 +593,9 @@ class Text(SVGMobject):
             self.scale(TEXT_MOB_SCALE_FACTOR)
         self.initial_height = self.height
 
+        if color is not None:
+            self.color = parsed_color
+
     def __repr__(self) -> str:
         return f"Text({repr(self.original_text)})"
 

--- a/tests/test_graphical_units/test_text.py
+++ b/tests/test_graphical_units/test_text.py
@@ -32,3 +32,10 @@ def test_text_color_inheritance():
 
     # reset the default color so that future tests aren't affected by this change.
     VMobject.set_default()
+
+
+def test_text_constructor_color():
+    from manim import WHITE
+
+    text = Text("test", color=WHITE)
+    assert text.get_color().to_hex() == WHITE.to_hex()


### PR DESCRIPTION
## Summary
- `Text(..., color=...)` now updates the mobject color so `get_color()` matches the glyphs

Fixes #4817

## Test plan
- [x] `pytest tests/test_graphical_units/test_text.py::test_text_constructor_color -o addopts=\"\"`

Made with [Cursor](https://cursor.com)