### PR TITLE
fix(config): restore renderer class bases on config update

### DIFF
--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -380,7 +380,12 @@ class ManimConfig(MutableMapping):
 
         """
         if isinstance(obj, ManimConfig):
+            renderer = obj.renderer
             self._d.update(obj._d)
+            if renderer is not None:
+                # Apply the renderer through its setter so that the
+                # ConvertToOpenGL class bases stay in sync with the config value.
+                self.renderer = renderer
             if obj.tex_template:
                 self.tex_template = obj.tex_template
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,8 +6,11 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from manim import WHITE, Scene, Square, Tex, Text, tempconfig
+from manim import RIGHT, WHITE, Scene, Square, Tex, Text, Vector, tempconfig
 from manim._config.utils import ManimConfig
+from manim.constants import RendererType
+from manim.mobject.opengl.opengl_vectorized_mobject import OpenGLVMobject
+from manim.mobject.types.vectorized_mobject import VMobject
 from tests.assert_utils import assert_dir_exists, assert_dir_filled, assert_file_exists
 
 
@@ -32,6 +35,17 @@ def test_tempconfig(config):
             np.testing.assert_allclose(config[k], v)
         else:
             assert config[k] == v
+
+
+def test_tempconfig_restores_renderer_class_bases(config):
+    with tempconfig({"renderer": "opengl"}):
+        assert config.renderer == RendererType.OPENGL
+        assert issubclass(Vector, OpenGLVMobject)
+
+    assert config.renderer == RendererType.CAIRO
+    assert issubclass(Vector, VMobject)
+    assert not issubclass(Vector, OpenGLVMobject)
+    Vector(RIGHT)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #4952.

## Summary

- Reapply the renderer through its property setter when updating from another `ManimConfig`.
- Keep `config.renderer` synchronized with the class bases managed by `ConvertToOpenGL`.
- Add a regression test covering an OpenGL `tempconfig` context, restoration to Cairo, and subsequent `Vector` construction.

## Validation

- 4 focused configuration, metaclass, and ghost-vector tests
- 100 renderer round-trip runtime checks
- Ruff check and formatting
- Targeted mypy check for `manim/_config/utils.py`
- `git diff --check`