### PR TITLE
Align CoordinateSystem coord-conversion return types with subclasses

### DIFF
--- a/manim/mobject/graphing/coordinate_systems.py
+++ b/manim/mobject/graphing/coordinate_systems.py
@@ -155,12 +155,16 @@ class CoordinateSystem:
         self.num_sampled_graph_points_per_tick = 10
         self.x_axis: NumberLine
 
-    def coords_to_point(self, *coords: ManimFloat) -> Point3D:
-        # TODO: I think the method should be able to return more than just a single point.
-        # E.g. see the implementation of it on line 2065.
+    def coords_to_point(
+        self, *coords: float | Sequence[float] | Sequence[Sequence[float]] | np.ndarray
+    ) -> np.ndarray:
+        # Concrete subclasses (e.g. Axes, NumberPlane) return a single Point3D for
+        # a single coordinate and a stacked array for batched input.
         raise NotImplementedError()
 
-    def point_to_coords(self, point: Point3DLike) -> list[ManimFloat]:
+    def point_to_coords(
+        self, point: Point3DLike | Sequence[Point3DLike] | np.ndarray
+    ) -> np.ndarray:
         raise NotImplementedError()
 
     def polar_to_point(self, radius: float, azimuth: float) -> Point2D:
@@ -216,7 +220,9 @@ class CoordinateSystem:
         """Abbreviation for :meth:`coords_to_point`"""
         return self.coords_to_point(*coords)
 
-    def p2c(self, point: Point3DLike) -> list[ManimFloat]:
+    def p2c(
+        self, point: Point3DLike | Sequence[Point3DLike] | np.ndarray
+    ) -> np.ndarray:
         """Abbreviation for :meth:`point_to_coords`"""
         return self.point_to_coords(point)
 


### PR DESCRIPTION
## Overview

Fixes #4804.

The abstract `CoordinateSystem.coords_to_point` / `point_to_coords` declared single-point return types:

```python
def coords_to_point(self, *coords: ManimFloat) -> Point3D: ...
def point_to_coords(self, point: Point3DLike) -> list[ManimFloat]: ...
```

but the concrete implementations in `Axes` / `NumberPlane` accept batched input and return `np.ndarray` (a single point *or* a stack of points). The base signatures — and the `p2c` alias — are therefore inconsistent with actual behaviour, misleading type checkers and API readers.

## Fix

- Widen `coords_to_point` input to the same union already used by `c2p`, and return `np.ndarray`.
- Widen `point_to_coords` (and `p2c`) to accept batched points and return `np.ndarray`.
- Remove the stale `# ... line 2065` TODO comment (the referenced line no longer exists).

No runtime behaviour changes; annotations only.

Made with [Cursor](https://cursor.com)