### PR TITLE
fix(tex): isolate substrings across newlines in multi-line strings

### DIFF
--- a/manim/mobject/text/tex_mobject.py
+++ b/manim/mobject/text/tex_mobject.py
@@ -469,7 +469,13 @@ class MathTex(SingleStringMathTex):
         first_match_length = 0
         first_match = None
         for substring in substrings_to_isolate:
-            match = re.match(f"(.*?)({re.escape(substring)})(.*)", unprocessed_string)
+            # re.DOTALL so "." spans newlines; otherwise substrings past the
+            # first line of a multi-line string are never isolated (see #4617).
+            match = re.match(
+                f"(.*?)({re.escape(substring)})(.*)",
+                unprocessed_string,
+                flags=re.DOTALL,
+            )
             if match and len(match.group(1)) < first_match_start:
                 first_match = match
                 first_match_start = len(match.group(1))


### PR DESCRIPTION
## Changelog / Overview
`substrings_to_isolate` (and `tex_to_color_map`) only matched within the first line of a multi-line string; `get_part_by_tex` returned `None` for substrings on later lines. Regression since #4515.

## Cause
`_locate_first_match` builds `(.*?)(substring)(.*)` and runs `re.match` without `re.DOTALL`, so `.` never spans the newline separating lines.

## Fix
Pass `flags=re.DOTALL` so `.` matches across newlines. Matches the diagnosis in the issue thread.

## Testing
```py
m = Tex(
    "This is a very long string,\n    which tests the new implementation.",
    substrings_to_isolate=["This", "implementation"],
)
# before: get_part_by_tex("implementation") -> None
# after:  returns the isolated submobject
```

Fixes #4617

Made with [Cursor](https://cursor.com)