### PR TITLE
[Experimental] Fix tests in `test_dashed_vmobject.py`

### DIFF
--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -691,11 +691,13 @@ class Arrow(Line):
     def _set_stroke_width_from_length(self) -> Self:
         """Sets stroke width based on length."""
         max_ratio = self.max_stroke_width_to_length_ratio
+        target_stroke_width = max_ratio * self.get_length()
+        if np.isscalar(self.initial_stroke_width):
+            width = min(float(self.initial_stroke_width), target_stroke_width)
+        else:
+            width = np.minimum(self.initial_stroke_width, target_stroke_width)
         self.set_stroke(
-            width=min(
-                self.initial_stroke_width,
-                [max_ratio * self.get_length()] * len(self.initial_stroke_width),
-            ),
+            width=width,
             recurse=False,
         )
         return self

--- a/manim/mobject/geometry/line.py
+++ b/manim/mobject/geometry/line.py
@@ -690,12 +690,11 @@ class Arrow(Line):
 
     def _set_stroke_width_from_length(self) -> Self:
         """Sets stroke width based on length."""
-        max_ratio = self.max_stroke_width_to_length_ratio
-        target_stroke_width = max_ratio * self.get_length()
+        max_stroke_width = self.max_stroke_width_to_length_ratio * self.get_length()
         if np.isscalar(self.initial_stroke_width):
-            width = min(float(self.initial_stroke_width), target_stroke_width)
+            width = min(float(self.initial_stroke_width), max_stroke_width)
         else:
-            width = np.minimum(self.initial_stroke_width, target_stroke_width)
+            width = np.minimum(self.initial_stroke_width, max_stroke_width)
         self.set_stroke(
             width=width,
             recurse=False,

--- a/manim/mobject/opengl/opengl_vectorized_mobject.py
+++ b/manim/mobject/opengl/opengl_vectorized_mobject.py
@@ -2257,6 +2257,21 @@ class OpenGLDashedVMobject(OpenGLVMobject):
         super().__init__(**kwargs)
         self.dashed_ratio = dashed_ratio
         self.num_dashes = num_dashes
+
+        # Work on a copy to avoid mutating the caller's mobject (e.g. removing tips).
+        base_vmobject = vmobject
+        vmobject = base_vmobject.copy()
+
+        # TipableVMobject instances (Arrow, Vector, etc.) carry tips as submobjects.
+        # When dashing such objects, each subcurve would otherwise include its own
+        # tip, leading to many overlapping arrowheads. Pop tips from the working
+        # copy and re-attach them only once after the dashes are created.
+        tips = None
+        if hasattr(vmobject, "pop_tips"):
+            popped_tips = vmobject.pop_tips()
+            if len(popped_tips.submobjects) > 0:
+                tips = popped_tips
+
         r = self.dashed_ratio
         n = self.num_dashes
 
@@ -2277,7 +2292,10 @@ class OpenGLDashedVMobject(OpenGLVMobject):
 
         # Family is already taken care of by get_subcurve
         # implementation
-        self.match_style(vmobject, recurse=False)
+        self.match_style(base_vmobject, recurse=False)
+
+        if tips is not None:
+            self.add(*tips.submobjects)
 
 
 class VHighlight(OpenGLVGroup):


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Fixes 4 tests in `test_dashed_vmobject.py` by
- allowing `initial_stroke_width` to be scalar or iterable in `set_stroke_width_from_length()`.
- applying the fix in #4484 to `opengl_vectorized_mobject.py`.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->



## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
