### PR TITLE
Fix: skip hidden files and tolerate vanishing files when cleaning the partial movie cache

### DIFF
--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -1053,23 +1053,46 @@ class SceneFileWriter:
         with (self.sections_output_dir / f"{self.output_name}.json").open("w") as file:
             json.dump(sections_index, file, indent=4)
 
+    def _cached_partial_movie_files(self) -> list[Path]:
+        """Return the partial movie files currently contained in the cache.
+
+        The partial movie file list is excluded (matching by file name: a
+        ``Path`` never compares equal to its ``str`` name). Hidden files are
+        excluded as well: on macOS, Finder leaves resource forks (``._*.mp4``)
+        and ``.DS_Store`` files in the directory which must not count against
+        ``max_files_cached`` and may vanish again before they could be
+        deleted.
+        """
+        return [
+            self.partial_movie_directory / file_name
+            for file_name in self.partial_movie_directory.iterdir()
+            if file_name.name != "partial_movie_file_list.txt"
+            and not file_name.name.startswith(".")
+        ]
+
     def clean_cache(self) -> None:
         """Will clean the cache by removing the oldest partial_movie_files."""
-        cached_partial_movies = [
-            (self.partial_movie_directory / file_name)
-            for file_name in self.partial_movie_directory.iterdir()
-            if file_name != "partial_movie_file_list.txt"
-        ]
+        cached_partial_movies = self._cached_partial_movie_files()
         if len(cached_partial_movies) > config["max_files_cached"]:
             number_files_to_delete = (
                 len(cached_partial_movies) - config["max_files_cached"]
             )
+
+            def access_time(path: Path) -> float:
+                try:
+                    return path.stat().st_atime
+                except OSError:
+                    # The file vanished between listing the directory and
+                    # now; sort it last and let unlink(missing_ok=True)
+                    # handle its deletion.
+                    return float("inf")
+
             oldest_files_to_delete = sorted(
                 cached_partial_movies,
-                key=lambda path: path.stat().st_atime,
+                key=access_time,
             )[:number_files_to_delete]
             for file_to_delete in oldest_files_to_delete:
-                file_to_delete.unlink()
+                file_to_delete.unlink(missing_ok=True)
             logger.info(
                 f"The partial movie directory is full (> {config['max_files_cached']} files). Therefore, manim has removed the {number_files_to_delete} oldest file(s)."
                 " You can change this behaviour by changing max_files_cached in config.",
@@ -1077,13 +1100,9 @@ class SceneFileWriter:
 
     def flush_cache_directory(self) -> None:
         """Delete all the cached partial movie files"""
-        cached_partial_movies = [
-            self.partial_movie_directory / file_name
-            for file_name in self.partial_movie_directory.iterdir()
-            if file_name != "partial_movie_file_list.txt"
-        ]
+        cached_partial_movies = self._cached_partial_movie_files()
         for f in cached_partial_movies:
-            f.unlink()
+            f.unlink(missing_ok=True)
         logger.info(
             f"Cache flushed. {len(cached_partial_movies)} file(s) deleted in %(par_dir)s.",
             {"par_dir": self.partial_movie_directory},

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -1081,11 +1081,11 @@ class SceneFileWriter:
             def access_time(path: Path) -> float:
                 try:
                     return path.stat().st_atime
-                except OSError:
+                except FileNotFoundError:
                     # The file vanished between listing the directory and
-                    # now; sort it last and let unlink(missing_ok=True)
-                    # handle its deletion.
-                    return float("inf")
+                    # now; sort it first and let unlink(missing_ok=True)
+                    # handle its deletion without evicting an existing file.
+                    return float("-inf")
 
             oldest_files_to_delete = sorted(
                 cached_partial_movies,

--- a/tests/test_scene_rendering/test_file_writer.py
+++ b/tests/test_scene_rendering/test_file_writer.py
@@ -1,13 +1,14 @@
 import sys
 from fractions import Fraction
 from pathlib import Path
+from unittest.mock import Mock
 
 import av
 import numpy as np
 import pytest
 
 from manim import DR, Circle, Create, Scene, Star, tempconfig
-from manim.scene.scene_file_writer import to_av_frame_rate
+from manim.scene.scene_file_writer import SceneFileWriter, to_av_frame_rate
 from manim.utils.commands import capture, get_video_metadata
 
 
@@ -185,3 +186,76 @@ def test_frame_rates():
     assert to_av_frame_rate(23.976) == Fraction(24 * 1000, 1001)
     assert to_av_frame_rate(23.98) == Fraction(24 * 1000, 1001)
     assert to_av_frame_rate(59.94) == Fraction(60 * 1000, 1001)
+
+
+def _new_file_writer(scene_name: str) -> SceneFileWriter:
+    renderer = Mock()
+    renderer.num_plays = 0
+    return SceneFileWriter(renderer, scene_name)
+
+
+def test_clean_cache_ignores_hidden_files(config, tmp_path):
+    # macOS leaves resource forks (._*.mp4) and .DS_Store files in the
+    # partial movie directory; they must not be counted against
+    # max_files_cached nor be deleted, see issue #3234.
+    with tempconfig({"media_dir": tmp_path, "write_to_movie": True}):
+        writer = _new_file_writer("CacheCleaningScene")
+        cache_dir = writer.partial_movie_directory
+
+        for name in ["00001.mp4", ".DS_Store", "._00001.mp4"]:
+            (cache_dir / name).touch()
+
+        config.max_files_cached = 1
+        # The hidden files must not count towards the limit: with a single
+        # real partial movie file cached, nothing must be evicted.
+        writer.clean_cache()
+
+        assert (cache_dir / "00001.mp4").exists()
+        assert (cache_dir / ".DS_Store").exists()
+        assert (cache_dir / "._00001.mp4").exists()
+
+        config.max_files_cached = 0
+        writer.clean_cache()
+
+        assert not (cache_dir / "00001.mp4").exists()
+        assert (cache_dir / ".DS_Store").exists()
+        assert (cache_dir / "._00001.mp4").exists()
+
+
+def test_flush_cache_directory_ignores_hidden_files(config, tmp_path):
+    with tempconfig({"media_dir": tmp_path, "write_to_movie": True}):
+        writer = _new_file_writer("CacheFlushingScene")
+        cache_dir = writer.partial_movie_directory
+
+        for name in ["00001.mp4", "00002.mp4", ".DS_Store", "._00001.mp4"]:
+            (cache_dir / name).touch()
+        (cache_dir / "partial_movie_file_list.txt").touch()
+
+        writer.flush_cache_directory()
+
+        assert not (cache_dir / "00001.mp4").exists()
+        assert not (cache_dir / "00002.mp4").exists()
+        assert (cache_dir / "partial_movie_file_list.txt").exists()
+        assert (cache_dir / ".DS_Store").exists()
+        assert (cache_dir / "._00001.mp4").exists()
+
+
+def test_clean_cache_tolerates_vanishing_files(config, tmp_path, monkeypatch):
+    # A file can disappear between listing the directory and unlinking it
+    # (e.g. Finder removing a transient resource fork); clean_cache must
+    # not raise FileNotFoundError in that case.
+    with tempconfig({"media_dir": tmp_path, "write_to_movie": True}):
+        writer = _new_file_writer("VanishingFileScene")
+        cache_dir = writer.partial_movie_directory
+
+        survivor = cache_dir / "00001.mp4"
+        survivor.touch()
+        ghost = cache_dir / "00002.mp4"
+        monkeypatch.setattr(
+            writer, "_cached_partial_movie_files", lambda: [survivor, ghost]
+        )
+
+        config.max_files_cached = 0
+        writer.clean_cache()
+
+        assert not survivor.exists()

--- a/tests/test_scene_rendering/test_file_writer.py
+++ b/tests/test_scene_rendering/test_file_writer.py
@@ -259,3 +259,24 @@ def test_clean_cache_tolerates_vanishing_files(config, tmp_path, monkeypatch):
         writer.clean_cache()
 
         assert not survivor.exists()
+
+
+def test_clean_cache_does_not_evict_for_vanished_file(config, tmp_path, monkeypatch):
+    with tempconfig({"media_dir": tmp_path, "write_to_movie": True}):
+        writer = _new_file_writer("VanishedFileEvictionScene")
+        cache_dir = writer.partial_movie_directory
+
+        survivors = [cache_dir / f"{index:05}.mp4" for index in range(2)]
+        for survivor in survivors:
+            survivor.touch()
+        ghost = cache_dir / "00002.mp4"
+        monkeypatch.setattr(
+            writer,
+            "_cached_partial_movie_files",
+            lambda: [*survivors, ghost],
+        )
+
+        config.max_files_cached = len(survivors)
+        writer.clean_cache()
+
+        assert all(survivor.exists() for survivor in survivors)


### PR DESCRIPTION
## Overview: What does this pull request change?

`SceneFileWriter.clean_cache()` and `flush_cache_directory()` now share a new `_cached_partial_movie_files()` helper that fixes three issues:

1. **Hidden files are excluded from cache operations.** On macOS, Finder leaves `.DS_Store` and AppleDouble resource-fork files (`._*.mp4`) in the partial movie directory. They were counted against `max_files_cached` and deleted like regular partial movie files; since such transient files can vanish between listing and deletion, this could raise `FileNotFoundError` and abort the generation of the final video.
2. **The partial movie file list is now actually excluded.** The previous comparison `file_name != "partial_movie_file_list.txt"` compared a `Path` against a `str`, which never matches — the intended exclusion never worked, so the file list itself was deleted by `flush_cache_directory()`.
3. **Files vanishing mid-run no longer break the cache cleaning.** Both the access-time sort key (`path.stat()`) and the deletion (`unlink()`) are now tolerant of files that disappear after the directory listing: the sort key falls back to sorting vanished files last, and deletion uses `unlink(missing_ok=True)`.

## Motivation and Explanation: Why and how do your changes improve the library?

Fixes #3234. Items 2 and 3 are latent bugs in the same code paths that were found and verified while writing regression tests for the reported issue.

## Links to added or changed documentation pages

Not applicable — no user-facing API or behavior beyond the bugfix changed. (The new private helper has a docstring.)

## Further Information and Comments

**Testing** (all run locally, Windows, Python 3.14 venv):

- Three new non-rendering tests in `tests/test_scene_rendering/test_file_writer.py`:
  - `test_clean_cache_ignores_hidden_files` — hidden files neither count against `max_files_cached` nor get deleted;
  - `test_flush_cache_directory_ignores_hidden_files` — flush keeps hidden files and `partial_movie_file_list.txt`;
  - `test_clean_cache_tolerates_vanishing_files` — a file disappearing between listing and deletion no longer raises.
- Verified as regression tests: with this PR's changes reverted (original code stashed), all 3 new tests **fail**; with the changes applied, all 3 **pass**.
- The remaining non-slow tests in `test_file_writer.py` pass (`5 passed`), no regressions.
- `ruff check` and `ruff format --check` pass on both changed files.
