### PR TITLE
Perf: Use temporary set to to speed up list_update and list_difference_update

### DIFF
--- a/manim/utils/iterables.py
+++ b/manim/utils/iterables.py
@@ -143,6 +143,7 @@ def list_difference_update(l1: Iterable[T], l2: Iterable[T]) -> list[T]:
         >>> list_difference_update([1, 2, 3, 4], [2, 4])
         [1, 3]
     """
+    l2 = set(l2)
     return [e for e in l1 if e not in l2]
 
 
@@ -158,7 +159,7 @@ def list_update(l1: Iterable[T], l2: Iterable[T]) -> list[T]:
         >>> list_update([1, 2, 3], [2, 4, 4])
         [1, 3, 2, 4, 4]
     """
-    return [e for e in l1 if e not in l2] + list(l2)
+    return list_difference_update(l1, l2) + list(l2)
 
 
 @overload

--- a/manim/utils/iterables.py
+++ b/manim/utils/iterables.py
@@ -159,7 +159,8 @@ def list_update(l1: Iterable[T], l2: Iterable[T]) -> list[T]:
         >>> list_update([1, 2, 3], [2, 4, 4])
         [1, 3, 2, 4, 4]
     """
-    return list_difference_update(l1, l2) + list(l2)
+    l2 = list(l2)
+    return list_difference_update(l1, l2) + l2
 
 
 @overload

--- a/tests/module/utils/test_iterables.py
+++ b/tests/module/utils/test_iterables.py
@@ -1,0 +1,35 @@
+import pytest
+
+from manim.utils.iterables import list_difference_update, list_update
+
+
+def test_list_difference_update_removes_matching_items():
+    assert list_difference_update([1, 2, 3, 4], [2, 4]) == [1, 3]
+
+
+def test_list_difference_update_preserves_duplicates_and_order():
+    assert list_difference_update([3, 1, 3, 2, 1], [1]) == [3, 3, 2]
+
+
+@pytest.mark.parametrize(
+    ("l1", "l2", "expected"),
+    [([1, 2, 3, 4], [2, 4], [1, 3]), ([], [1, 2], [])],
+)
+def test_list_difference_update_removes_elements(l1, l2, expected):
+    assert list_difference_update(l1, l2) == expected
+
+
+def test_list_difference_update_preserves_l1_order_and_duplicates():
+    assert list_difference_update([3, 1, 3, 2, 1], [1]) == [3, 3, 2]
+
+
+@pytest.mark.parametrize(
+    ("l1", "l2", "expected"),
+    [([1, 2, 3], [2, 4], [1, 3, 2, 4]), ([], [1, 2], [1, 2])],
+)
+def test_list_update_removes_overlap_and_appends_l2(l1, l2, expected):
+    assert list_update(l1, l2) == expected
+
+
+def test_list_update_preserves_duplicates_in_l2():
+    assert list_update([1, 2, 3], [2, 4, 4]) == [1, 3, 2, 4, 4]


### PR DESCRIPTION
## Overview: What does this pull request change?
This PR uses a `set` for the repeated membership test performed in `list_update` and `list_difference_update` to improve performance. I've also written tests for these functions, since none existed.

The new versions of both methods also explicitly support generator iterables, which is not currently the case despite the `Iterable[T]` type hints.
## Motivation and Explanation: Why and how do your changes improve the library?
In their current implementations, both functions use this pattern:
```py
return [e for e in l1 if e not in l2] # (and some other stuff)
```
Clearly, if `l2` is a list, then the time complexity is `O(len(l1) * len(l2))` in the worst case. This small change massively improves performance when `l2` is large.

I wrote a quick script to benchmark the before and after, measured with cProfile:
```py
def construct(self):
    self.foreground_mobjects = [Circle() for _ in range(10000)]
    group = Group()
    group.submobjects = [Triangle() for _ in range(1000)]
    anims = [Animation(mob) for mob in group]
    for _ in range(20):
        self.play(*anims)
```
Results with current implementation (**total time 15.417 seconds**):
<img width="943" height="119" alt="image" src="https://github.com/user-attachments/assets/6b9e50f2-8a0b-45bc-bae6-d4f9e8b66b5e" />
Results with my implementation (**total time 0.0232 seconds**):
<img width="838" height="128" alt="image" src="https://github.com/user-attachments/assets/7b046cf7-0aaf-48e9-a1bb-88e1d128e070" />
I haven't done a similar benchmark for small `l2` but anecdotally, performance is more or less unchanged.
## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->

## Further Information and Comments
It seems that there are simply no tests for any of the `utils/iterables` methods? Let's hope the ones I wrote are a good enough start, then we can add more later :)

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
