### PR TITLE
docs: fix register_font docstring

### DIFF
--- a/docs/i18n/gettext/reference/manim.mobject.text.text_mobject.pot
+++ b/docs/i18n/gettext/reference/manim.mobject.text.text_mobject.pot
@@ -65,7 +65,7 @@ msgid "In ``assets/fonts`` folder."
 msgstr ""
 
 #: ../../../manim/mobject/text/text_mobject.py:docstring of manim.mobject.text.text_mobject.register_font:7
-msgid "In ``font/`` folder."
+msgid "In ``fonts/`` folder."
 msgstr ""
 
 #: ../../../manim/mobject/text/text_mobject.py:docstring of manim.mobject.text.text_mobject.register_font:8

--- a/manim/mobject/text/text_mobject.py
+++ b/manim/mobject/text/text_mobject.py
@@ -1491,7 +1491,7 @@ def register_font(font_file: str | Path) -> Iterator[None]:
 
     1. Absolute path.
     2. In ``assets/fonts`` folder.
-    3. In ``font/`` folder.
+    3. In ``fonts/`` folder.
     4. In the same directory.
 
     Parameters


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

Fixed the discrepancy between the third directory lookup path described in `register_font` and the actual code.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

When I was using `register_font`, I noticed that the documentation stated:
```python
1. Absolute path.
2. In ``assets/fonts`` folder.
3. In ``font/`` folder.          # Here it says "font"
4. In the same directory.
```
But the actual code reads:
```python
possible_paths = [
    Path(font_file),
    input_folder / "assets/fonts" / font_file,
    input_folder / "fonts" / font_file,          # Here it says "fonts"
    input_folder / font_file,
]
```
I found this inconsistency between the two, so I changed the description and documentation from `In ``font/`` folder.` to `In ``fonts/`` folder.`

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->

https://manimce--4880.org.readthedocs.build/en/4880/

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
