### PR TITLE
fix(animation): LaggedStartMap Restore builds subanimations

### DIFF
--- a/manim/animation/composition.py
+++ b/manim/animation/composition.py
@@ -433,7 +433,6 @@ class LaggedStartMap(LaggedStart):
         if "lag_ratio" in anim_kwargs:
             anim_kwargs.pop("lag_ratio")
         animations = [
-            animation_class(*animation_args(args), **anim_kwargs)
-            for args in args_list
+            animation_class(*animation_args(args), **anim_kwargs) for args in args_list
         ]
         super().__init__(*animations, run_time=run_time, lag_ratio=lag_ratio)

--- a/manim/animation/composition.py
+++ b/manim/animation/composition.py
@@ -413,9 +413,27 @@ class LaggedStartMap(LaggedStart):
 
             arg_creator = identity
 
+        def animation_args(value: Any) -> tuple[Any, ...]:
+            # ``arg_creator`` may return either a tuple of constructor args (e.g.
+            # ``(m.set_color, YELLOW)``) or a single mobject (the default identity).
+            # Only tuples are unpacked; mobjects must be passed as a single argument
+            # so animations like ``Restore(mob)`` are not called as ``Restore(*mob)``.
+            if isinstance(value, tuple):
+                return value
+            return (value,)
+
         args_list = [arg_creator(submob) for submob in mobject]
+        if not args_list:
+            raise ValueError(
+                f"LaggedStartMap cannot build animations from {mobject!r}: "
+                "it has no submobjects to map over. Pass a VGroup of the "
+                "targets to animate, or provide a non-empty mobject."
+            )
         anim_kwargs = dict(kwargs)
         if "lag_ratio" in anim_kwargs:
             anim_kwargs.pop("lag_ratio")
-        animations = [animation_class(*args, **anim_kwargs) for args in args_list]
+        animations = [
+            animation_class(*animation_args(args), **anim_kwargs)
+            for args in args_list
+        ]
         super().__init__(*animations, run_time=run_time, lag_ratio=lag_ratio)

--- a/tests/module/animation/test_composition.py
+++ b/tests/module/animation/test_composition.py
@@ -6,9 +6,9 @@ import pytest
 
 from manim.animation.animation import Animation, Wait
 from manim.animation.composition import AnimationGroup, LaggedStartMap, Succession
-from manim.animation.transform import Restore
 from manim.animation.creation import Create, Write
 from manim.animation.fading import FadeIn, FadeOut
+from manim.animation.transform import Restore
 from manim.constants import DOWN, UP
 from manim.mobject.geometry.arc import Circle
 from manim.mobject.geometry.line import Line
@@ -199,7 +199,9 @@ def test_laggedstartmap_restore_builds_subanimations():
         submob.scale(0)
     animation = LaggedStartMap(Restore, mobject, lag_ratio=0.1, run_time=1)
     assert len(animation.animations) == len(mobject)
-    assert all(isinstance(subanimation, Restore) for subanimation in animation.animations)
+    assert all(
+        isinstance(subanimation, Restore) for subanimation in animation.animations
+    )
 
 
 def test_laggedstartmap_empty_mobject_raises():

--- a/tests/module/animation/test_composition.py
+++ b/tests/module/animation/test_composition.py
@@ -6,6 +6,7 @@ import pytest
 
 from manim.animation.animation import Animation, Wait
 from manim.animation.composition import AnimationGroup, LaggedStartMap, Succession
+from manim.animation.transform import Restore
 from manim.animation.creation import Create, Write
 from manim.animation.fading import FadeIn, FadeOut
 from manim.constants import DOWN, UP
@@ -189,6 +190,22 @@ def test_animationgroup_calls_finish():
     scene.play(animation_group)
     assert sqr_animation.finished
     assert circ_animation.finished
+
+
+def test_laggedstartmap_restore_builds_subanimations():
+    mobject = VGroup(Square(), Square().shift(UP))
+    for submob in mobject:
+        submob.save_state()
+        submob.scale(0)
+    animation = LaggedStartMap(Restore, mobject, lag_ratio=0.1, run_time=1)
+    assert len(animation.animations) == len(mobject)
+    assert all(isinstance(subanimation, Restore) for subanimation in animation.animations)
+
+
+def test_laggedstartmap_empty_mobject_raises():
+    mobject = VGroup()
+    with pytest.raises(ValueError, match="no submobjects"):
+        LaggedStartMap(Restore, mobject)
 
 
 def test_laggedstartmap_only_passes_kwargs_to_subanimations():


### PR DESCRIPTION
## Summary
- `LaggedStartMap(Restore, mob)` called `Restore(*mob)` when `arg_creator` returned a mobject (#4861)
- Only unpack tuples from `arg_creator`; pass mobjects as single args
- Clear error on empty mobject

Fixes #4861

## Test plan
- [x] `pytest tests/module/animation/test_composition.py -k laggedstartmap -o addopts=\"\"`

Made with [Cursor](https://cursor.com)