### PR TITLE
Prevent `round_corners()` failures for collinear vertices

### DIFF
--- a/manim/mobject/geometry/polygram.py
+++ b/manim/mobject/geometry/polygram.py
@@ -254,6 +254,15 @@ class Polygram(VMobject, metaclass=ConvertToOpenGL):
                 # Distance between vertex and start of the arc
                 cut_off_length = current_radius * np.tan(angle / 2)
 
+                # Clamp the cut-off length so that a (near) 180 degree turn
+                # between consecutive edges - which makes ``tan(angle / 2)``
+                # diverge to infinity - cannot push the arc endpoints to
+                # infinity.  This also bounds the rounded corner to at most half
+                # of the shorter adjacent edge, matching the expected behavior
+                # for degenerate collinear polygons (see issue #3052).
+                max_cut_off = min(np.linalg.norm(vect1), np.linalg.norm(vect2)) / 2
+                cut_off_length = np.clip(cut_off_length, -max_cut_off, max_cut_off)
+
                 # Determines counterclockwise vs. clockwise
                 sign = np.sign(np.cross(vect1, vect2)[2])
 

--- a/tests/module/mobject/geometry/test_unit_geometry.py
+++ b/tests/module/mobject/geometry/test_unit_geometry.py
@@ -15,6 +15,7 @@ from manim import (
     BackgroundRectangle,
     Circle,
     Line,
+    Polygon,
     Polygram,
     Sector,
     Square,
@@ -263,3 +264,18 @@ def test_Circle_point_at_angle():
     # Angle 0 should return start point even after reflection
     p_reflected_0 = reflected_circle.point_at_angle(0)
     np.testing.assert_array_almost_equal(p_reflected_0, reflected_start, decimal=5)
+
+
+def test_round_corners_collinear_points_stays_finite():
+    # Regression test for https://github.com/ManimCommunity/manim/issues/3052
+    # Collinear vertices create a (near) 180 degree turn at a corner, which
+    # makes ``tan(angle / 2)`` diverge to infinity.  This previously produced
+    # either astronomically large coordinates (default mode) or an 8.70 PiB
+    # ``MemoryError`` when anchors were evenly distributed.
+    for kwargs in ({}, {"evenly_distribute_anchors": True}):
+        poly = Polygon([-1, 0, 0], [0, 0, 0], [1, 0, 0])
+        poly.round_corners(0.15, **kwargs)
+        assert np.all(np.isfinite(poly.points))
+        # The rounded corner is bounded by half the shorter adjacent edge, so
+        # no coordinate should blow up beyond the original extent.
+        assert np.max(np.abs(poly.points)) <= 1.0


### PR DESCRIPTION
## Summary
Fixes #3052.

`Polygram.round_corners` computes the distance between a corner vertex and the start of the rounded arc as:

```python
cut_off_length = current_radius * np.tan(angle / 2)
```

When three consecutive vertices are collinear, one corner forms a (near) 180 degree turn, so `tan(angle / 2)` diverges to infinity. This previously produced either astronomically large coordinates (default `round_corners`, e.g. ~2.4e15) or an `8.70 PiB` `MemoryError` when anchors were evenly distributed.

This PR clamps `cut_off_length` to at most half the shorter adjacent edge via `np.clip`, so the rounded arc endpoints can never be pushed to infinity. The degenerate collinear case now yields a finite, valid mobject.

## Changes
- `manim/mobject/geometry/polygram.py`: clamp `cut_off_length` to `[-max_cut_off, max_cut_off]` where `max_cut_off = min(|vect1|, |vect2|) / 2`.
- `tests/module/mobject/geometry/test_unit_geometry.py`: add `test_round_corners_collinear_points_stays_finite` covering both `round_corners` modes.

## Test plan
- `pytest tests/module/mobject/geometry/test_unit_geometry.py -k round_corners` passes; full file 13 passed locally.
- Verified: a collinear polygon no longer produces non-finite coordinates or a MemoryError, and a normal polygon still rounds as before.

## Notes
Earlier attempts #4835 and #4873 were closed; this PR applies the same validated clamp direction with a regression test and a clean commit.