### PR TITLE
Add proper singular/plural form of "submobject(s)" in VGroup __str__

### DIFF
--- a/manim/mobject/opengl/opengl_vectorized_mobject.py
+++ b/manim/mobject/opengl/opengl_vectorized_mobject.py
@@ -1704,10 +1704,10 @@ class OpenGLVGroup(OpenGLVMobject):
             + ")"
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"{self.__class__.__name__} of {len(self.submobjects)} "
-            f"submobject{'s' if len(self.submobjects) > 0 else ''}"
+            f"submobject{'' if len(self.submobjects) == 1 else 's'}"
         )
 
     def add(self, *vmobjects: OpenGLVMobject) -> Self:

--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -2249,7 +2249,7 @@ class VGroup(VMobject, metaclass=ConvertToOpenGL):
     def __str__(self) -> str:
         return (
             f"{self.__class__.__name__} of {len(self.submobjects)} "
-            f"submobject{'s' if len(self.submobjects) > 0 else ''}"
+            f"submobject{'' if len(self.submobjects) == 1 else 's'}"
         )
 
     def add(

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -452,6 +452,28 @@ def test_vgroup_item_assignment_only_allows_vmobjects():
     )
 
 
+def test_vgroup_str_name():
+    """Test VGroup's string representation correctly includes class name"""
+
+    class VGroupSubclass(VGroup):
+        pass
+
+    for cls, name in (VGroup, "VGroup"), (VGroupSubclass, "VGroupSubclass"):
+        group = cls(VMobject())
+        expected = f"{name} of"
+        actual = str(group)
+        assert actual.startswith(expected), f"'{actual}'.startswith('{expected}')"
+
+
+def test_vgroup_str_pluralization():
+    """Test VGroup's string representation correctly pluralizes 'submobject(s)'"""
+    for i in (0, 1, 2):
+        group = VGroup(VMobject() for _ in range(i))
+        expected = f"of {i} {'submobject' if i == 1 else 'submobjects'}"
+        actual = str(group)
+        assert actual.endswith(expected), f"'{actual}'.endswith('{expected}')"
+
+
 def test_trim_dummy():
     o = VMobject()
     o.start_new_path(np.array([0, 0, 0]))

--- a/tests/opengl/test_opengl_vectorized_mobject.py
+++ b/tests/opengl/test_opengl_vectorized_mobject.py
@@ -372,3 +372,25 @@ def test_vgroup_item_assignment_only_allows_vmobjects(using_opengl_renderer):
         "Only values of type OpenGLVMobject can be added as submobjects of "
         "VGroup, but the value invalid object (at index 0) is of type str."
     )
+
+
+def test_vgroup_str_name(using_opengl_renderer):
+    """Test VGroup's string representation correctly includes class name"""
+
+    class VGroupSubclass(VGroup):
+        pass
+
+    for cls, name in (VGroup, "VGroup"), (VGroupSubclass, "VGroupSubclass"):
+        group = cls(OpenGLVMobject())
+        expected = f"{name} of"
+        actual = str(group)
+        assert actual.startswith(expected), f"'{actual}'.startswith('{expected}')"
+
+
+def test_vgroup_str_pluralization(using_opengl_renderer):
+    """Test VGroup's string representation correctly pluralizes 'submobject(s)'"""
+    for i in (0, 1, 2):
+        group = VGroup(OpenGLVMobject() for _ in range(i))
+        expected = f"of {i} {'submobject' if i == 1 else 'submobjects'}"
+        actual = str(group)
+        assert actual.endswith(expected), f"'{actual}'.endswith('{expected}')"


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
This PR fixes an incorrect conditional; `VGroup.__str__` now correctly returns `VGroup of 1 submobject` if it contains exactly 1 submobject and `VGroup of {num} submobjects` for 0 or 2+ submobjects. This has been done for both `VGroup` and `OpenGLVGroup`. Tests have been added for this feature as well as for proper inclusion of the class name in the output string.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
The current implementation pluralizes "submobject(s)" with `f"submobject{'s' if len(self.submobjects) > 0 else ''}"`, which returns `of 0 submobject` for an empty group and `of k submobjects` for 1 submobject or greater. IOW, the string output is wrong for both the 0 and 1 case. This PR fixes that. 

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
Should this also be done for `Group`?


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
