### PR TITLE
Preserve z-index ordering in animation groups

### DIFF
--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -923,12 +923,13 @@ class Scene:
         ) -> list[Mobject | OpenGLMobject]:
             animation_mobjects: list[Mobject | OpenGLMobject] = []
             for anim in nested_animations:
+                # Keep composition wrappers as conservative boundaries for the
+                # static frame cache, in addition to their nested animations.
+                animation_mobjects.extend(anim.mobject.get_family())
                 if isinstance(anim, AnimationGroup):
                     animation_mobjects.extend(
                         _collect_animation_mobjects(anim.animations),
                     )
-                else:
-                    animation_mobjects.extend(anim.mobject.get_family())
             return animation_mobjects
 
         animation_mobjects = _collect_animation_mobjects(animations)

--- a/tests/module/scene/test_scene.py
+++ b/tests/module/scene/test_scene.py
@@ -4,7 +4,18 @@ import datetime
 
 import pytest
 
-from manim import Circle, Dot, FadeIn, Group, Mobject, Scene, Square
+from manim import (
+    Circle,
+    Dot,
+    FadeIn,
+    Group,
+    Line,
+    Mobject,
+    Scene,
+    ShowPassingFlash,
+    Square,
+    Succession,
+)
 from manim.animation.animation import Wait
 
 
@@ -49,6 +60,24 @@ def test_scene_time(dry_run):
     scene.renderer._original_skipping_status = True
     scene.play(FadeIn(Square()), run_time=5)  # this animation gets skipped.
     assert pytest.approx(scene.time) == 7.5
+
+
+def test_animation_group_moving_mobjects_preserve_z_index_order(dry_run):
+    scene = Scene()
+    left_circle = Circle().set_z_index(1)
+    right_circle = Circle().set_z_index(1)
+    line = Line().set_z_index(-1)
+    scene.add(left_circle, right_circle)
+
+    succession = Succession(
+        right_circle.animate.set_fill(opacity=1),
+        ShowPassingFlash(line),
+    )
+    scene.compile_animation_data(succession)
+    scene.begin_animations()
+
+    assert left_circle in scene.moving_mobjects
+    assert left_circle not in scene.static_mobjects
 
 
 def test_subcaption(dry_run):


### PR DESCRIPTION
Fixes #4834.

Animation groups recursively collected only their nested animation mobjects when determining the static frame cache boundary. This could leave a higher-z mobject in the static frame while an introduced lower-z mobject was rendered on top of it.

Keep the composition wrapper family in the moving set alongside nested animation families, and add a regression test for `Succession` with `ShowPassingFlash`.

Tests:
- `pre-commit run --files manim/scene/scene.py tests/module/scene/test_scene.py`
- `pytest -q tests/module/scene/test_scene.py tests/module/animation/test_composition.py`
- `pytest -q tests/test_graphical_units/test_geometry.py -k 'negative_z_index_AnimationGroup or negative_z_index_LaggedStart or nested_animation_groups_with_negative_z_index'`

Opened via Codex using GPT-5.6 Sol.
