### PR TITLE
fix(cli): resolve checkhealth false positive for uv launcher shims

### DIFF
--- a/manim/cli/checkhealth/checks.py
+++ b/manim/cli/checkhealth/checks.py
@@ -142,7 +142,7 @@ def is_manim_executable_associated_to_this_library() -> bool:
 
     # support uv toolchain's shim executable structure
     companion_script = path_to_manim + ".__script__.py"
-    if os.path.exists(companion_script):
+    if os.path.isfile(companion_script):
         with open(companion_script, "rb") as f:
             manim_exec += f.read()
 

--- a/manim/cli/checkhealth/checks.py
+++ b/manim/cli/checkhealth/checks.py
@@ -140,6 +140,12 @@ def is_manim_executable_associated_to_this_library() -> bool:
     with open(path_to_manim, "rb") as manim_binary:
         manim_exec = manim_binary.read()
 
+    # support uv toolchain's shim executable structure
+    companion_script = path_to_manim + ".__script__.py"
+    if os.path.exists(companion_script):
+        with open(companion_script, "rb") as f:
+            manim_exec += f.read()
+
     # first condition below corresponds to the executable being
     # some sort of python script. second condition happens when
     # the executable is actually a Windows batch file.


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
It updates the `is_manim_executable_associated_to_this_library` health check in `manim/cli/checkhealth/checks.py` to support `uv` toolchain shims. If a companion `.__script__.py` file exists next to the resolved `manim` executable, it reads its contents and includes them in the verification check.

## Motivation and Explanation: Why and how do your changes improve the library?
When Manim is installed globally or managed via `uv`, the `manim` executable on the user's `PATH` is often a compiled Rust launcher shim (e.g. `C:\Users\<username>\AppData\Local\Python\bin\manim.exe`). 

Because this wrapper is a compiled binary, it does not contain the entrypoint string `manim.__main__` directly inside it. Instead, the python entrypoint code is written to a companion script file named `manim.exe.__script__.py`. This causes `manim checkhealth` to falsely report that the executable does not belong to the Manim Community library. 

This fix resolves the false positive warning for all users using the modern `uv` Python toolchain.

## Links to added or changed documentation pages
*Not applicable (No documentation changes required).*

## Further Information and Comments
This change is non-breaking, cross-platform, and falls back gracefully when no `uv` shim is present. 

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
