### PR TITLE
fix(svg): ignore point-less shape elements

### DIFF
--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -338,7 +338,7 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
             logger.warning(f"Unsupported element type: {type(shape)}")
             mob = None
         if mob is None or not mob.has_points():
-            return mob
+            return None
         self.apply_style_to_mobject(mob, shape)
         if isinstance(shape, se.Transformable) and shape.apply:
             self.handle_transform(mob, shape.transform)

--- a/tests/module/mobject/svg/test_svg_mobject.py
+++ b/tests/module/mobject/svg/test_svg_mobject.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from manim import *
 from tests.helpers.path_utils import get_svg_resource
 
@@ -54,6 +56,21 @@ def test_stroke_overrides_color():
         stroke_color=expected_color,
     )
     assert svg.stroke_color.to_hex() == expected_color
+
+
+def test_empty_path_is_ignored(tmp_path: Path):
+    svg_path = tmp_path / "empty_path.svg"
+    svg_path.write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg">'
+        '<path d=""/><path d="M 0 0 L 1 1"/>'
+        "</svg>",
+        encoding="utf-8",
+    )
+
+    svg = SVGMobject(svg_path)
+
+    assert len(svg.submobjects) == 1
+    assert svg.submobjects[0].has_points()
 
 
 def test_single_path_turns_into_sequence_of_points():


### PR DESCRIPTION
A change to SVG parsing in v0.20.0 caused point-less SVG elements to be retained. On Linux, Pango represents whitespace as empty paths, breaking character-to-glyph mapping in Text and resulting in shifted colors and missing lines in Code. This restores the previous behavior by ignoring point-less elements when converting an SVG to mobjects and adds a regression test.

If this works as intended, the rendered image included in the reference manual for `Code` should get its syntax highlighting fixed. (Broken, live version: https://docs.manim.community/en/stable/reference/manim.mobject.text.code_mobject.Code.html)