### PR TITLE
Add ZoomedScene.deactivate_zooming() to reverse activate_zooming()

### DIFF
--- a/manim/camera/multi_camera.py
+++ b/manim/camera/multi_camera.py
@@ -59,6 +59,18 @@ class MultiCamera(MovingCamera):
         assert isinstance(imfc.camera, MovingCamera)
         self.image_mobjects_from_cameras.append(imfc)
 
+    def remove_image_mobject_from_camera(
+        self, image_mobject_from_camera: ImageMobjectFromCamera
+    ) -> None:
+        """Removes an ImageMobject from ``self.image_mobjects_from_cameras``.
+
+        Parameters
+        ----------
+        image_mobject_from_camera
+            The ImageMobject to remove from ``self.image_mobjects_from_cameras``.
+        """
+        self.image_mobjects_from_cameras.remove(image_mobject_from_camera)
+
     def update_sub_cameras(self) -> None:
         """Reshape sub_camera pixel_arrays"""
         for imfc in self.image_mobjects_from_cameras:

--- a/manim/scene/zoomed_scene.py
+++ b/manim/scene/zoomed_scene.py
@@ -155,6 +155,58 @@ class ZoomedScene(MovingCameraScene):
             self.zoomed_display,
         )
 
+    def deactivate_zooming(self, animate: bool = False) -> None:
+        """This method is used to deactivate the zooming for the zoomed_camera.
+
+        It reverses the effects of :meth:`activate_zooming`, removing the
+        zoomed camera frame and the zoomed display from the scene.
+        If zooming is not currently activated, nothing happens.
+
+        Parameters
+        ----------
+        animate
+            Whether or not to animate the deactivation
+            of the zoomed camera.
+        """
+        if not self.zoom_activated:
+            return
+        frame = self.zoomed_camera.frame
+        display = self.zoomed_display
+        if animate:
+            frame.save_state()
+            # save_state cannot be used for the display: its pixel array is
+            # reshaped while animating, which makes a later restore fail.
+            display_height = display.height
+            display_width = display.width
+            display_center = display.get_center()
+            # Reverse of the pop out animation: the display collapses back
+            # onto the zoomed camera frame.
+            self.play(display.animate.replace(frame, stretch=True))
+            # Reverse of the zoom in animation: the frame expands to cover
+            # the full frame while its stroke fades out.
+            if isinstance(self.camera, OpenGLCamera):
+                full_frame_width, full_frame_height = self.camera.frame_shape
+            else:
+                full_frame_height = self.camera.frame_height
+                full_frame_width = self.camera.frame_width
+            self.play(
+                frame.animate.stretch_to_fit_width(full_frame_width)
+                .stretch_to_fit_height(full_frame_height)
+                .center()
+                .set_stroke(width=0),
+            )
+        self.remove_foreground_mobjects(frame, display)
+        self.remove(frame, display)
+        self.renderer.camera.remove_image_mobject_from_camera(display)  # type: ignore[union-attr]
+        if animate:
+            # Restore the original geometry so that a later call to
+            # activate_zooming starts from the original layout.
+            frame.restore()
+            display.stretch_to_fit_height(display_height)
+            display.stretch_to_fit_width(display_width)
+            display.move_to(display_center)
+        self.zoom_activated = False
+
     def get_zoom_in_animation(self, run_time: float = 2, **kwargs: Any) -> ApplyMethod:
         """Returns the animation of camera zooming in.
 

--- a/tests/module/scene/test_zoomed_scene.py
+++ b/tests/module/scene/test_zoomed_scene.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from manim import Dot, ZoomedScene, tempconfig
+
+
+def test_activate_deactivate_zooming():
+    with tempconfig({"dry_run": True, "quality": "low_quality"}):
+        scene = ZoomedScene()
+        scene.setup()
+        dot = Dot()
+        scene.add(dot)
+
+        scene.activate_zooming(animate=False)
+        assert scene.zoom_activated
+        assert scene.zoomed_camera.frame in scene.foreground_mobjects
+        assert scene.zoomed_display in scene.foreground_mobjects
+        assert scene.zoomed_display in scene.camera.image_mobjects_from_cameras
+
+        scene.deactivate_zooming()
+        assert not scene.zoom_activated
+        assert scene.zoomed_camera.frame not in scene.mobjects
+        assert scene.zoomed_display not in scene.mobjects
+        assert scene.zoomed_camera.frame not in scene.foreground_mobjects
+        assert scene.zoomed_display not in scene.foreground_mobjects
+        assert scene.zoomed_display not in scene.camera.image_mobjects_from_cameras
+        assert dot in scene.mobjects
+
+
+def test_deactivate_zooming_when_inactive():
+    with tempconfig({"dry_run": True, "quality": "low_quality"}):
+        scene = ZoomedScene()
+        scene.setup()
+
+        # Deactivating before activating must not raise.
+        scene.deactivate_zooming()
+        assert not scene.zoom_activated
+
+
+def test_reactivate_zooming_after_deactivation():
+    with tempconfig({"dry_run": True, "quality": "low_quality"}):
+        scene = ZoomedScene()
+        scene.setup()
+
+        scene.activate_zooming(animate=False)
+        scene.deactivate_zooming()
+        scene.activate_zooming(animate=False)
+        assert scene.zoom_activated
+        assert scene.zoomed_display in scene.camera.image_mobjects_from_cameras
+
+
+def test_deactivate_zooming_animated_restores_geometry():
+    with tempconfig({"dry_run": True, "quality": "low_quality"}):
+        scene = ZoomedScene()
+        scene.setup()
+
+        frame_before = scene.zoomed_camera.frame.copy()
+        display_before = scene.zoomed_display.copy()
+
+        scene.activate_zooming(animate=True)
+        scene.deactivate_zooming(animate=True)
+
+        assert not scene.zoom_activated
+        assert scene.zoomed_camera.frame.width == frame_before.width
+        assert scene.zoomed_camera.frame.height == frame_before.height
+        assert (
+            scene.zoomed_camera.frame.get_center() == frame_before.get_center()
+        ).all()
+        assert scene.zoomed_display.width == display_before.width
+        assert scene.zoomed_display.height == display_before.height
+        assert (scene.zoomed_display.get_center() == display_before.get_center()).all()


### PR DESCRIPTION
## Overview: What does this pull request change?

Adds `ZoomedScene.deactivate_zooming(animate=False)`, which reverses `activate_zooming()`: it removes the zoomed camera frame and zoomed display from the scene (and from the foreground mobjects), unregisters the display from the `MultiCamera` via a new `MultiCamera.remove_image_mobject_from_camera()`, and resets `zoom_activated`. With `animate=True` it plays the reverse of the activation animations first. Calling it when zooming is not active is a no-op. Closes #3009.

## Motivation and Explanation: Why and how do your changes improve the library?

Zooming could be activated but never cleanly deactivated (#3009). The rough workaround suggested in the issue (`self.remove(frame, display)`) leaves the display registered in the `MultiCamera` and the foreground list, and leaves `zoom_activated` stale, which breaks re-activation. The design follows the direction sketched by @huguesdevimeux in the issue discussion.

One implementation note: `save_state()`/`restore()` is not used for the display because its pixel array is reshaped during animation, which makes `restore()` fail; geometry is restored explicitly instead. After deactivation, `activate_zooming()` can be called again and behaves like the first activation (covered by tests).

## Links to added or changed documentation pages

No documentation pages changed; the new method has a numpy-style docstring, so the API reference will pick it up.

## Further Information and Comments

New tests in `tests/module/scene/test_zoomed_scene.py` (the file did not exist before) use the same `dry_run` + `tempconfig` pattern as `test_auto_zoom.py`. All 14 tests in `tests/module/scene/` pass; pre-commit hooks (ruff lint/format, mypy, codespell) pass on touched files.
