### PR TITLE
Improve hashing stability for transient objects

### DIFF
--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -454,7 +454,7 @@ def get_hash_from_play_call(
         for animation in sorted(animations_list, key=str)
     ]
     current_mobjects_list_json = [
-        get_json(mobject, memoizer, include_pixel_array=True) 
+        get_json(mobject, memoizer, include_pixel_array=True)
         for mobject in current_mobjects_list
     ]
     hash_camera, hash_animations, hash_current_mobjects = (

--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -47,27 +47,18 @@ class _Memoizer:
     content-equality detection.
     """
 
-    _already_processed = set()
-
-    # Transient objects created during serialisation (eg the closure variable dict built for every updater or rate function)
-    # are freed mid-pass, and when a later allocation reuses one of those addresses the fresh object is incorrectly collapsed to
-    # the "already processed" placeholder. This results in the play hash depending on a race, meaning an identical scene can produce
-    # different partial-movie-file hashes from run to run, resulting in unnecessary re-renders of already cached partials.
-    _keep_alive = []
-
-    # Can be changed to whatever string to help debugging the JSon generation.
+    # Can be changed to whatever string to help debugging the JSON generation.
     ALREADY_PROCESSED_PLACEHOLDER = "AP"
     THRESHOLD_WARNING = 170_000
 
-    @classmethod
-    def reset_already_processed(cls: type[_Memoizer]) -> None:
-        cls._keep_alive.clear()
-        cls._already_processed.clear()
+    def __init__(self) -> None:
+        self._already_processed: set[tuple[str, int]] = set()
+        # Keep tracked objects alive for this serialization operation. CPython can
+        # otherwise reuse a transient object's address before encoding has completed;
+        # this also matters for objects whose hash is derived from their identity.
+        self._keep_alive: dict[int, Any] = {}
 
-    @classmethod
-    def check_already_processed_decorator(
-        cls: type[_Memoizer], is_method: bool = False
-    ) -> Callable:
+    def check_already_processed_decorator(self, is_method: bool = False) -> Callable:
         """Decorator to handle the arguments that goes through the decorated function.
         Returns the value of ALREADY_PROCESSED_PLACEHOLDER if the obj has been processed,
         or lets the decorated function call go ahead.
@@ -82,16 +73,17 @@ class _Memoizer:
             # NOTE : There is probably a better way to separate both case when func is
             # a method or a function.
             if is_method:
-                return lambda self, obj: cls._handle_already_processed(
+                return lambda obj_self, obj: self._handle_already_processed(
                     obj,
-                    default_function=lambda obj: func(self, obj),
+                    default_function=lambda obj: func(obj_self, obj),
                 )
-            return lambda obj: cls._handle_already_processed(obj, default_function=func)
+            return lambda obj: self._handle_already_processed(
+                obj, default_function=func
+            )
 
         return layer
 
-    @classmethod
-    def check_already_processed(cls: type[_Memoizer], obj: Any) -> Any:
+    def check_already_processed(self, obj: Any) -> Any:
         """Checks if obj has been already processed. Returns itself if it has not been,
         or the value of ALREADY_PROCESSED_PLACEHOLDER if it has.
         Marks the object as processed in the second case.
@@ -107,10 +99,9 @@ class _Memoizer:
             Either the object itself or the placeholder.
         """
         # When the object is not memoized, we return the object itself.
-        return cls._handle_already_processed(obj, lambda x: x)
+        return self._handle_already_processed(obj, lambda x: x)
 
-    @classmethod
-    def mark_as_processed(cls: type[_Memoizer], obj: Any) -> None:
+    def mark_as_processed(self, obj: Any) -> None:
         """Marks an object as processed.
 
         Parameters
@@ -118,12 +109,11 @@ class _Memoizer:
         obj
             The object to mark as processed.
         """
-        cls._handle_already_processed(obj, lambda x: x)
-        return cls._return(obj, id, lambda x: x, memoizing=False)
+        self._handle_already_processed(obj, lambda x: x)
+        self._return(obj, id, lambda x: x, memoizing=False)
 
-    @classmethod
     def _handle_already_processed(
-        cls: type[_Memoizer],
+        self,
         obj: Any,
         default_function: Callable[[Any], Any],
     ) -> str | Any:
@@ -135,42 +125,39 @@ class _Memoizer:
                 str,
                 complex,
             ),
-        ) and obj not in [None, cls.ALREADY_PROCESSED_PLACEHOLDER]:
+        ) and obj not in [None, self.ALREADY_PROCESSED_PLACEHOLDER]:
             # It makes no sense (and it'd slower) to memoize objects of these primitive
             # types.  Hence, we simply return the object.
             return obj
         if isinstance(obj, Hashable):
             try:
-                return cls._return(obj, hash, default_function)
+                return self._return(obj, hash, default_function)
             except TypeError:
                 # In case of an error with the hash (eg an object is marked as hashable
                 # but contains a non hashable within it)
                 # Fallback to use the built-in function id instead.
                 pass
-        return cls._return(obj, id, default_function)
+        return self._return(obj, id, default_function)
 
-    @classmethod
     def _return(
-        cls: type[_Memoizer],
+        self,
         obj: Any,
         obj_to_membership_sign: Callable[[Any], int],
         default_func: Callable[[Any], Any],
         memoizing: bool = True,
     ) -> str | Any:
-        cls._keep_alive.append(obj)
         # hash() values and id() addresses are both raw ints that share no meaning, so entries are tagged with
         # their signature kind: in an untagged set, a hash() value that numerically equals a recorded id() address
-        # (or vice versa) collapses a never-processed object to the placeholder. Whether such a coincidence occurs
-        # varies from process to process (str hashes are randomized), making play hashes unstable across identical
-        # runs and causing unnecessary re-renders of already cached partial movie files.
+        # (or vice versa) collapses a never-processed object to the placeholder.
         sign_kind = "h" if obj_to_membership_sign is hash else "i"
-        obj_membership_sign = (sign_kind, obj_to_membership_sign(obj))
-        if obj_membership_sign in cls._already_processed:
-            return cls.ALREADY_PROCESSED_PLACEHOLDER
+        signature = obj_to_membership_sign(obj)
+        obj_membership_sign = (sign_kind, signature)
+        if obj_membership_sign in self._already_processed:
+            return self.ALREADY_PROCESSED_PLACEHOLDER
         if memoizing:
             if (
                 not config.disable_caching_warning
-                and len(cls._already_processed) == cls.THRESHOLD_WARNING
+                and len(self._already_processed) == self.THRESHOLD_WARNING
             ):
                 logger.warning(
                     "It looks like the scene contains a lot of sub-mobjects. Caching "
@@ -183,11 +170,16 @@ class _Memoizer:
                     "to True in your config file.",
                 )
 
-            cls._already_processed.add(obj_membership_sign)
+            self._already_processed.add(obj_membership_sign)
+            self._keep_alive.setdefault(id(obj), obj)
         return default_func(obj)
 
 
 class _CustomEncoder(json.JSONEncoder):
+    def __init__(self, *, memoizer: _Memoizer, **kwargs: Any) -> None:
+        self._memoizer = memoizer
+        super().__init__(**kwargs)
+
     def default(self, obj: Any) -> Any:
         """This method is used to serialize objects to JSON format.
 
@@ -267,12 +259,12 @@ class _CustomEncoder(json.JSONEncoder):
         """
 
         def _key_to_hash(key: Any) -> int:
-            return zlib.crc32(json.dumps(key, cls=_CustomEncoder).encode())
+            return zlib.crc32(_get_json(key, self._memoizer).encode())
 
         def _iter_check_list(lst: Sequence[Any]) -> list[Any]:
             processed_list = [None] * len(lst)
             for i, el in enumerate(lst):
-                el = _Memoizer.check_already_processed(el)
+                el = self._memoizer.check_already_processed(el)
                 if isinstance(el, (list, tuple)):
                     new_value = _iter_check_list(el)
                 elif isinstance(el, dict):
@@ -285,7 +277,7 @@ class _CustomEncoder(json.JSONEncoder):
         def _iter_check_dict(dct: dict[Any, Any]) -> dict[Any, Any]:
             processed_dict = {}
             for k, v in dct.items():
-                v = _Memoizer.check_already_processed(v)
+                v = self._memoizer.check_already_processed(v)
                 if k in KEYS_TO_FILTER_OUT:
                     continue
                 # We check if the k is of the right format (supported by JSON)
@@ -322,10 +314,15 @@ class _CustomEncoder(json.JSONEncoder):
         :class:`str`
            The object encoder with the standard json process.
         """
-        _Memoizer.mark_as_processed(obj)
+        self._memoizer.mark_as_processed(obj)
         if isinstance(obj, (dict, list, tuple)):
             return super().encode(self._cleaned_iterable(obj))
         return super().encode(obj)
+
+
+def _get_json(obj: Any, memoizer: _Memoizer) -> str:
+    """Serialize ``obj`` using an existing serialization-operation memoizer."""
+    return json.dumps(obj, cls=_CustomEncoder, memoizer=memoizer)
 
 
 def get_json(obj: Any) -> str:
@@ -341,7 +338,7 @@ def get_json(obj: Any) -> str:
     :class:`str`
         The flattened object
     """
-    return json.dumps(obj, cls=_CustomEncoder)
+    return _get_json(obj, _Memoizer())
 
 
 def get_hash_from_play_call(
@@ -373,10 +370,15 @@ def get_hash_from_play_call(
     """
     logger.debug("Hashing ...")
     t_start = perf_counter()
-    _Memoizer.mark_as_processed(scene_object)
-    camera_json = get_json(camera_object)
-    animations_list_json = [get_json(x) for x in sorted(animations_list, key=str)]
-    current_mobjects_list_json = [get_json(x) for x in current_mobjects_list]
+    memoizer = _Memoizer()
+    memoizer.mark_as_processed(scene_object)
+    camera_json = _get_json(camera_object, memoizer)
+    animations_list_json = [
+        _get_json(animation, memoizer) for animation in sorted(animations_list, key=str)
+    ]
+    current_mobjects_list_json = [
+        _get_json(mobject, memoizer) for mobject in current_mobjects_list
+    ]
     hash_camera, hash_animations, hash_current_mobjects = (
         zlib.crc32(repr(json_val).encode())
         for json_val in [camera_json, animations_list_json, current_mobjects_list_json]
@@ -384,7 +386,5 @@ def get_hash_from_play_call(
     hash_complete = f"{hash_camera}_{hash_animations}_{hash_current_mobjects}"
     t_end = perf_counter()
     logger.debug("Hashing done in %(time)s s.", {"time": str(t_end - t_start)[:8]})
-    # End of the hashing for the animation, reset all the memoize.
-    _Memoizer.reset_already_processed()
     logger.debug("Hash generated :  %(h)s", {"h": hash_complete})
     return hash_complete

--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -49,11 +49,10 @@ class _Memoizer:
 
     _already_processed = set()
 
-    """Transient objects created during serialisation (eg the closure variable dict built for every updater or rate function)
-    are freed mid-pass, and when a later allocation reuses one of those addresses the fresh object is incorrectly collapsed to
-    the "already processed" placeholder. This results in the play hash depending on a race, meaning an identical scene can produce
-    different partial-movie-file hashes from run to run, resulting in unnecessary re-renders of already cached partials.
-    """
+    # Transient objects created during serialisation (eg the closure variable dict built for every updater or rate function)
+    # are freed mid-pass, and when a later allocation reuses one of those addresses the fresh object is incorrectly collapsed to
+    # the "already processed" placeholder. This results in the play hash depending on a race, meaning an identical scene can produce
+    # different partial-movie-file hashes from run to run, resulting in unnecessary re-renders of already cached partials.
     _keep_alive = []
 
     # Can be changed to whatever string to help debugging the JSon generation.

--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -410,11 +410,7 @@ def get_json(obj: Any, *, include_pixel_array: bool = False) -> str:
     :class:`str`
         The flattened object
     """
-    return json.dumps(
-        obj,
-        _Memoizer(),
-        include_pixel_array=include_pixel_array,
-    )
+    return _get_json(obj, _Memoizer(), include_pixel_array=include_pixel_array)
 
 
 def get_hash_from_play_call(
@@ -448,13 +444,13 @@ def get_hash_from_play_call(
     t_start = perf_counter()
     memoizer = _Memoizer()
     memoizer.mark_as_processed(scene_object)
-    camera_json = get_json(camera_object, memoizer)
+    camera_json = _get_json(camera_object, memoizer)
     animations_list_json = [
-        get_json(animation, memoizer, include_pixel_array=True)
+        _get_json(animation, memoizer, include_pixel_array=True)
         for animation in sorted(animations_list, key=str)
     ]
     current_mobjects_list_json = [
-        get_json(mobject, memoizer, include_pixel_array=True)
+        _get_json(mobject, memoizer, include_pixel_array=True)
         for mobject in current_mobjects_list
     ]
     hash_camera, hash_animations, hash_current_mobjects = (

--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -49,12 +49,20 @@ class _Memoizer:
 
     _already_processed = set()
 
+    """Transient objects created during serialisation (eg the closure variable dict built for every updater or rate function)
+    are freed mid-pass, and when a later allocation reuses one of those addresses the fresh object is incorrectly collapsed to
+    the "already processed" placeholder. This results in the play hash depending on a race, meaning an identical scene can produce
+    different partial-movie-file hashes from run to run, resulting in unnecessary re-renders of already cached partials.
+    """
+    _keep_alive = []
+
     # Can be changed to whatever string to help debugging the JSon generation.
     ALREADY_PROCESSED_PLACEHOLDER = "AP"
     THRESHOLD_WARNING = 170_000
 
     @classmethod
     def reset_already_processed(cls: type[_Memoizer]) -> None:
+        cls._keep_alive.clear()
         cls._already_processed.clear()
 
     @classmethod
@@ -150,6 +158,7 @@ class _Memoizer:
         default_func: Callable[[Any], Any],
         memoizing: bool = True,
     ) -> str | Any:
+        cls._keep_alive.append(obj)
         # hash() values and id() addresses are both raw ints that share no meaning, so entries are tagged with
         # their signature kind: in an untagged set, a hash() value that numerically equals a recorded id() address
         # (or vice versa) collapses a never-processed object to the placeholder. Whether such a coincidence occurs

--- a/tests/module/utils/test_hashing.py
+++ b/tests/module/utils/test_hashing.py
@@ -186,3 +186,41 @@ def test_memoizer_does_not_confuse_hash_and_id_signatures():
 
     hashing._Memoizer.check_already_processed(HashCollidingWithLiveId())
     assert hashing._Memoizer.check_already_processed(unhashable) is unhashable
+
+
+def test_memoizer_does_not_confuse_fresh_objects_with_dead_ones():
+    """
+    A fresh object must never be reported as already processed just because it was allocated at the address of a
+    dead object recorded earlier in the same pass (membership signs are id-derived, and ids are only unique among
+    simultaneously live objects).
+    """
+    transient = {"value": 1}
+    hashing._Memoizer.check_already_processed(transient)
+    del transient
+    for i in range(10):
+        fresh = {"value": i + 2}
+        assert hashing._Memoizer.check_already_processed(fresh) is fresh
+        del fresh
+
+
+def test_sibling_closures_are_not_collapsed_to_placeholder():
+    """
+    Serializing many closures in one pass builds a transient closure-vars dict per closure (via inspect.getclosurevars).
+    These share nothing, so none of them may collapse to the already-processed placeholder — yet without the
+    keep-alive fix, dead dicts' reused addresses collapse most of them.
+    """
+
+    def make_closure(k):
+        def closure(x):
+            return x + k
+
+        return closure
+
+    closures = [make_closure(k) for k in range(20)]
+    entries = json.loads(hashing.get_json(closures))
+    assert len(entries) == 20
+    for k, entry in enumerate(entries):
+        assert entry != ALREADY_PROCESSED_PLACEHOLDER
+        assert entry["nonlocals"] == {"k": k}, (
+            f"closure {k} collapsed: {entry['nonlocals']!r}"
+        )

--- a/tests/module/utils/test_hashing.py
+++ b/tests/module/utils/test_hashing.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
+import gc
 import json
+import weakref
 from zlib import crc32
-
-import pytest
 
 import manim.utils.hashing as hashing
 from manim import Square
 
 ALREADY_PROCESSED_PLACEHOLDER = hashing._Memoizer.ALREADY_PROCESSED_PLACEHOLDER
-
-
-@pytest.fixture(autouse=True)
-def reset_already_processed():
-    hashing._Memoizer.reset_already_processed()
 
 
 def test_JSON_basic():
@@ -145,9 +140,7 @@ def test_hash_consistency():
         and pytest will display a nice difference summary making it easier to debug.
         """
         json1 = hashing.get_json(obj1)
-        hashing._Memoizer.reset_already_processed()
         json2 = hashing.get_json(obj2)
-        hashing._Memoizer.reset_already_processed()
         hash1 = crc32(repr(json1).encode())
         hash2 = crc32(repr(json2).encode())
         if hash1 != hash2 and debug:
@@ -167,15 +160,16 @@ def test_memoizer_does_not_confuse_hash_and_id_signatures():
     must not mark a never-processed object as already processed. Whether such a coincidence occurs varies from
     process to process (str hashes are randomized), so an untagged set makes play hashes unstable across runs.
     """
+    memoizer = hashing._Memoizer()
     id_signed = {"a": 1}  # dicts are unhashable, so this is recorded under its id.
-    hashing._Memoizer.check_already_processed(id_signed)
+    memoizer.check_already_processed(id_signed)
 
     class HashCollidingWithRecordedId:
         def __hash__(self):
             return id(id_signed)
 
     collider = HashCollidingWithRecordedId()
-    assert hashing._Memoizer.check_already_processed(collider) is collider
+    assert memoizer.check_already_processed(collider) is collider
 
     # The other direction: an id() address colliding with a recorded hash() value.
     unhashable = {"b": 2}
@@ -184,8 +178,8 @@ def test_memoizer_does_not_confuse_hash_and_id_signatures():
         def __hash__(self):
             return id(unhashable)
 
-    hashing._Memoizer.check_already_processed(HashCollidingWithLiveId())
-    assert hashing._Memoizer.check_already_processed(unhashable) is unhashable
+    memoizer.check_already_processed(HashCollidingWithLiveId())
+    assert memoizer.check_already_processed(unhashable) is unhashable
 
 
 def test_memoizer_does_not_confuse_fresh_objects_with_dead_ones():
@@ -194,13 +188,61 @@ def test_memoizer_does_not_confuse_fresh_objects_with_dead_ones():
     dead object recorded earlier in the same pass (membership signs are id-derived, and ids are only unique among
     simultaneously live objects).
     """
+    memoizer = hashing._Memoizer()
     transient = {"value": 1}
-    hashing._Memoizer.check_already_processed(transient)
+    memoizer.check_already_processed(transient)
     del transient
     for i in range(10):
         fresh = {"value": i + 2}
-        assert hashing._Memoizer.check_already_processed(fresh) is fresh
+        assert memoizer.check_already_processed(fresh) is fresh
         del fresh
+
+
+def test_memoizer_retains_each_distinct_tracked_object_once():
+    memoizer = hashing._Memoizer()
+    hash_tracked = object()
+    memoizer.check_already_processed(hash_tracked)
+    memoizer.check_already_processed(hash_tracked)
+
+    id_tracked = {}
+    memoizer.check_already_processed(id_tracked)
+    memoizer.check_already_processed(id_tracked)
+
+    assert memoizer._keep_alive == {
+        id(hash_tracked): hash_tracked,
+        id(id_tracked): id_tracked,
+    }
+
+
+def test_get_json_does_not_retain_tracked_objects_after_returning():
+    class HashTracked:
+        pass
+
+    class IdTracked:
+        __hash__ = None
+
+    references = []
+    for tracked_type in (HashTracked, IdTracked):
+        obj = tracked_type()
+        references.append(weakref.ref(obj))
+        hashing.get_json(obj)
+        del obj
+
+    gc.collect()
+    assert all(reference() is None for reference in references)
+
+
+def test_get_json_calls_have_independent_memoizers():
+    shared = {}
+    assert hashing.get_json([shared]) == "[{}]"
+    assert hashing.get_json([shared]) == "[{}]"
+
+
+def test_shared_memoizer_spans_component_serializations():
+    shared = {}
+    memoizer = hashing._Memoizer()
+    assert hashing._get_json([shared], memoizer) == "[{}]"
+    assert hashing._get_json([shared], memoizer) == '["AP"]'
 
 
 def test_sibling_closures_are_not_collapsed_to_placeholder():


### PR DESCRIPTION
## Overview: What does this pull request change?
It adds a new class variable to the Memoizer class to enable the class to keep objects alive during the serialisation process for calculating hashes, and thus ensures that certain transient objects don't expire mid serialisation and result in unnecessary re-renders of parts of scenes that have not changed. 

It also adds two tests both of which assert the fixed behaviour:
- against a patched manim they pass deterministically (ie the memoizer keeps every recorded object alive, so no address can be reused within a pass)
- against stock ManimCE 0.20.1 they fail, reproducing the bug: CPython's free lists hand a dead recorded object's address to the next same-shaped allocation, so the fresh object is falsely reported as already processed and collapses to the "AP" placeholder.

## Motivation and Explanation: Why and how do your changes improve the library?
In the Memoizer class, there is a bug relating to the caching. In particular transient objects created during serialisation (eg the closure variable dict built for every updater or rate function) are freed mid-pass, and when a later allocation reuses one of those addresses the fresh object is incorrectly collapsed to the "already processed" placeholder. This results in the play hash depending on a race, meaning an identical scene can produce different partial-movie-file hashes from run to run, resulting in unnecessary re-renders of already cached partials.

In some of my scenes I was seeing 42/49 partial's being rerendered even though that scene did not change (it was being included in the render pass because I'm compiling a video and my render script attempts to rerender every scene, as it is not aware of which scene I have changed when it is called). After fixing this in my local copy with a patch file, I got no erroneous re-renders of the partials in this scene.

## Links to added or changed documentation pages

This is expected:
[manim.utils.hashing source](https://manimce--4896.org.readthedocs.build/en/4896/_modules/manim/utils/hashing.html?readthedocs-diff=true&readthedocs-diff-chunk=1)

Unexpected (likely due to commits to main after 0.20.1):
These two I'm surprised by given I didn't change anything that would touch these:
[Camera](https://manimce--4896.org.readthedocs.build/en/4896/reference/manim.camera.camera.Camera.html?readthedocs-diff=true&readthedocs-diff-chunk=1)
[invert_image](https://manimce--4896.org.readthedocs.build/en/4896/reference/manim.utils.images.html?readthedocs-diff=true&readthedocs-diff-chunk=1)



## Further Information and Comments



## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
