### PR TITLE
Fix bare except clause in manim/utils/rate_functions.py

### DIFF
--- a/manim/utils/rate_functions.py
+++ b/manim/utils/rate_functions.py
@@ -34,7 +34,7 @@ for the non-standard ones
                                 .next_to(plot_bg, UP, buff=0.1)
                             )
                             x.add(VGroup(plot_bg, plot, plot_title))
-                        except: # because functions `not_quite_there`, `function squish_rate_func` are not working.
+                        except Exception: # because functions `not_quite_there`, `function squish_rate_func` are not working.
                             pass
             x.arrange_in_grid(cols=8)
             x.height = config.frame_height


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `manim/utils/rate_functions.py`.

The bare `except:` is used to silently skip rate functions that aren't working (e.g. `not_quite_there`, `squish_rate_func`). Using `except Exception:` preserves that behavior while avoiding accidentally swallowing `SystemExit` and `KeyboardInterrupt`. The existing comment is preserved.