### PR TITLE
Fix dim of OpenGLMobject.stretch_to_fit_depth

### DIFF
--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -2004,7 +2004,7 @@ class OpenGLMobject:
 
     def stretch_to_fit_depth(self, depth: float, **kwargs: Any) -> Self:
         """Stretches the :class:`~.OpenGLMobject` to fit a depth, not keeping width/height proportional."""
-        return self.rescale_to_fit(depth, 1, stretch=True, **kwargs)
+        return self.rescale_to_fit(depth, 2, stretch=True, **kwargs)
 
     def set_width(
         self,

--- a/tests/opengl/test_opengl_mobject.py
+++ b/tests/opengl/test_opengl_mobject.py
@@ -65,6 +65,17 @@ def test_opengl_mobject_remove(using_opengl_renderer):
     assert obj.remove(OpenGLMobject()) is obj
 
 
+def test_opengl_mobject_stretch_to_fit_depth(using_opengl_renderer):
+    """Test that stretch_to_fit_depth changes the depth dimension."""
+    obj = OpenGLMobject().set_points(
+        np.array([[-1.0, -2.0, -3.0], [1.0, 2.0, 3.0]]),
+    )
+
+    obj.stretch_to_fit_depth(12)
+
+    np.testing.assert_allclose([obj.width, obj.height, obj.depth], [2, 4, 12])
+
+
 def test_opengl_rotate_about_vertex_view(using_opengl_renderer):
     """Test that rotating about a vertex obtained from get_vertices() works correctly.
 


### PR DESCRIPTION
## Overview: What does this pull request change?
Fixes dimension of `OpenGLMobject.stretch_to_fit_depth`.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
