### PR TITLE
Fix flaky ConvexHull example in rendered docs

### DIFF
--- a/manim/utils/qhull.py
+++ b/manim/utils/qhull.py
@@ -112,12 +112,22 @@ class QuickHull:
         self.internal: PointND | None = None
         self.tolerance = tolerance
 
+    def _find_initial_simplex(self, points: PointND_Array) -> PointND_Array:
+        """Find a deterministic, affinely independent initial simplex."""
+        dimension = points.shape[1]
+        indices = [0]
+
+        for index in range(1, len(points)):
+            candidate = points[indices + [index]]
+            if np.linalg.matrix_rank(candidate[1:] - candidate[0]) == len(indices):
+                indices.append(index)
+                if len(indices) == dimension + 1:
+                    return points[indices]
+
+        raise ValueError("The points do not span the full coordinate dimension.")
+
     def initialize(self, points: PointND_Array) -> None:
-        # Sample Points
-        rng = np.random.default_rng()
-        simplex = points[
-            rng.choice(points.shape[0], points.shape[1] + 1, replace=False)
-        ]
+        simplex = self._find_initial_simplex(points)
         self.unclaimed = points
         new_internal: PointND = np.mean(simplex, axis=0)
         self.internal = new_internal

--- a/tests/module/utils/test_qhull.py
+++ b/tests/module/utils/test_qhull.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from manim.utils.qhull import QuickHull
+
+
+def test_initial_simplex_is_affinely_independent():
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 1.0],
+            [2.0, 2.0],  # The first three points are collinear.
+            [0.0, 2.0],
+            [2.0, 0.0],
+        ]
+    )
+
+    simplex = QuickHull()._find_initial_simplex(points)
+
+    assert np.linalg.matrix_rank(simplex[1:] - simplex[0]) == points.shape[1]
+
+
+def test_quickhull_rejects_degenerate_input():
+    collinear_points = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 1.0],
+            [2.0, 2.0],
+            [3.0, 3.0],
+        ]
+    )
+
+    with pytest.raises(ValueError, match="full coordinate dimension"):
+        QuickHull().build(collinear_points)


### PR DESCRIPTION
Fixes flaky `ConvexHull` builds by deterministically selecting an affinely independent initial simplex instead of random points. Adds regression tests for collinear and degenerate inputs.