### PR TITLE
Glyphs at end of Code lines no longer deleted when disable_ligatures is False

### DIFF
--- a/manim/mobject/text/code_mobject.py
+++ b/manim/mobject/text/code_mobject.py
@@ -223,7 +223,7 @@ class Code(VMobject, metaclass=ConvertToOpenGL):
             BLACK if default_text_color is None else f"#{default_text_color}"
         )
 
-        from manim.mobject.text.text_mobject import Paragraph
+        from manim.mobject.text.text_mobject import Paragraph, Text
 
         # Paragraph cannot render input consisting entirely of whitespace, but
         # such lines contain no visible glyphs and can safely be represented as empty.
@@ -237,6 +237,10 @@ class Code(VMobject, metaclass=ConvertToOpenGL):
         # ascender and a descender to the first and last lines. This normalizes
         # the vertical bounds of code listings independently of their contents.
         alignment_suffix = " pA" + str(line_numbers_from)
+        # Get actual number of glyphs in case it differs from the number of characters
+        alignment_length = len(
+            Text(alignment_suffix, **base_paragraph_config).submobjects
+        )
         boundary_line_indices = sorted({0, len(rendered_code_lines) - 1})
         aligned_code_lines = rendered_code_lines.copy()
         for index in boundary_line_indices:
@@ -302,7 +306,7 @@ class Code(VMobject, metaclass=ConvertToOpenGL):
             *(
                 self.code_lines[index].submobjects.pop()
                 for index in boundary_line_indices
-                for _ in range(len(alignment_suffix))
+                for _ in range(alignment_length)
             )
         ).stretch_to_fit_width(0, about_edge=LEFT)
 

--- a/manim/mobject/text/code_mobject.py
+++ b/manim/mobject/text/code_mobject.py
@@ -223,7 +223,7 @@ class Code(VMobject, metaclass=ConvertToOpenGL):
             BLACK if default_text_color is None else f"#{default_text_color}"
         )
 
-        from manim.mobject.text.text_mobject import Paragraph, Text
+        from manim.mobject.text.text_mobject import Paragraph
 
         # Paragraph cannot render input consisting entirely of whitespace, but
         # such lines contain no visible glyphs and can safely be represented as empty.
@@ -238,9 +238,11 @@ class Code(VMobject, metaclass=ConvertToOpenGL):
         # the vertical bounds of code listings independently of their contents.
         alignment_suffix = " pA" + str(line_numbers_from)
         # Get actual number of glyphs in case it differs from the number of characters
-        alignment_length = len(
-            Text(alignment_suffix, **base_paragraph_config).submobjects
+        alignment_reference = Paragraph(
+            alignment_suffix,
+            **base_paragraph_config,
         )
+        alignment_length = len(alignment_reference[0])
         boundary_line_indices = sorted({0, len(rendered_code_lines) - 1})
         aligned_code_lines = rendered_code_lines.copy()
         for index in boundary_line_indices:

--- a/tests/module/mobject/text/test_code_mobject.py
+++ b/tests/module/mobject/text/test_code_mobject.py
@@ -204,11 +204,14 @@ def test_code_line_mobject_is_independent_of_ordinality(
         paragraph_config={"disable_ligatures": disable_ligatures},
     )
     lines = code_mobject.code_lines
-    for i in range(len(lines)):
-        j = i % len(lines)
-        assert len(lines[i]) == len(lines[j])
-
-        np.testing.assert_allclose(lines[i].width, lines[j].width, atol=1e-6)
+    reference_line = lines[len(lines) // 2]
+    for boundary_line in (lines[0], lines[-1]):
+        assert len(boundary_line) == len(reference_line)
+        np.testing.assert_allclose(
+            boundary_line.width,
+            reference_line.width,
+            atol=1e-6,
+        )
 
 
 def test_code_syntax_highlighting_colors():

--- a/tests/module/mobject/text/test_code_mobject.py
+++ b/tests/module/mobject/text/test_code_mobject.py
@@ -189,6 +189,28 @@ def test_code_height_is_independent_of_boundary_glyphs(
     np.testing.assert_allclose(background_heights, background_heights[0], atol=1e-6)
 
 
+@pytest.mark.parametrize("disable_ligatures", [True, False])
+@pytest.mark.parametrize("add_line_numbers", [True, False])
+def test_code_line_mobject_is_independent_of_ordinality(
+    disable_ligatures, add_line_numbers
+):
+    """Test that the (sub)mobject structure and width of a line of code does not depend
+    on the line's order in the block.
+    """
+    code_strings = ("Hello World!",) * 5
+    code_mobject = Code(
+        code_string="\n".join(code_strings),
+        add_line_numbers=add_line_numbers,
+        paragraph_config={"disable_ligatures": disable_ligatures},
+    )
+    lines = code_mobject.code_lines
+    for i in range(len(lines)):
+        j = i % len(lines)
+        assert len(lines[i]) == len(lines[j])
+
+        np.testing.assert_allclose(lines[i].width, lines[j].width, atol=1e-6)
+
+
 def test_code_syntax_highlighting_colors():
     code_string = "pass\n# comment"
     rendered_code = Code(


### PR DESCRIPTION
- Use actual number of rendered glyphs to count how many glyphs to remove from a line
- Add test to confirm that an adjusted and non-adjusted line are identical

<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
Fixes a bug introduced by yours truly in #4692 where, when `disable_ligatures` was set to `False` in `paragraph_config`, the line alignment code would delete actual content glyphs because the length of the reference string used for alignment and the number of added submobjects did not match. This count is now directly based on a separate `Text` object created from the alignment string rather than the string itself.

A rudimentary test has been added to confirm that code lines are indeed unchanged at the time the `Code` initializer finishes.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
