### PR TITLE
docs: Rename "scene" in MovingCameraScene example

### DIFF
--- a/manim/scene/moving_camera_scene.py
+++ b/manim/scene/moving_camera_scene.py
@@ -64,22 +64,22 @@ Examples
             self.play(Restore(self.camera.frame))
             self.wait()
 
-.. manim:: SlidingMultipleScenes
+.. manim:: SlidingMultipleFrames
 
-    class SlidingMultipleScenes(MovingCameraScene):
+    class SlidingMultipleFrames(MovingCameraScene):
         def construct(self):
-            def create_scene(number):
-                frame = Rectangle(width=16,height=9)
+            def create_frame(number):
+                frame = Rectangle(width=16, height=9)
                 circ = Circle().shift(LEFT)
-                text = Tex(f"This is Scene {str(number)}").next_to(circ, RIGHT)
+                text = Tex(f"This is Frame {str(number)}").next_to(circ, RIGHT)
                 frame.add(circ,text)
                 return frame
 
-            group = VGroup(*(create_scene(i) for i in range(4))).arrange_in_grid(buff=4)
+            group = VGroup(*(create_frame(i) for i in range(4))).arrange_in_grid(buff=4)
             self.add(group)
             self.camera.auto_zoom(group[0], animate=False)
-            for scene in group:
-                self.play(self.camera.auto_zoom(scene))
+            for frame in group:
+                self.play(self.camera.auto_zoom(frame))
                 self.wait()
 
             self.play(self.camera.auto_zoom(group, margin=2))


### PR DESCRIPTION
- Change all occurrences of "scene" to "frame" in MovingCameraScene's SlidingMultipleScenes example

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
In the [`SlidingMultipleScenes`](https://docs.manim.community/en/stable/reference/manim.scene.moving_camera_scene.html#slidingmultiplescenes) example in the docs for `MovingCameraScene`, all occurrences of the word "scene" were replaced with "frame".
## Motivation and Explanation: Why and how do your changes improve the library?
This PR was made following a [conversation in the Manim Discord](https://discord.com/channels/1453870851807117363/1533621519375405068/1533821789333880923) in which a new Manim user seemed to have gotten the impression that this example scene actually combines multiple `Scene` objects into a single one rather than simply moving the camera between four `Rectangle`s within the same scene, which is what is actually happening. I had the exact same experience when I started using Manim. This change to the example emphasizes that the four displayed frames are _not_ related to `Scene` in any way and hopefully reduces confusion among new users.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
[https://manimce--4910.org.readthedocs.build/en/4910/reference/manim.scene.moving_camera_scene.html#slidingmultipleframes](https://manimce--4910.org.readthedocs.build/en/4910/reference/manim.scene.moving_camera_scene.html#slidingmultipleframes)

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
