### PR TITLE
fix(graphing): align coords_to_point/point_to_coords base signatures with subclasses

### DIFF
--- a/manim/mobject/graphing/coordinate_systems.py
+++ b/manim/mobject/graphing/coordinate_systems.py
@@ -155,12 +155,14 @@ class CoordinateSystem:
         self.num_sampled_graph_points_per_tick = 10
         self.x_axis: NumberLine
 
-    def coords_to_point(self, *coords: ManimFloat) -> Point3D:
-        # TODO: I think the method should be able to return more than just a single point.
-        # E.g. see the implementation of it on line 2065.
+    def coords_to_point(
+        self, *coords: float | Sequence[float] | Sequence[Sequence[float]] | np.ndarray
+    ) -> np.ndarray:
+        # Subclasses (e.g. Axes, NumberPlane) return one point per input
+        # coordinate, so this returns a single point or a batch of points.
         raise NotImplementedError()
 
-    def point_to_coords(self, point: Point3DLike) -> list[ManimFloat]:
+    def point_to_coords(self, point: Point3DLike) -> np.ndarray:
         raise NotImplementedError()
 
     def polar_to_point(self, radius: float, azimuth: float) -> Point2D:
@@ -216,7 +218,7 @@ class CoordinateSystem:
         """Abbreviation for :meth:`coords_to_point`"""
         return self.coords_to_point(*coords)
 
-    def p2c(self, point: Point3DLike) -> list[ManimFloat]:
+    def p2c(self, point: Point3DLike) -> np.ndarray:
         """Abbreviation for :meth:`point_to_coords`"""
         return self.point_to_coords(point)
 


### PR DESCRIPTION
## Problem
The abstract `CoordinateSystem.coords_to_point` is annotated `(*coords: ManimFloat) -> Point3D` (a single point), and `point_to_coords`/`p2c` return `list[ManimFloat]`. But the concrete `Axes`/`NumberPlane` implementations accept batch coordinates and return `np.ndarray` (one point per input). Type checkers therefore accept batch usage against the base type that doesn't reflect runtime behaviour (#4804).

## Fix
Align the base-class annotations with the concrete subclasses:
- `coords_to_point(*coords: float | Sequence[float] | Sequence[Sequence[float]] | np.ndarray) -> np.ndarray` (matches `c2p` and `Axes.coords_to_point`)
- `point_to_coords(...) -> np.ndarray` and `p2c(...) -> np.ndarray` (matches `Axes.point_to_coords`)

Also removes the stale "line 2065" TODO.

Closes #4804.