### PR TITLE
Fix OpenGLMobject.is_off_screen right-bounds check

### DIFF
--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -1947,7 +1947,7 @@ class OpenGLMobject:
     def is_off_screen(self) -> bool:
         if self.get_left()[0] > config.frame_x_radius:
             return True
-        if self.get_right()[0] < config.frame_x_radius:
+        if self.get_right()[0] < -config.frame_x_radius:
             return True
         if self.get_bottom()[1] > config.frame_y_radius:
             return True


### PR DESCRIPTION
## Overview: What does this pull request change?
Fixes the check for the right-bounds in the `OpenGLMobject.is_off_screen` method.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
