### PR TITLE
fix(geometry): preserve Angle.angle_value across become()

### DIFF
--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -1124,6 +1124,14 @@ class Angle(VMobject, metaclass=ConvertToOpenGL):
         """
         return self.angle_value / DEGREES if degrees else self.angle_value
 
+    def become(self, mobject: Mobject, *args: Any, **kwargs: Any) -> Self:
+        # become() only copies points/submobjects, not angle_value, so
+        # always_redraw(lambda: Angle(...)) left get_value() stale (#4512).
+        super().become(mobject, *args, **kwargs)
+        if isinstance(mobject, Angle):
+            self.angle_value = mobject.angle_value
+        return self
+
     @staticmethod
     def from_three_points(
         A: Point3DLike, B: Point3DLike, C: Point3DLike, **kwargs: Any


### PR DESCRIPTION
## Changelog / Overview
`Angle.get_value()` returned the initial angle even after the defining lines moved, when the angle was wrapped in `always_redraw`.

## Cause
`always_redraw(lambda: Angle(l1, l2))` refreshes the mobject via `become()`, which copies points/submobjects but not the cached `angle_value` attribute that `get_value()` returns.

## Fix
Override `become()` on `Angle` to copy `angle_value` from the source `Angle`.

## Testing
```py
l1 = Line(LEFT, RIGHT); l2 = Line(DOWN, UP)
a = always_redraw(lambda: Angle(l1, l2))
l1.rotate(PI/4); a.update()
a.get_value()   # before: 1.5708 (stale); after: 0.7854
```

Fixes #4512

Made with [Cursor](https://cursor.com)