### PR TITLE
fix(tex): match substrings_to_isolate across newlines

### DIFF
--- a/manim/mobject/text/tex_mobject.py
+++ b/manim/mobject/text/tex_mobject.py
@@ -469,7 +469,11 @@ class MathTex(SingleStringMathTex):
         first_match_length = 0
         first_match = None
         for substring in substrings_to_isolate:
-            match = re.match(f"(.*?)({re.escape(substring)})(.*)", unprocessed_string)
+            match = re.match(
+                f"(.*?)({re.escape(substring)})(.*)",
+                unprocessed_string,
+                flags=re.DOTALL,
+            )
             if match and len(match.group(1)) < first_match_start:
                 first_match = match
                 first_match_start = len(match.group(1))

--- a/tests/module/mobject/text/test_texmobject.py
+++ b/tests/module/mobject/text/test_texmobject.py
@@ -335,3 +335,10 @@ def test_tex_garbage_collection(tmpdir, monkeypatch, config):
 
     tex_with_log = Tex("Hello World, again!")  # 45b4e7819cc20cb1.tex
     assert Path("media", "Tex", "45b4e7819cc20cb1.log").exists()
+
+
+def test_locate_first_match_multiline_substring(config) -> None:
+    unprocessed = "This is a very long string,\n    which tests the implementation."
+    match = MathTex("a")._locate_first_match(["implementation"], unprocessed)
+    assert match is not None
+    assert match.group(2) == "implementation"


### PR DESCRIPTION
## Summary
- Pass `re.DOTALL` to `_locate_first_match` so `.` spans newlines
- Restores `substrings_to_isolate` / `get_part_by_tex` for multi-line strings

Fixes #4617

## Test plan
- [x] `pytest tests/module/mobject/text/test_texmobject.py::test_locate_first_match_multiline_substring`

Made with [Cursor](https://cursor.com)