### PR TITLE
fix: np.sum deprecation for generators

### DIFF
--- a/manim/mobject/opengl/opengl_vectorized_mobject.py
+++ b/manim/mobject/opengl/opengl_vectorized_mobject.py
@@ -1129,9 +1129,14 @@ class OpenGLVMobject(OpenGLMobject):
             The length of the :class:`OpenGLVMobject`.
         """
         return np.sum(
-            length
-            for _, length in self.get_curve_functions_with_lengths(
-                sample_points=sample_points_per_curve,
+            np.fromiter(
+                (
+                    length
+                    for _, length in self.get_curve_functions_with_lengths(
+                        sample_points=sample_points_per_curve,
+                    )
+                ),
+                dtype=np.float64,
             )
         )
 


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

Fixes `np.sum` over generator that is deprecated. 

As a small example, the `TypeError` is raised with the following scene when using `OpenGL` renderer (the combination of `path_arc` and `buff` triggers `get_arc_length` to be called):

```
class Test(Scene):
    def construct(self):
        line = Line(
                LEFT,
                RIGHT,
                path_arc=PI / 2,
                buff=SMALL_BUFF,
            )
        self.add(line)
```

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->

- https://numpy.org/doc/2.4/release/2.4.0-notes.html#numpy-array2string-and-numpy-sum-deprecations-finalized


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
