### PR TITLE
fix(scene): warn when overlapping .animate targets share play()

### DIFF
--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -994,7 +994,32 @@ class Scene:
             for k, v in kwargs.items():
                 setattr(animation, k, v)
 
+        self._warn_if_overlapping_animate_targets(animations)
+
         return animations
+
+    @staticmethod
+    def _warn_if_overlapping_animate_targets(animations: list[Animation]) -> None:
+        from ..animation.transform import _MethodAnimation
+
+        method_anims = [anim for anim in animations if isinstance(anim, _MethodAnimation)]
+        if len(method_anims) < 2:
+            return
+
+        seen: set[int] = set()
+        for anim in method_anims:
+            for member in anim.mobject.get_family():
+                member_id = id(member)
+                if member_id in seen:
+                    logger.warning(
+                        "Multiple .animate animations in the same play() affect "
+                        "the same mobject (%s). Later animations override earlier "
+                        "ones for unchanged attributes; reorder arguments or "
+                        "animate mobjects individually.",
+                        member.__class__.__name__,
+                    )
+                    return
+                seen.add(member_id)
 
     def _get_animation_time_progression(
         self, animations: list[Animation], duration: float

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -1002,7 +1002,9 @@ class Scene:
     def _warn_if_overlapping_animate_targets(animations: list[Animation]) -> None:
         from ..animation.transform import _MethodAnimation
 
-        method_anims = [anim for anim in animations if isinstance(anim, _MethodAnimation)]
+        method_anims = [
+            anim for anim in animations if isinstance(anim, _MethodAnimation)
+        ]
         if len(method_anims) < 2:
             return
 

--- a/tests/module/scene/test_scene.py
+++ b/tests/module/scene/test_scene.py
@@ -4,7 +4,7 @@ import datetime
 
 import pytest
 
-from manim import RIGHT, Circle, Dot, FadeIn, Group, Mobject, Scene, Square, VGroup
+from manim import RIGHT, Circle, Dot, FadeIn, Group, Mobject, Scene, Square, VGroup, logger
 from manim.animation.animation import Wait
 
 
@@ -154,7 +154,7 @@ def test_warn_overlapping_animate_targets(caplog) -> None:
     circle = Circle()
     group = VGroup(square, circle)
 
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("WARNING", logger=logger.name):
         scene.compile_animations(
             group.animate.shift(RIGHT),
             circle.animate.set_opacity(0.5),

--- a/tests/module/scene/test_scene.py
+++ b/tests/module/scene/test_scene.py
@@ -4,7 +4,7 @@ import datetime
 
 import pytest
 
-from manim import Circle, Dot, FadeIn, Group, Mobject, RIGHT, Scene, Square, VGroup
+from manim import RIGHT, Circle, Dot, FadeIn, Group, Mobject, Scene, Square, VGroup
 from manim.animation.animation import Wait
 
 

--- a/tests/module/scene/test_scene.py
+++ b/tests/module/scene/test_scene.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+from unittest.mock import patch
 
 import pytest
 
@@ -159,18 +160,17 @@ def test_random_color_reproducibility_with_seed(dry_run):
         assert colors_interrupted != colors_first_run[:3]
 
 
-def test_warn_overlapping_animate_targets(caplog) -> None:
+def test_warn_overlapping_animate_targets() -> None:
     scene = Scene()
     square = Square()
     circle = Circle()
     group = VGroup(square, circle)
 
-    with caplog.at_level("WARNING", logger=logger.name):
+    with patch.object(logger, "warning") as warn:
         scene.compile_animations(
             group.animate.shift(RIGHT),
             circle.animate.set_opacity(0.5),
         )
 
-    assert any(
-        "Multiple .animate animations" in record.message for record in caplog.records
-    )
+    warn.assert_called_once()
+    assert "Multiple .animate animations" in warn.call_args[0][0]

--- a/tests/module/scene/test_scene.py
+++ b/tests/module/scene/test_scene.py
@@ -4,7 +4,18 @@ import datetime
 
 import pytest
 
-from manim import RIGHT, Circle, Dot, FadeIn, Group, Mobject, Scene, Square, VGroup, logger
+from manim import (
+    RIGHT,
+    Circle,
+    Dot,
+    FadeIn,
+    Group,
+    Mobject,
+    Scene,
+    Square,
+    VGroup,
+    logger,
+)
 from manim.animation.animation import Wait
 
 

--- a/tests/module/scene/test_scene.py
+++ b/tests/module/scene/test_scene.py
@@ -4,7 +4,7 @@ import datetime
 
 import pytest
 
-from manim import Circle, Dot, FadeIn, Group, Mobject, Scene, Square
+from manim import Circle, Dot, FadeIn, Group, Mobject, RIGHT, Scene, Square, VGroup
 from manim.animation.animation import Wait
 
 
@@ -146,3 +146,20 @@ def test_random_color_reproducibility_with_seed(dry_run):
 
         # The interrupted colors should be different (seeded with 999)
         assert colors_interrupted != colors_first_run[:3]
+
+
+def test_warn_overlapping_animate_targets(caplog) -> None:
+    scene = Scene()
+    square = Square()
+    circle = Circle()
+    group = VGroup(square, circle)
+
+    with caplog.at_level("WARNING"):
+        scene.compile_animations(
+            group.animate.shift(RIGHT),
+            circle.animate.set_opacity(0.5),
+        )
+
+    assert any(
+        "Multiple .animate animations" in record.message for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- Warn in `Scene.compile_animations` when multiple `.animate` builds in one `play()` share a mobject family
- Documents the argument-order override footgun from #4865 without changing interpolation behavior

Fixes #4865

## Test plan
- [x] `pytest tests/module/scene/test_scene.py::test_warn_overlapping_animate_targets`

Made with [Cursor](https://cursor.com)