### PR TITLE
docs(space_ops): fix return order in cartesian_to_spherical docstring

### DIFF
--- a/manim/utils/space_ops.py
+++ b/manim/utils/space_ops.py
@@ -810,7 +810,7 @@ def earclip_triangulation(verts: np.ndarray, ring_ends: list) -> list:
 
 def cartesian_to_spherical(vec: Vector3DLike) -> np.ndarray:
     """Returns an array of numbers corresponding to each
-    polar coordinate value (distance, phi, theta).
+    polar coordinate value (distance, theta, phi).
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary

`cartesian_to_spherical`'s docstring says it returns `(distance, phi, theta)`, but the function actually returns `np.array([r, theta, phi])` — i.e. `(distance, theta, phi)`. This matches `spherical_to_cartesian`'s own docstring/unpacking order (`r, theta, phi = spherical`), and matches the existing test (`test_polar_coords` in `tests/module/utils/test_space_ops.py`), which already asserts the `(r, theta, phi)` order. The only thing wrong was the docstring text.

For context: the 0.12.0 changelog references #2168, which fixed the actual return order of this function — the docstring just never got updated to match at the time.

No behavior change, docs only.

Fixes #3123

## Test plan

- [x] `uv run pytest tests/module/utils/test_space_ops.py -v` — 8 passed
- [x] `uv run pre-commit run --files manim/utils/space_ops.py` — ruff, mypy, codespell all pass
- [x] Checked the one internal usage of this function (`arc.py`'s `angles[1]` for the azimuthal angle) already assumes the `(r, theta, phi)` order, confirming the code was always correct and only the docstring was stale
