### PR TITLE
Prevent memoizer collisions between object hashes and IDs

### DIFF
--- a/manim/utils/hashing.py
+++ b/manim/utils/hashing.py
@@ -150,7 +150,13 @@ class _Memoizer:
         default_func: Callable[[Any], Any],
         memoizing: bool = True,
     ) -> str | Any:
-        obj_membership_sign = obj_to_membership_sign(obj)
+        # hash() values and id() addresses are both raw ints that share no meaning, so entries are tagged with
+        # their signature kind: in an untagged set, a hash() value that numerically equals a recorded id() address
+        # (or vice versa) collapses a never-processed object to the placeholder. Whether such a coincidence occurs
+        # varies from process to process (str hashes are randomized), making play hashes unstable across identical
+        # runs and causing unnecessary re-renders of already cached partial movie files.
+        sign_kind = "h" if obj_to_membership_sign is hash else "i"
+        obj_membership_sign = (sign_kind, obj_to_membership_sign(obj))
         if obj_membership_sign in cls._already_processed:
             return cls.ALREADY_PROCESSED_PLACEHOLDER
         if memoizing:

--- a/tests/module/utils/test_hashing.py
+++ b/tests/module/utils/test_hashing.py
@@ -159,3 +159,30 @@ def test_hash_consistency():
     assert_two_objects_produce_same_hash(Square(), Square())
     s = Square()
     assert_two_objects_produce_same_hash(s, s.copy())
+
+
+def test_memoizer_does_not_confuse_hash_and_id_signatures():
+    """
+    hash() values and id() addresses are recorded in the same set, so a numeric coincidence between the two kinds
+    must not mark a never-processed object as already processed. Whether such a coincidence occurs varies from
+    process to process (str hashes are randomized), so an untagged set makes play hashes unstable across runs.
+    """
+    id_signed = {"a": 1}  # dicts are unhashable, so this is recorded under its id.
+    hashing._Memoizer.check_already_processed(id_signed)
+
+    class HashCollidingWithRecordedId:
+        def __hash__(self):
+            return id(id_signed)
+
+    collider = HashCollidingWithRecordedId()
+    assert hashing._Memoizer.check_already_processed(collider) is collider
+
+    # The other direction: an id() address colliding with a recorded hash() value.
+    unhashable = {"b": 2}
+
+    class HashCollidingWithLiveId:
+        def __hash__(self):
+            return id(unhashable)
+
+    hashing._Memoizer.check_already_processed(HashCollidingWithLiveId())
+    assert hashing._Memoizer.check_already_processed(unhashable) is unhashable


### PR DESCRIPTION
## Overview: What does this pull request change?
Tag each membership sign with its signature kind ("h" for hash, "i" for id) so the two kinds can never collide, and add a regression test covering both collision directions.

The test fails on the current main branch, but succeeds on this branch.

## Motivation and Explanation: Why and how do your changes improve the library?
This is a separate bug to the one found in [PR 4896: Hashing stability for transient objects in manim 0.20.1](https://github.com/ManimCommunity/manim/pull/4896).

The _Memoizer class mixes two classes of ints when it is processing, hashes and id addresses. If a hash matches a recorded id or vice-versa then the current behaviour is to record a potentially never recorded object to the already processed placeholder, which changes the serialisation of the json and the play hash.

Because str hashes are randomised per process, whether such a coincidence occurs varies between otherwise identical runs, so a cached scene can silently re-render partial movie files.


## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
Depending on which (if either) are merged first between this and [PR 4896](https://github.com/ManimCommunity/manim/pull/4896), a trivial rebase will be needed on the other, but even though the code is adjacent it does not conflict.



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
