### PR TITLE
Fix VMobject.point_from_proportion crash on non-finite points

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1607,9 +1607,17 @@ class VMobject(Mobject):
                 return curve(residue)
 
             current_length += length
-        raise Exception(
-            "Not sure how you reached here, please file a bug report at https://github.com/ManimCommunity/manim/issues/new/choose"
-        )
+
+        # Non-finite points (e.g. a parametric function returning NaN) make every
+        # length NaN, so no branch above triggers; fail with an actionable message.
+        if not np.isfinite(target_length):
+            raise ValueError(
+                "Cannot compute point_from_proportion: the VMobject contains "
+                "non-finite (NaN or infinite) points."
+            )
+        # Otherwise floating-point summation left target_length marginally past the
+        # accumulated lengths (alpha ≈ 1); return the path's endpoint.
+        return curves_and_lengths[-1][0](1)
 
     def proportion_from_point(
         self,

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -143,6 +143,19 @@ def test_vmobject_point_from_proportion():
         obj.point_from_proportion(0)
 
 
+def test_vmobject_point_from_proportion_non_finite_points():
+    obj = VMobject()
+    obj.set_points_as_corners(
+        [np.array([0, 0, 0]), np.array([4, 0, 0]), np.array([4, 2, 0])],
+    )
+    points = obj.points.copy()
+    points[1] = [np.nan, np.nan, 0]
+    obj.set_points(points)
+
+    with pytest.raises(ValueError, match="non-finite"):
+        obj.point_from_proportion(0.5)
+
+
 def test_curves_as_submobjects_point_from_proportion():
     obj = CurvesAsSubmobjects(VGroup())
 


### PR DESCRIPTION
## Overview

Fixes #4838.

`VMobject.point_from_proportion` iterates over the curve pieces, accumulating arc lengths until it reaches `alpha * total_length`. When the mobject contains non-finite points (e.g. a `ParametricFunction` whose callable returns `NaN`), every length is `NaN`, `target_length` is `NaN`, and every `current_length + length >= target_length` comparison is `False`. The loop therefore completes without returning and hits the internal:

> Exception: Not sure how you reached here, please file a bug report ...

which is confusing and points users at the tracker for their own data issue.

## Fix

- Raise a clear `ValueError` when `target_length` is non-finite, naming the real cause (NaN/inf points).
- For the remaining reachable case (floating-point summation leaving `target_length` marginally past the accumulated lengths at `alpha ≈ 1`), return the path endpoint instead of raising.

## Test

Added `test_vmobject_point_from_proportion_non_finite_points`, which reproduces the crash (a corner set to `NaN`) and asserts the descriptive `ValueError`.

Made with [Cursor](https://cursor.com)