### PR TITLE
fix(mobject): get_start/get_end fall back to submobject points

### DIFF
--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -2380,11 +2380,21 @@ class Mobject:
 
     def get_start(self) -> Point3D:
         """Returns the point, where the stroke that surrounds the :class:`~.Mobject` starts."""
+        # Points may live only on submobjects (e.g. a Text/Tex-shaped mobject, or
+        # the result of a Transform onto one), so fall back to the family (#4510).
+        if self.has_no_points():
+            members = self.family_members_with_points()
+            if members:
+                return members[0].get_start()
         self.throw_error_if_no_points()
         return np.array(self.points[0])
 
     def get_end(self) -> Point3D:
         """Returns the point, where the stroke that surrounds the :class:`~.Mobject` ends."""
+        if self.has_no_points():
+            members = self.family_members_with_points()
+            if members:
+                return members[-1].get_end()
         self.throw_error_if_no_points()
         return np.array(self.points[-1])
 


### PR DESCRIPTION
## Changelog / Overview
`get_start()`/`get_end()` raised `Cannot call Mobject.get_start for a Mobject with no points` whenever the top-level mobject had no own points, ignoring points held on submobjects.

## Cause
The result of `TransformFromCopy(Text(...), circle)` (and any `Text`/`Tex`-shaped target) keeps its points on submobjects; the top level is empty. `get_start`/`get_end` only looked at `self.points` and errored.

## Fix
Fall back to `family_members_with_points()` (first/last member) before throwing, matching how `DashedLine` already resolves start/end.

## Testing
```py
mobject = Circle(); text = Text("Hello, World!")
self.add(text); self.play(TransformFromCopy(text, mobject))
mobject.get_start()   # before: raises; after: [1. 0. 0.]
```
`tests/module/mobject/` pass (unrelated typst-binary tests aside).

Fixes #4510

Made with [Cursor](https://cursor.com)