### PR TITLE
Change ORIGIN type from Vector3D to Point3D

### DIFF
--- a/manim/constants.py
+++ b/manim/constants.py
@@ -9,7 +9,7 @@ import numpy as np
 from cloup import Context
 from PIL.Image import Resampling
 
-from manim.typing import Vector3D
+from manim.typing import Point3D, Vector3D
 
 __all__ = [
     "SCENE_NOT_FOUND_MESSAGE",
@@ -118,7 +118,7 @@ RESAMPLING_ALGORITHMS = {
 }
 
 # Geometry: directions
-ORIGIN: Vector3D = np.array((0.0, 0.0, 0.0))
+ORIGIN: Point3D = np.array((0.0, 0.0, 0.0))
 """The center of the coordinate system."""
 
 UP: Vector3D = np.array((0.0, 1.0, 0.0))


### PR DESCRIPTION
## Overview: What does this pull request change?
Changes the type of `ORIGIN` from `Vector3D` to `Point3D` to reflect that the constant is meant to represent the **point** at the origin. 

## Further Information and Comments
Doesn't actually change underlying type, as both are defined as `npt.NDArray[PointDType]`.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
