### PR TITLE
Fix MathTypst grouping changing expression layout

### DIFF
--- a/manim/mobject/text/typst_mobject.py
+++ b/manim/mobject/text/typst_mobject.py
@@ -137,7 +137,10 @@ from manim.mobject.types.vectorized_mobject import VGroup, VMobject
 from manim.utils.color import BLACK, ParsableManimColor
 from manim.utils.typst_file_writing import typst_to_svg_file
 
-_MANIMGRP_PREAMBLE = "#let manimgrp(lbl, body) = [#box(body) #label(lbl)]"
+_MANIMGRP_LINK_PREFIX = "https://manim.invalid/group/"
+_MANIMGRP_PREAMBLE = (
+    f'#let manimgrp(lbl, body) = link("{_MANIMGRP_LINK_PREFIX}" + lbl, body)'
+)
 
 # Pattern for the label part of {{ content : label }}.
 # The label must be a valid Typst label identifier.
@@ -499,21 +502,29 @@ class Typst(SVGMobject):
     # -- SVG post-processing -------------------------------------------------
 
     def modify_xml_tree(self, element_tree: ET.ElementTree) -> ET.ElementTree:
-        """Convert ``data-typst-label`` attributes to ``id`` before parsing.
+        """Convert Typst selection metadata to ``id`` attributes before parsing.
 
-        Typst's SVG renderer emits ``data-typst-label`` on ``<g>`` elements
-        that carry a label (created via ``#box(body) <label>``).  The
-        ``svgelements`` library propagates custom ``data-*`` attributes from
-        parent groups to all children, making them unusable as unique group
-        keys.  ``id`` attributes, on the other hand, are *not* inherited.
+        Typst's SVG renderer emits an ``<a>`` marker after every visible SVG
+        sibling covered by a link. MathTypst uses links with a private URL
+        prefix so selectable expressions retain their surrounding math context.
+        Replace those markers with labeled wrappers around the corresponding
+        visible siblings, then remove the links before SVG import.
 
-        This method walks the XML tree and promotes every
-        ``data-typst-label`` to ``id`` (on ``<g>`` elements only), so that
-        :meth:`~.SVGMobject.get_mobjects_from` can pick them up via its
-        existing ``id``-based grouping logic.
+        Ordinary Typst labels emit ``data-typst-label`` on ``<g>`` elements.
+        The ``svgelements`` library propagates custom ``data-*`` attributes
+        from parent groups to all children, making them unusable as unique
+        group keys. ``id`` attributes, on the other hand, are *not* inherited.
+
+        This method converts private link markers to ``data-typst-label``
+        wrappers and then promotes every such attribute to ``id``, so that
+        :meth:`~.SVGMobject.get_mobjects_from` can use its existing grouping
+        logic.
         """
         # Let the base class inject default style wrappers first.
         element_tree = super().modify_xml_tree(element_tree)
+        root = element_tree.getroot()
+        if root is not None:
+            self._replace_manimgrp_links(root)
 
         # Walk all elements regardless of namespace — ElementTree
         # qualifies tags with the namespace URI, so a bare ``"g"``
@@ -531,6 +542,43 @@ class Typst(SVGMobject):
                 del element.attrib["data-typst-label"]
 
         return element_tree
+
+    @classmethod
+    def _replace_manimgrp_links(cls, parent: ET.Element) -> None:
+        """Replace private Typst link markers with labeled SVG wrappers."""
+        for child in parent:
+            cls._replace_manimgrp_links(child)
+
+        visible_children: list[ET.Element] = []
+        for child in parent:
+            label = cls._get_manimgrp_link_label(child)
+            if label is None:
+                visible_children.append(child)
+                continue
+
+            if not visible_children:
+                continue
+
+            preceding = visible_children[-1]
+            if preceding.get("data-typst-label") == label:
+                continue
+
+            wrapper = ET.Element("g", {"data-typst-label": label})
+            wrapper.append(preceding)
+            visible_children[-1] = wrapper
+
+        parent[:] = visible_children
+
+    @staticmethod
+    def _get_manimgrp_link_label(element: ET.Element) -> str | None:
+        """Return the label encoded in a private Typst link marker."""
+        if element.tag.rsplit("}", 1)[-1] != "a":
+            return None
+
+        href = element.get("href") or element.get("{http://www.w3.org/1999/xlink}href")
+        if href is None or not href.startswith(_MANIMGRP_LINK_PREFIX):
+            return None
+        return href.removeprefix(_MANIMGRP_LINK_PREFIX)
 
     # -- sub-expression selection --------------------------------------------
 

--- a/tests/module/mobject/text/test_typst_mobject.py
+++ b/tests/module/mobject/text/test_typst_mobject.py
@@ -275,6 +275,16 @@ def test_mathtypst_double_brace_named(config):
     assert len(eq.select("denom")) == 3
 
 
+def test_mathtypst_grouping_preserves_math_layout(config):
+    """Grouping an expression only adds selection metadata."""
+    expression = r"integral_0^infinity e^(-x^2) dif x"
+    plain = MathTypst(expression, use_svg_cache=False)
+    grouped = MathTypst(f"{{{{ {expression} : integral }}}}", use_svg_cache=False)
+
+    assert len(grouped.select("integral")) == len(grouped.submobjects)
+    np.testing.assert_allclose(grouped.get_all_points(), plain.get_all_points())
+
+
 def test_mathtypst_double_brace_mixed_named_auto(config):
     """Named and auto-numbered groups can coexist."""
     eq = MathTypst("{{ a : lhs }} = {{ b }}", use_svg_cache=False)


### PR DESCRIPTION
## Overview: What does this pull request change?

Fixes `MathTypst` selection groups so adding `{{ ... }}` metadata no longer changes the grouped expression's math style, spacing, or geometry.

Fixes #4931.

## Motivation and Explanation: Why and how do your changes improve the library?

The existing `manimgrp` helper wrapped selected content in `#box(body)`. That moved the body out of its surrounding math context, which changed display-style operators and glyph styling such as the `x` in `dif x`.

The helper now uses a temporary link with a private marker URL. Typst preserves the original math context and emits SVG link markers after the visible elements. During SVG post-processing, Manim converts only those private markers into labeled wrappers used by `select()`, then removes the links and their transparent rectangles before SVG import.

A regression test compares every rendered point of the issue's grouped integral with the identical ungrouped expression and verifies that selection still covers the full group.

## Links to added or changed documentation pages

No documentation pages changed.

## Testing

- `uv run pytest tests/module/mobject/text/test_typst_mobject.py -q` — 35 passed
- `uv run pytest tests/module/mobject/text -q` — 114 passed
- `uv run pytest --skip_slow -q` — 1035 passed, 73 skipped, 6 xfailed, 2 xpassed
- `uv run pre-commit run --files manim/mobject/text/typst_mobject.py tests/module/mobject/text/test_typst_mobject.py` — all hooks passed
- Manual reproducer: grouped and ungrouped expressions both measured `3.195333371 × 1.559187513`, contained 812 points, and had identical point geometry; `select("integral")` returned all 9 leaves.

## Further Information and Comments

The implementation relies on the SVG link-marker structure emitted by the supported Typst 0.14 series. The regression and existing Typst selection tests exercise this integration.


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
