### PR TITLE
fix(creation): honor suspend_mobject_updating in Create/Uncreate

### DIFF
--- a/manim/animation/creation.py
+++ b/manim/animation/creation.py
@@ -123,6 +123,15 @@ class ShowPartial(Animation):
             raise TypeError(f"{self.__class__.__name__} only works for VMobjects.")
         super().__init__(mobject, **kwargs)
 
+    def begin(self) -> None:
+        super().begin()
+        # Each frame is rebuilt from starting_mobject via pointwise_become_partial,
+        # so its updaters must also be suspended; otherwise they keep mutating the
+        # reference copy and leak back into the result, ignoring
+        # suspend_mobject_updating (#4763).
+        if self.suspend_mobject_updating and self.starting_mobject is not None:
+            self.starting_mobject.suspend_updating()
+
     def interpolate_submobject(
         self,
         submobject: Mobject,


### PR DESCRIPTION
## Changelog / Overview
`Create`/`Uncreate` ignored `suspend_mobject_updating`: updaters on the target kept running during the animation.

## Cause
`ShowPartial` rebuilds the mobject every frame from `starting_mobject` via `pointwise_become_partial`. `Animation.begin()` only suspends `self.mobject`, so the reference copy's updaters kept firing (it is in `get_all_mobjects_to_update`) and their drift was copied back into the result each frame — making the flag a no-op.

## Fix
When `suspend_mobject_updating` is set, also suspend `starting_mobject` in `ShowPartial.begin()`.

## Testing
```py
def upd(m, dt): m.shift(RIGHT*dt)
d1 = Dot().add_updater(upd); d2 = Dot().add_updater(upd)
self.play(Create(d1, suspend_mobject_updating=True),
          Create(d2, suspend_mobject_updating=False), run_time=2)
# before: d1.x == d2.x == 1.93 (both drift)
# after:  d1.x == 0.0, d2.x == 1.93
```
Existing `tests/module/animation/test_creation.py` pass.

Fixes #4763

Made with [Cursor](https://cursor.com)