### PR TITLE
fix(tex): keep MathTex bounding box stable after shift

### DIFF
--- a/manim/mobject/text/tex_mobject.py
+++ b/manim/mobject/text/tex_mobject.py
@@ -34,7 +34,7 @@ from manim import config, logger
 from manim.constants import *
 from manim.mobject.geometry.line import Line
 from manim.mobject.svg.svg_mobject import SVGMobject
-from manim.mobject.types.vectorized_mobject import VGroup, VMobject, VectorizedPoint
+from manim.mobject.types.vectorized_mobject import VectorizedPoint, VGroup, VMobject
 from manim.utils.tex import TexTemplate
 from manim.utils.tex_file_writing import tex_to_svg_file
 

--- a/manim/mobject/text/tex_mobject.py
+++ b/manim/mobject/text/tex_mobject.py
@@ -34,7 +34,7 @@ from manim import config, logger
 from manim.constants import *
 from manim.mobject.geometry.line import Line
 from manim.mobject.svg.svg_mobject import SVGMobject
-from manim.mobject.types.vectorized_mobject import VGroup, VMobject
+from manim.mobject.types.vectorized_mobject import VGroup, VMobject, VectorizedPoint
 from manim.utils.tex import TexTemplate
 from manim.utils.tex_file_writing import tex_to_svg_file
 
@@ -522,17 +522,15 @@ class MathTex(SingleStringMathTex):
         of tex_strings)
         """
         new_submobjects: list[VMobject] = []
-        try:
-            for tex_string, tex_string_id in self._main_matches:
-                mtp = MathTexPart()
-                mtp.tex_string = tex_string
-                mtp.add(*self.id_to_vgroup_dict[tex_string_id].submobjects)
-                new_submobjects.append(mtp)
-        except KeyError:
-            logger.error(
-                f"MathTex: Could not find SVG group for tex part '{tex_string}' (id: {tex_string_id}). Using fallback to root group."
-            )
-            new_submobjects.append(self.id_to_vgroup_dict["root"])
+        for tex_string, tex_string_id in self._main_matches:
+            mtp = MathTexPart()
+            mtp.tex_string = tex_string
+            vgroup = self.id_to_vgroup_dict.get(tex_string_id)
+            if vgroup is None or len(vgroup.submobjects) == 0:
+                mtp.add(VectorizedPoint())
+            else:
+                mtp.add(*vgroup.submobjects)
+            new_submobjects.append(mtp)
         self.submobjects = new_submobjects
         return self
 

--- a/tests/module/mobject/text/test_texmobject.py
+++ b/tests/module/mobject/text/test_texmobject.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from manim import MathTex, SingleStringMathTex, Tex, TexTemplate, tempconfig
+from manim import MathTex, RIGHT, SingleStringMathTex, Tex, TexTemplate, UP, tempconfig
 
 
 def test_MathTex(config):
@@ -335,3 +335,13 @@ def test_tex_garbage_collection(tmpdir, monkeypatch, config):
 
     tex_with_log = Tex("Hello World, again!")  # 45b4e7819cc20cb1.tex
     assert Path("media", "Tex", "45b4e7819cc20cb1.log").exists()
+
+
+def test_mathtex_bounding_box_stable_after_shift(config):
+    """Regression test for https://github.com/ManimCommunity/manim/issues/4643."""
+    parts = [r"\overrightarrow{", "C", "A", "}", "=", r"\bold{", "m", "}"]
+    math_tex = MathTex(*parts)
+    width_before, height_before = math_tex.width, math_tex.height
+    math_tex.shift(2 * RIGHT + UP)
+    assert math_tex.width == pytest.approx(width_before, rel=0, abs=1e-6)
+    assert math_tex.height == pytest.approx(height_before, rel=0, abs=1e-6)

--- a/tests/module/mobject/text/test_texmobject.py
+++ b/tests/module/mobject/text/test_texmobject.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from manim import MathTex, RIGHT, SingleStringMathTex, Tex, TexTemplate, UP, tempconfig
+from manim import RIGHT, UP, MathTex, SingleStringMathTex, Tex, TexTemplate, tempconfig
 
 
 def test_MathTex(config):


### PR DESCRIPTION
## Summary
- Use `VectorizedPoint` placeholders for empty `MathTexPart` submobjects
- Restores pre-0.20 behavior removed in #3423; bbox no longer grows on `.shift()`

Fixes #4643

## Test plan
- [x] `pytest tests/module/mobject/text/test_texmobject.py::test_mathtex_bounding_box_stable_after_shift`

Made with [Cursor](https://cursor.com)