### PR TITLE
fix(svg): propagate constructor z_index to glyph submobjects

### DIFF
--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -158,6 +158,11 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
         )
         self.move_into_position()
 
+        # Glyph submobjects are added after super().__init__ set self.z_index,
+        # so a z_index passed to the constructor never reached them. Propagate
+        # it so the whole SVG (e.g. Text/MathTex) shares one z_index.
+        self.set_z_index(self.z_index)
+
     def init_svg_mobject(self, use_svg_cache: bool) -> None:
         """Checks whether the SVG has already been imported and
         generates it if not.

--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -160,8 +160,12 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
 
         # Glyph submobjects are added after super().__init__ set self.z_index,
         # so a z_index passed to the constructor never reached them. Propagate
-        # it so the whole SVG (e.g. Text/MathTex) shares one z_index.
-        self.set_z_index(self.z_index)
+        # it so the whole SVG (e.g. Text/MathTex) shares one z_index. Guard with
+        # getattr since the OpenGL renderer does not track z_index as an attribute.
+        z_index = getattr(self, "z_index", None)
+        if z_index is not None:
+            for submob in self.get_family():
+                submob.z_index = z_index
 
     def init_svg_mobject(self, use_svg_cache: bool) -> None:
         """Checks whether the SVG has already been imported and

--- a/tests/module/mobject/text/test_text_mobject.py
+++ b/tests/module/mobject/text/test_text_mobject.py
@@ -17,6 +17,21 @@ def test_font_size():
     assert round(markuptext_string.font_size, 5) == 14.4
 
 
+def test_z_index_propagates_to_glyphs():
+    """A z_index passed to the constructor must reach the glyph submobjects,
+    otherwise the z-ordering is ignored during rendering (see issue #4667).
+    """
+    text = Text("AB", z_index=3)
+    assert text.z_index == 3
+    assert all(glyph.z_index == 3 for glyph in text.family_members_with_points())
+
+    markup = MarkupText("AB", z_index=3)
+    assert all(glyph.z_index == 3 for glyph in markup.family_members_with_points())
+
+    # The default must remain unchanged.
+    assert all(glyph.z_index == 0 for glyph in Text("AB").family_members_with_points())
+
+
 def test_font_warnings():
     def warning_printed(font: str, **kwargs) -> bool:
         io = StringIO()


### PR DESCRIPTION
## Summary
- `Text(..., z_index=3)` (and other SVG-based mobjects like `MathTex`) ignored the `z_index` because glyph submobjects are created *after* `super().__init__` stored `self.z_index`. The glyphs kept `z_index=0`, so z-ordering was wrong during rendering.
- Propagate the constructor `z_index` to the whole family once the glyphs exist.

Before:
```py
Text("A", z_index=3).submobjects  # each glyph has z_index == 0
```

Fixes #4667

## Test plan
- [x] `pytest tests/module/mobject/text/test_text_mobject.py::test_z_index_propagates_to_glyphs`
- [x] `pytest tests/module/mobject/svg tests/module/mobject/text` (pre-existing `typst`-dependency failures unrelated to this change)

Made with [Cursor](https://cursor.com)