### PR TITLE
Preserve line color in MovingDots example

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -226,7 +226,7 @@ Animations
             y=ValueTracker(0)
             d1.add_updater(lambda z: z.set_x(x.get_value()))
             d2.add_updater(lambda z: z.set_y(y.get_value()))
-            l1.add_updater(lambda z: z.become(Line(d1.get_center(),d2.get_center()).set_color(RED)))
+            l1.add_updater(lambda z: z.match_points(Line(d1.get_center(),d2.get_center())))
             self.add(d1,d2,l1)
             self.play(x.animate.set_value(5))
             self.play(y.animate.set_value(4))

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -226,7 +226,7 @@ Animations
             y=ValueTracker(0)
             d1.add_updater(lambda z: z.set_x(x.get_value()))
             d2.add_updater(lambda z: z.set_y(y.get_value()))
-            l1.add_updater(lambda z: z.become(Line(d1.get_center(),d2.get_center())))
+            l1.add_updater(lambda z: z.become(Line(d1.get_center(),d2.get_center()).set_color(RED)))
             self.add(d1,d2,l1)
             self.play(x.animate.set_value(5))
             self.play(y.animate.set_value(4))


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
This PR fixes the `MovingDots` documentation example so that the line remains red during the animation.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
The example initially calls `set_color(RED)`, but the subsequent `become(Line(...))` call replaces the styled line on every update.
As a result, the rendered line does not remain red.

Applying `set_color(RED)` to the new `Line` makes the rendered result consistent with the example code and avoids suggesting that the initial `set_color(RED)` call has no effect.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
N/A

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
None


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
