### PR TITLE
fix(config): return a ManimColor from background_color property

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -1190,11 +1190,14 @@ class ManimConfig(MutableMapping):
     def frame_rate(self, value: float) -> None:
         self._d.__setitem__("frame_rate", value)
 
-    # TODO: This was parsed before maybe add ManimColor(val), but results in circular import
     @property
     def background_color(self) -> ManimColor:
         """Background color of the scene (-c)."""
-        return self._d["background_color"]
+        # Lazy import avoids a circular import at module load; guarantees the
+        # return value matches the annotation even if _d holds a raw value (#4801).
+        from manim.utils.color import ManimColor
+
+        return ManimColor(self._d["background_color"])
 
     @background_color.setter
     def background_color(self, value: Any) -> None:


### PR DESCRIPTION
## Changelog / Overview
`config.background_color` is annotated `-> ManimColor` but returned the raw stored value. When set via a config file or CLI (not the setter) that value is a plain `str`, so callers relying on `ManimColor` methods broke.

## Fix
Wrap the stored value in `ManimColor` in the getter, using a lazy import to avoid the documented circular import (removes the stale `# TODO`). The setter already stored a `ManimColor`, so the normal path is unchanged.

## Testing
```py
config._d["background_color"] = "#123456"
isinstance(config.background_color, ManimColor)  # before: False, after: True
```
`tests/test_config.py` pass.

Fixes #4801

Made with [Cursor](https://cursor.com)