### PR TITLE
Fix OpenGLMobject.get_boundary_point

### DIFF
--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -2384,10 +2384,7 @@ class OpenGLMobject:
 
     def get_boundary_point(self, direction: Vector3DLike) -> Point3D:
         all_points = self.get_all_points()
-        boundary_directions = all_points - self.get_center()
-        norms = np.linalg.norm(boundary_directions, axis=1)
-        boundary_directions /= np.repeat(norms, 3).reshape((len(norms), 3))
-        index = np.argmax(np.dot(boundary_directions, direction))
+        index = np.argmax(np.dot(all_points, direction))
         return all_points[index]
 
     def get_continuous_bounding_box_point(self, direction: Vector3DLike) -> Point3D:

--- a/tests/opengl/test_opengl_mobject.py
+++ b/tests/opengl/test_opengl_mobject.py
@@ -65,6 +65,15 @@ def test_opengl_mobject_remove(using_opengl_renderer):
     assert obj.remove(OpenGLMobject()) is obj
 
 
+def test_opengl_mobject_get_boundary_point(using_opengl_renderer):
+    """Test that get_boundary_point returns the furthest point in a direction."""
+    obj = OpenGLMobject().set_points(
+        np.array([[-2.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]),
+    )
+
+    np.testing.assert_array_equal(obj.get_boundary_point([1, 0, 0]), [2, 0, 0])
+
+
 def test_opengl_rotate_about_vertex_view(using_opengl_renderer):
     """Test that rotating about a vertex obtained from get_vertices() works correctly.
 


### PR DESCRIPTION
## Overview: What does this pull request change?
Fixes the implementation of `get_boundary_point` in `OpenGLMobject`. Now uses the same implementation as `Mobject`.

Here I small scene made by nikolaj where the result of the old implementations differed:
```py
def construct(self):
    self.add(Text(config.renderer.name).to_edge(DOWN))
    line = Line().set_points_as_corners([
        [-2, 0, 0],
        [1, 0, 0],
        [2, 0, 0]
    ])
    self.add(
        line,
        Dot(line.get_boundary_point(RIGHT), color=RED)
    )
```
<img width="960" height="540" alt="opengl" src="https://github.com/user-attachments/assets/19fea301-6402-480e-a6d6-c3a7915ab26f" />
<img width="1280" height="720" alt="cairo" src="https://github.com/user-attachments/assets/f892ba18-c61c-48fb-bf37-22e2afa7c73f" />




<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
