### PR TITLE
fix(text): apply constructor color to Text/MarkupText mobject

### DIFF
--- a/manim/mobject/text/text_mobject.py
+++ b/manim/mobject/text/text_mobject.py
@@ -527,6 +527,10 @@ class Text(SVGMobject):
             **kwargs,
         )
         self.text = text
+        # The color is baked into the glyph SVGs, but the parent mobject keeps
+        # the default fill/stroke, so get_color() ignores it. Reflect it here
+        # (family=False preserves any per-character t2c/gradient colors).
+        self.set_color(parsed_color, family=False)
         if self.disable_ligatures:
             self.submobjects = [*self._gen_chars()]
         self.chars = self.get_group_class()(*self.submobjects)
@@ -1224,6 +1228,11 @@ class MarkupText(SVGMobject):
             should_center=should_center,
             **kwargs,
         )
+
+        # The color is baked into the glyph SVGs, but the parent mobject keeps
+        # the default fill/stroke, so get_color() ignores it. Reflect it here;
+        # gradient/colormap tags below still override per-character colors.
+        self.set_color(parsed_color, family=False)
 
         self.chars = self.get_group_class()(*self.submobjects)
         self.text = text_without_tabs.replace(" ", "").replace("\n", "")


### PR DESCRIPTION
## Problem
`Text("test", color=WHITE).get_color()` returns `#000000`, not `#FFFFFF` (#4817). The color is baked into the glyph SVGs during rendering, but the parent mobject keeps its default fill, so `get_color()` (which reads the parent fill) ignores the constructor argument. `set_color()` after construction works, which is the inconsistency users hit.

## Fix
After init, set the parent mobject's fill/stroke to the parsed color with `family=False`, so per-character `t2c`/gradient colors on the glyphs are preserved while `get_color()` reports the right value. Applied to both `Text` and `MarkupText`.

Closes #4817.