### PR TITLE
Refactor: media output path resolution + removal of `--custom_folders` CLI flag and config option

### DIFF
--- a/docs/source/guides/deep_dive.rst
+++ b/docs/source/guides/deep_dive.rst
@@ -274,6 +274,12 @@ continues as follows:
         self.renderer.capabilities,
         renderer_name=type(self.renderer).__name__,
     )
+    self.output_plan = resolve_output_plan(
+        resolve_media_layout(...),
+        self.session_spec.output,
+        scene_name=type(self).__name__,
+        requested_output_name=...,
+    )
     self.renderer.init_scene(self, self.session_spec)
 
 The session specification separates primary artifact intent (an ``OutputSpec``)
@@ -292,10 +298,18 @@ validates requests against the selected renderer's capabilities. For example,
 Cairo rejects live preview, while OpenGL advertises support for it. A concrete
 format records the live preview as well.
 
+The scene then resolves existing directory templates once into an immutable
+output plan containing exact scene-specific artifact, section, image-sequence,
+and cache paths. Planning performs no file I/O and creates no directories. The
+resolved format determines the artifact suffix; ``output_file`` supplies only a
+name and cannot change the format.
+
 Inspecting the initialization methods of both renderers shows that they
 instantiate a :class:`.SceneFileWriter`. The writer must receive the already
-resolved ``OutputSpec``. It remains Manim's interface to ``libav`` for
-encoding media. The Cairo renderer (see the implementation `here
+resolved ``OutputSpec`` and output plan; it does not reinterpret global
+configuration to decide what or where to write. Directories are created lazily
+when their owning operation first writes. The writer remains Manim's interface
+to ``libav`` for encoding media. The Cairo renderer (see the implementation `here
 <https://github.com/ManimCommunity/manim/blob/main/manim/renderer/cairo_renderer.py>`__)
 does not require further renderer-specific initialization. OpenGL creates a
 window only when the resolved presentation specification requests a live preview.
@@ -309,9 +323,10 @@ attribute is initially ``None`` unless the caller attaches a manager explicitly.
 
 .. warning::
 
-    The manager coordinates the scene lifecycle, while the renderer still owns
-    its camera, clock, play count, skip state, and file writer. The manager
-    currently exposes these through forwarding properties.
+    The scene captures the immutable session specification and output plan before
+    renderer initialization. The manager coordinates the scene lifecycle, while
+    the renderer still owns its camera, clock, play count, skip state, and file
+    writer. The manager exposes these through forwarding properties.
 
 The rest of this article is concerned with the last line in our toy example script::
 

--- a/docs/source/tutorials/output_and_config.rst
+++ b/docs/source/tutorials/output_and_config.rst
@@ -148,6 +148,41 @@ To write every rendered frame as a numbered PNG instead, use
 ``--format=png-sequence``. The sequence is stored in a scene-specific directory,
 for example ``media/images/scene/SquareToCircle/0000.png``.
 
+Customizing output directories
+******************************
+
+The canonical layout can be customized through the ordinary directory options in
+the ``[CLI]`` section of ``manim.cfg``. These options support placeholders and may
+refer to one another; for example:
+
+.. code-block:: ini
+
+   [CLI]
+   media_dir = project-media
+   video_dir = {media_dir}/renders/{module_name}/{quality}
+   images_dir = {media_dir}/stills/{module_name}
+   sections_dir = {video_dir}/sections
+   partial_movie_dir = {video_dir}/partial_movie_files/{scene_name}
+   log_dir = {media_dir}/logs
+
+The former ``--custom_folders`` switch and ``[custom_folders]`` preset have been
+removed. To reproduce that preset, configure its directory values explicitly:
+
+.. code-block:: ini
+
+   [CLI]
+   media_dir = videos
+   video_dir = {media_dir}
+   sections_dir = {media_dir}
+   images_dir = {media_dir}
+   text_dir = {media_dir}/temp_files
+   tex_dir = {media_dir}/temp_files
+   log_dir = {media_dir}/temp_files
+   partial_movie_dir = {media_dir}/partial_movie_files/{scene_name}
+
+This retains the same layout while keeping one explicit directory configuration
+model. Passing the removed ``--custom_folders`` option is an error.
+
 Output formats
 **************
 

--- a/docs/source/tutorials/output_and_config.rst
+++ b/docs/source/tutorials/output_and_config.rst
@@ -276,13 +276,15 @@ If you do this, the ``media`` folder will look like this:
                 │       ├── 3163782288_524160878_1793580042.mp4
                 │       └── partial_movie_file_list.txt
                 └── sections
-                    ├── ElaborateSceneWithSections_0000.mp4
-                    ├── ElaborateSceneWithSections_0001.mp4
-                    ├── ElaborateSceneWithSections_0002.mp4
+                    ├── ElaborateSceneWithSections_0000_create-square.mp4
+                    ├── ElaborateSceneWithSections_0001_transform-to-circle.mp4
+                    ├── ElaborateSceneWithSections_0003_fade-out.mp4
                     └── ElaborateSceneWithSections.json
 
 As you can see each section receives their own output video in the ``sections`` directory.
-The JSON file in here contains some useful information for each section:
+Section names are normalized into safe filename components, while the original names
+are retained in the JSON index. The JSON file contains some useful information for
+each section:
 
 .. code-block:: json
 
@@ -290,7 +292,7 @@ The JSON file in here contains some useful information for each section:
         {
             "name": "create square",
             "type": "default.normal",
-            "video": "ElaborateSceneWithSections_0000.mp4",
+            "video": "ElaborateSceneWithSections_0000_create-square.mp4",
             "codec_name": "h264",
             "width": 854,
             "height": 480,
@@ -301,7 +303,7 @@ The JSON file in here contains some useful information for each section:
         {
             "name": "transform to circle",
             "type": "default.normal",
-            "video": "ElaborateSceneWithSections_0001.mp4",
+            "video": "ElaborateSceneWithSections_0001_transform-to-circle.mp4",
             "codec_name": "h264",
             "width": 854,
             "height": 480,
@@ -312,7 +314,7 @@ The JSON file in here contains some useful information for each section:
         {
             "name": "fade out",
             "type": "default.normal",
-            "video": "ElaborateSceneWithSections_0002.mp4",
+            "video": "ElaborateSceneWithSections_0003_fade-out.mp4",
             "codec_name": "h264",
             "width": 854,
             "height": 480,

--- a/docs/source/tutorials/output_and_config.rst
+++ b/docs/source/tutorials/output_and_config.rst
@@ -217,6 +217,17 @@ preview, but it counts as a separate execution request rather than modifying the
 choice of output format. This allows Manim to function as if it were rendering a
 normal scene, but without producing any artifact.
 
+``-o`` / ``--output_file`` names the primary artifact for a single selected scene;
+it does not select the format. Manim applies the resolved format suffix exactly
+once, so ``-o movie.mp4 --format=mp4`` produces ``movie.mp4`` while
+``-o movie.mov --format=mp4`` also produces ``movie.mp4``. A single output name is
+ambiguous for a multi-scene render, so ``-o`` cannot be combined with
+``--write_all`` or with several selected scene names.
+
+A nested or absolute output name can relocate the primary artifact. Cache and section
+outputs still use their independently configured directories. In particular, section
+filenames use the normalized output stem but always remain under ``sections_dir``.
+
 
 Sections
 ********

--- a/docs/source/tutorials/output_and_config.rst
+++ b/docs/source/tutorials/output_and_config.rst
@@ -165,24 +165,6 @@ refer to one another; for example:
    partial_movie_dir = {video_dir}/partial_movie_files/{scene_name}
    log_dir = {media_dir}/logs
 
-The former ``--custom_folders`` switch and ``[custom_folders]`` preset have been
-removed. To reproduce that preset, configure its directory values explicitly:
-
-.. code-block:: ini
-
-   [CLI]
-   media_dir = videos
-   video_dir = {media_dir}
-   sections_dir = {media_dir}
-   images_dir = {media_dir}
-   text_dir = {media_dir}/temp_files
-   tex_dir = {media_dir}/temp_files
-   log_dir = {media_dir}/temp_files
-   partial_movie_dir = {media_dir}/partial_movie_files/{scene_name}
-
-This retains the same layout while keeping one explicit directory configuration
-model. Passing the removed ``--custom_folders`` option is an error.
-
 Output formats
 **************
 
@@ -218,15 +200,11 @@ choice of output format. This allows Manim to function as if it were rendering a
 normal scene, but without producing any artifact.
 
 ``-o`` / ``--output_file`` names the primary artifact for a single selected scene;
-it does not select the format. Manim applies the resolved format suffix exactly
-once, so ``-o movie.mp4 --format=mp4`` produces ``movie.mp4`` while
-``-o movie.mov --format=mp4`` also produces ``movie.mp4``. A single output name is
-ambiguous for a multi-scene render, so ``-o`` cannot be combined with
-``--write_all`` or with several selected scene names.
-
-A nested or absolute output name can relocate the primary artifact. Cache and section
-outputs still use their independently configured directories. In particular, section
-filenames use the normalized output stem but always remain under ``sections_dir``.
+it does not select the format. Manim appends the resolved format suffix unless the
+name already ends with it. For example, ``-o movie.mp4 --format=mp4`` produces
+``movie.mp4``, while ``-o movie.mov --format=mp4`` produces ``movie.mov.mp4``. A
+single output name is ambiguous for a multi-scene render, so ``-o`` cannot be
+combined with ``--write_all`` or with several selected scene names.
 
 
 Sections

--- a/manim/_config/default.cfg
+++ b/manim/_config/default.cfg
@@ -178,19 +178,6 @@ col1 =
 col2 =
 epilog =
 
-# Overrides the default output folders, NOT the output file names.  Note that
-# if the custom_folders flag is present, the Tex and text files will not be put
-# under media_dir, as is the default.
-[custom_folders]
-media_dir = videos
-video_dir = {media_dir}
-sections_dir = {media_dir}
-images_dir = {media_dir}
-text_dir = {media_dir}/temp_files
-tex_dir = {media_dir}/temp_files
-log_dir = {media_dir}/temp_files
-partial_movie_dir = {media_dir}/partial_movie_files/{scene_name}
-
 # Rich settings
 [logger]
 logging_keyword = bold yellow

--- a/manim/_config/logger_utils.py
+++ b/manim/_config/logger_utils.py
@@ -148,27 +148,14 @@ def parse_theme(parser: configparser.SectionProxy) -> Theme | None:
     return custom_theme
 
 
-def set_file_logger(scene_name: str, module_name: str, log_dir: Path) -> None:
-    """Add a file handler to manim logger.
-
-    The path to the file is built using ``config.log_dir``.
+def set_file_logger(log_file_path: Path) -> None:
+    """Add a file handler for one exact, already resolved log path.
 
     Parameters
     ----------
-    scene_name
-        The name of the scene, used in the name of the log file.
-    module_name
-        The name of the module, used in the name of the log file.
-    log_dir
-        Path to the folder where log files are stored.
+    log_file_path
+        Exact path of the log file for this scene.
     """
-    # Note: The log file name will be
-    # <name_of_animation_file>_<name_of_scene>.log, gotten from config.  So it
-    # can differ from the real name of the scene.  <name_of_scene> would only
-    # appear if scene name was provided when manim was called.
-    log_file_name = f"{module_name}_{scene_name}.log"
-    log_file_path = log_dir / log_file_name
-
     file_handler = logging.FileHandler(log_file_path, mode="w")
     file_handler.setFormatter(JSONFormatter())
 

--- a/manim/_config/output_plan.py
+++ b/manim/_config/output_plan.py
@@ -198,10 +198,10 @@ def resolve_media_layout(
     )
 
 
-def _with_artifact_extension(path: Path, extension: str) -> Path:
+def _add_artifact_extension(path: Path, extension: str) -> Path:
     if path.suffix == extension:
         return path
-    return path.with_suffix(extension)
+    return path.with_suffix(path.suffix + extension)
 
 
 def _versioned(path: Path) -> Path:
@@ -209,7 +209,7 @@ def _versioned(path: Path) -> Path:
 
 
 def _output_path(root: Path, name: Path, extension: str) -> Path:
-    return root / _with_artifact_extension(name, extension)
+    return root / _add_artifact_extension(name, extension)
 
 
 def resolve_output_plan(

--- a/manim/_config/output_plan.py
+++ b/manim/_config/output_plan.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import re
+import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
@@ -84,9 +86,18 @@ class OutputPlan:
             raise ValueError("This output plan does not contain section output.")
         if index < 0:
             raise ValueError("Section indices must be non-negative.")
+        section_slug = _slugify_section_name(name)
         return self.sections_dir / (
-            f"{self.output_stem}_{index:04}_{name}{self.segment_extension}"
+            f"{self.output_stem}_{index:04}_{section_slug}{self.segment_extension}"
         )
+
+
+def _slugify_section_name(name: str) -> str:
+    """Return a safe filename component while preserving Unicode words."""
+    if not isinstance(name, str):
+        raise TypeError("Section names must be strings.")
+    normalized = unicodedata.normalize("NFKC", name)
+    return re.sub(r"[^\w]+", "-", normalized).strip("-_") or "section"
 
 
 def _absolute_lexical(path: Path, working_directory: Path) -> Path:
@@ -306,7 +317,7 @@ def resolve_output_plan(
 
     return OutputPlan(
         primary_artifact=primary_artifact,
-        fallback_image=versioned_png,
+        fallback_image=versioned_png if output.fallback_to_still else None,
         image_sequence_dir=None,
         segment_cache_dir=layout.partial_movie_dir,
         sections_dir=sections_dir,

--- a/manim/_config/output_plan.py
+++ b/manim/_config/output_plan.py
@@ -1,0 +1,331 @@
+"""Internal scene-output path planning."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from manim import __version__
+
+from .output import OutputFormat, OutputSpec
+
+
+class _LayoutConfigSource(Protocol):
+    input_file: str | Path
+    output_file: str | Path
+    log_to_file: bool
+    zero_pad: int
+
+    def get_dir(self, key: str, **kwargs: str) -> Path | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class MediaLayoutSpec:
+    """Exact output directories captured for one scene."""
+
+    video_dir: Path | None
+    images_dir: Path | None
+    sections_dir: Path | None
+    partial_movie_dir: Path | None
+    log_dir: Path | None
+    zero_pad: int
+
+    def __post_init__(self) -> None:
+        for path in (
+            self.video_dir,
+            self.images_dir,
+            self.sections_dir,
+            self.partial_movie_dir,
+            self.log_dir,
+        ):
+            if path is not None and not path.is_absolute():
+                raise ValueError("Media layout paths must be absolute.")
+        if not 0 <= self.zero_pad <= 9:
+            raise ValueError("PNG zero padding must be between 0 and 9.")
+
+
+@dataclass(frozen=True, slots=True)
+class OutputPlan:
+    """Exact paths and dynamic child-name policy for one scene output."""
+
+    primary_artifact: Path | None
+    fallback_image: Path | None
+    image_sequence_dir: Path | None
+    segment_cache_dir: Path | None
+    sections_dir: Path | None
+    section_index: Path | None
+    subcaption_file: Path | None
+    concat_manifest: Path | None
+    output_stem: str
+    segment_extension: str | None
+    zero_pad: int
+
+    def image_frame_path(self, frame_index: int) -> Path:
+        """Return the exact path for one PNG-sequence frame."""
+        if self.image_sequence_dir is None:
+            raise ValueError("This output plan does not contain an image sequence.")
+        if frame_index < 0:
+            raise ValueError("Frame indices must be non-negative.")
+        return self.image_sequence_dir / f"{frame_index:0{self.zero_pad}d}.png"
+
+    def segment_path(self, cache_key: str) -> Path:
+        """Return the exact path for one silent cached video segment."""
+        if self.segment_cache_dir is None or self.segment_extension is None:
+            raise ValueError("This output plan does not contain video segments.")
+        if not cache_key or Path(cache_key).name != cache_key:
+            raise ValueError("A cache key must be a non-empty filename component.")
+        return self.segment_cache_dir / f"{cache_key}{self.segment_extension}"
+
+    def section_path(self, index: int, name: str) -> Path:
+        """Return the exact path for one derived section video."""
+        if self.sections_dir is None or self.segment_extension is None:
+            raise ValueError("This output plan does not contain section output.")
+        if index < 0:
+            raise ValueError("Section indices must be non-negative.")
+        return self.sections_dir / (
+            f"{self.output_stem}_{index:04}_{name}{self.segment_extension}"
+        )
+
+
+def _absolute_lexical(path: Path, working_directory: Path) -> Path:
+    if not working_directory.is_absolute():
+        raise ValueError("The output planning working directory must be absolute.")
+    anchored = path if path.is_absolute() else working_directory / path
+    return Path(os.path.normpath(anchored))
+
+
+def _required_dir(
+    config: _LayoutConfigSource,
+    key: str,
+    *,
+    working_directory: Path,
+    module_name: str,
+    scene_name: str,
+) -> Path:
+    path = config.get_dir(key, module_name=module_name, scene_name=scene_name)
+    if path is None:
+        raise ValueError(f"{key} must not be empty for the requested output.")
+    return _absolute_lexical(path, working_directory)
+
+
+def resolve_module_name(config: _LayoutConfigSource) -> str:
+    """Resolve the source module name used by configured directory templates."""
+    if not config.input_file:
+        return ""
+    input_file = config.get_dir("input_file")
+    if input_file is None:
+        return ""
+    return input_file.stem
+
+
+def resolve_requested_output_name(
+    config: _LayoutConfigSource,
+) -> Path | None:
+    """Resolve the optional user-requested output name without choosing a format."""
+    if not config.output_file:
+        return None
+    output_file = config.get_dir("output_file")
+    if output_file is None:
+        return None
+    return output_file
+
+
+def resolve_media_layout(
+    config: _LayoutConfigSource,
+    output: OutputSpec,
+    *,
+    module_name: str,
+    scene_name: str,
+    working_directory: Path,
+) -> MediaLayoutSpec:
+    """Capture exact directories needed by one concrete scene output."""
+    images_dir = None
+    video_dir = None
+    sections_dir = None
+    partial_movie_dir = None
+
+    if output.enabled:
+        images_dir = _required_dir(
+            config,
+            "images_dir",
+            working_directory=working_directory,
+            module_name=module_name,
+            scene_name=scene_name,
+        )
+    if output.is_video:
+        video_dir = _required_dir(
+            config,
+            "video_dir",
+            working_directory=working_directory,
+            module_name=module_name,
+            scene_name=scene_name,
+        )
+        partial_movie_dir = _required_dir(
+            config,
+            "partial_movie_dir",
+            working_directory=working_directory,
+            module_name=module_name,
+            scene_name=scene_name,
+        )
+        if output.save_sections:
+            sections_dir = _required_dir(
+                config,
+                "sections_dir",
+                working_directory=working_directory,
+                module_name=module_name,
+                scene_name=scene_name,
+            )
+
+    log_dir = None
+    if config.log_to_file:
+        log_dir = _required_dir(
+            config,
+            "log_dir",
+            working_directory=working_directory,
+            module_name=module_name,
+            scene_name=scene_name,
+        )
+
+    return MediaLayoutSpec(
+        video_dir=video_dir,
+        images_dir=images_dir,
+        sections_dir=sections_dir,
+        partial_movie_dir=partial_movie_dir,
+        log_dir=log_dir,
+        zero_pad=config.zero_pad,
+    )
+
+
+def _with_artifact_extension(path: Path, extension: str) -> Path:
+    if path.suffix == extension:
+        return path
+    return path.with_suffix(extension)
+
+
+def _versioned(path: Path) -> Path:
+    return path.with_name(f"{path.stem}_ManimCE_v{__version__}{path.suffix}")
+
+
+def _output_path(root: Path, name: Path, extension: str) -> Path:
+    return root / _with_artifact_extension(name, extension)
+
+
+def resolve_output_plan(
+    layout: MediaLayoutSpec,
+    output: OutputSpec,
+    *,
+    scene_name: str,
+    requested_output_name: Path | None,
+) -> OutputPlan:
+    """Resolve all stable artifact and cache paths for one scene."""
+    if not scene_name:
+        raise ValueError("A scene name is required for output planning.")
+
+    output_name = requested_output_name or Path(scene_name)
+    if output_name.name in {"", ".", ".."}:
+        raise ValueError("The requested output name must contain a filename.")
+    output_stem = output_name.stem
+
+    if output.format is OutputFormat.NONE:
+        return OutputPlan(
+            primary_artifact=None,
+            fallback_image=None,
+            image_sequence_dir=None,
+            segment_cache_dir=None,
+            sections_dir=None,
+            section_index=None,
+            subcaption_file=None,
+            concat_manifest=None,
+            output_stem=output_stem,
+            segment_extension=None,
+            zero_pad=layout.zero_pad,
+        )
+
+    images_dir = layout.images_dir
+    if images_dir is None:
+        raise ValueError("Image output requires an images directory.")
+
+    default_name = requested_output_name is None
+    normalized_png = _output_path(images_dir, output_name, ".png")
+    versioned_png = _versioned(normalized_png) if default_name else normalized_png
+
+    if output.is_still:
+        return OutputPlan(
+            primary_artifact=versioned_png,
+            fallback_image=None,
+            image_sequence_dir=None,
+            segment_cache_dir=None,
+            sections_dir=None,
+            section_index=None,
+            subcaption_file=None,
+            concat_manifest=None,
+            output_stem=output_stem,
+            segment_extension=None,
+            zero_pad=layout.zero_pad,
+        )
+
+    if output.is_image_sequence:
+        sequence_dir = normalized_png.with_suffix("")
+        return OutputPlan(
+            primary_artifact=sequence_dir,
+            fallback_image=None,
+            image_sequence_dir=sequence_dir,
+            segment_cache_dir=None,
+            sections_dir=None,
+            section_index=None,
+            subcaption_file=None,
+            concat_manifest=None,
+            output_stem=output_stem,
+            segment_extension=None,
+            zero_pad=layout.zero_pad,
+        )
+
+    if not output.is_video:
+        raise ValueError(f"Unsupported output format: {output.format.value}")
+    if layout.video_dir is None or layout.partial_movie_dir is None:
+        raise ValueError("Video output requires video and segment-cache directories.")
+
+    artifact_extension = output.artifact_extension
+    assert artifact_extension is not None
+    primary_artifact = _output_path(
+        layout.video_dir,
+        output_name,
+        artifact_extension,
+    )
+    if output.is_gif and default_name:
+        primary_artifact = _versioned(primary_artifact)
+
+    sections_dir = layout.sections_dir
+    if output.save_sections and sections_dir is None:
+        raise ValueError("Section output requires a sections directory.")
+    section_index = (
+        sections_dir / f"{output_stem}.json" if sections_dir is not None else None
+    )
+
+    return OutputPlan(
+        primary_artifact=primary_artifact,
+        fallback_image=versioned_png,
+        image_sequence_dir=None,
+        segment_cache_dir=layout.partial_movie_dir,
+        sections_dir=sections_dir,
+        section_index=section_index,
+        subcaption_file=primary_artifact.with_suffix(".srt"),
+        concat_manifest=layout.partial_movie_dir / "partial_movie_file_list.txt",
+        output_stem=output_stem,
+        segment_extension=output.segment_extension,
+        zero_pad=layout.zero_pad,
+    )
+
+
+def resolve_file_log_path(
+    layout: MediaLayoutSpec,
+    *,
+    module_name: str,
+    scene_name: str,
+) -> Path | None:
+    """Return the exact optional log-file path for one scene."""
+    if layout.log_dir is None:
+        return None
+    return layout.log_dir / f"{module_name}_{scene_name}.log"

--- a/manim/_config/output_plan.py
+++ b/manim/_config/output_plan.py
@@ -157,7 +157,7 @@ def resolve_media_layout(
     sections_dir = None
     partial_movie_dir = None
 
-    if output.enabled:
+    if output.is_still or output.is_image_sequence or output.fallback_to_still:
         images_dir = _required_dir(
             config,
             "images_dir",
@@ -254,15 +254,18 @@ def resolve_output_plan(
             zero_pad=layout.zero_pad,
         )
 
-    images_dir = layout.images_dir
-    if images_dir is None:
-        raise ValueError("Image output requires an images directory.")
-
     default_name = requested_output_name is None
-    normalized_png = _output_path(images_dir, output_name, ".png")
-    versioned_png = _versioned(normalized_png) if default_name else normalized_png
+    normalized_png = None
+    versioned_png = None
+    if output.is_still or output.is_image_sequence or output.fallback_to_still:
+        images_dir = layout.images_dir
+        if images_dir is None:
+            raise ValueError("Image output requires an images directory.")
+        normalized_png = _output_path(images_dir, output_name, ".png")
+        versioned_png = _versioned(normalized_png) if default_name else normalized_png
 
     if output.is_still:
+        assert versioned_png is not None
         return OutputPlan(
             primary_artifact=versioned_png,
             fallback_image=None,
@@ -278,6 +281,7 @@ def resolve_output_plan(
         )
 
     if output.is_image_sequence:
+        assert normalized_png is not None
         sequence_dir = normalized_png.with_suffix("")
         return OutputPlan(
             primary_artifact=sequence_dir,

--- a/manim/_config/utils.py
+++ b/manim/_config/utils.py
@@ -263,7 +263,6 @@ class ManimConfig(MutableMapping):
         "assets_dir",
         "background_color",
         "background_opacity",
-        "custom_folders",
         "disable_caching",
         "disable_caching_warning",
         "dry_run",
@@ -590,7 +589,6 @@ class ManimConfig(MutableMapping):
             "disable_caching",
             "disable_caching_warning",
             "flush_cache",
-            "custom_folders",
             "enable_gui",
             "fullscreen",
             "use_projection_fill_shaders",
@@ -823,23 +821,6 @@ class ManimConfig(MutableMapping):
         fps = args.frame_rate
         if fps:
             self.frame_rate = float(fps)
-
-        # Handle --custom_folders
-        if args.custom_folders:
-            for opt in [
-                "media_dir",
-                "video_dir",
-                "sections_dir",
-                "images_dir",
-                "text_dir",
-                "tex_dir",
-                "log_dir",
-                "partial_movie_dir",
-            ]:
-                self[opt] = self._parser["custom_folders"].get(opt, raw=True)
-            # --media_dir overrides the default.cfg file
-            if hasattr(args, "media_dir") and args.media_dir:
-                self.media_dir = args.media_dir
 
         # Handle --tex_template
         if args.tex_template:
@@ -1707,15 +1688,6 @@ class ManimConfig(MutableMapping):
     @partial_movie_dir.setter
     def partial_movie_dir(self, value: str | Path) -> None:
         self._set_dir("partial_movie_dir", value)
-
-    @property
-    def custom_folders(self) -> str:
-        """Whether to use custom folder output."""
-        return self._d["custom_folders"]
-
-    @custom_folders.setter
-    def custom_folders(self, value: str | Path) -> None:
-        self._set_dir("custom_folders", value)
 
     @property
     def input_file(self) -> str | Path:

--- a/manim/cli/render/commands.py
+++ b/manim/cli/render/commands.py
@@ -58,6 +58,14 @@ class ClickArgs(Namespace):
         return str(self.__dict__)
 
 
+def _validate_scene_batch_output_name(scene_classes: list[type]) -> None:
+    if config.output_file and (config.write_all or len(scene_classes) != 1):
+        raise ValueError(
+            "--output_file can only be used when rendering exactly one scene. "
+            "Remove --write_all or select a single scene.",
+        )
+
+
 @cloup.command(
     context_settings=None,
     no_args_is_help=True,
@@ -82,14 +90,17 @@ def render(**kwargs: Any) -> ClickArgs | dict[str, Any]:
 
     config.digest_args(click_args)
     file = Path(config.input_file)
-    if config.renderer == RendererType.OPENGL:
-        from manim.renderer.opengl_renderer import OpenGLRenderer
+    try:
+        scene_classes = scene_classes_from_file(file)
+        _validate_scene_batch_output_name(scene_classes)
 
-        try:
+        if config.renderer == RendererType.OPENGL:
+            from manim.renderer.opengl_renderer import OpenGLRenderer
+
             renderer = OpenGLRenderer()
             keep_running = True
             while keep_running:
-                for SceneClass in scene_classes_from_file(file):
+                for SceneClass in scene_classes:
                     with tempconfig({}):
                         scene = SceneClass(renderer)
                         # Attach explicitly, but preserve custom Scene.render overrides.
@@ -98,26 +109,20 @@ def render(**kwargs: Any) -> ClickArgs | dict[str, Any]:
                     if rerun or config["write_all"]:
                         renderer.num_plays = 0
                         continue
-                    else:
-                        keep_running = False
-                        break
+                    keep_running = False
+                    break
                 if config["write_all"]:
                     keep_running = False
-
-        except Exception:
-            error_console.print_exception()
-            sys.exit(1)
-    else:
-        for SceneClass in scene_classes_from_file(file):
-            try:
+        else:
+            for SceneClass in scene_classes:
                 with tempconfig({}):
                     scene = SceneClass()
                     # Attach explicitly, but preserve custom Scene.render overrides.
                     Manager(scene)
                     scene.render()
-            except Exception:
-                error_console.print_exception()
-                sys.exit(1)
+    except Exception:
+        error_console.print_exception()
+        sys.exit(1)
 
     if config.notify_outdated_version:
         manim_info_url = "https://pypi.org/pypi/manim/json"

--- a/manim/cli/render/global_options.py
+++ b/manim/cli/render/global_options.py
@@ -62,13 +62,6 @@ global_options = option_group(
         default=None,
     ),
     option(
-        "--custom_folders",
-        is_flag=True,
-        default=None,
-        help="Use the folders defined in the [custom_folders] section of the "
-        "config file to define the output folder structure.",
-    ),
-    option(
         "--disable_caching",
         is_flag=True,
         default=None,

--- a/manim/renderer/cairo_renderer.py
+++ b/manim/renderer/cairo_renderer.py
@@ -62,6 +62,7 @@ class CairoRenderer:
             self,
             scene.__class__.__name__,
             output_spec=session_spec.output,
+            output_plan=scene.output_plan,
         )
 
     def play(

--- a/manim/renderer/opengl_renderer.py
+++ b/manim/renderer/opengl_renderer.py
@@ -541,6 +541,7 @@ class OpenGLRenderer:
             self,
             scene.__class__.__name__,
             output_spec=session_spec.output,
+            output_plan=scene.output_plan,
         )
         self.scene = scene
 

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -43,6 +43,14 @@ from manim.mobject.mobject import Mobject
 from manim.mobject.opengl.opengl_mobject import OpenGLPoint
 
 from .. import config, logger
+from .._config.logger_utils import set_file_logger
+from .._config.output_plan import (
+    resolve_file_log_path,
+    resolve_media_layout,
+    resolve_module_name,
+    resolve_output_plan,
+    resolve_requested_output_name,
+)
 from .._config.render_session import resolve_render_session
 from ..animation.animation import Animation, Wait, prepare_animation
 from ..camera.camera import Camera
@@ -55,6 +63,7 @@ from ..utils import opengl, space_ops
 from ..utils.exceptions import RerunSceneException
 from ..utils.family import extract_mobject_family_members
 from ..utils.family_ops import restructure_list_to_exclude_certain_family_members
+from ..utils.file_ops import guarantee_existence
 from ..utils.iterables import list_difference_update, list_update
 from ..utils.module_ops import scene_classes_from_file
 
@@ -219,6 +228,32 @@ class Scene:
             self.renderer.capabilities,
             renderer_name=type(self.renderer).__name__,
         )
+        scene_name = type(self).__name__
+        module_name = resolve_module_name(config)
+        media_layout = resolve_media_layout(
+            config,
+            self.session_spec.output,
+            module_name=module_name,
+            scene_name=scene_name,
+            working_directory=Path.cwd(),
+        )
+        self.output_plan = resolve_output_plan(
+            media_layout,
+            self.session_spec.output,
+            scene_name=scene_name,
+            requested_output_name=resolve_requested_output_name(config),
+        )
+        self._log_file_path = resolve_file_log_path(
+            media_layout,
+            module_name=module_name,
+            scene_name=scene_name,
+        )
+        if self._log_file_path is not None:
+            set_file_logger(
+                scene_name=scene_name,
+                module_name=module_name,
+                log_dir=guarantee_existence(self._log_file_path.parent),
+            )
         self.renderer.init_scene(self, self.session_spec)
 
         self.mobjects: list[Mobject] = []

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -63,7 +63,6 @@ from ..utils import opengl, space_ops
 from ..utils.exceptions import RerunSceneException
 from ..utils.family import extract_mobject_family_members
 from ..utils.family_ops import restructure_list_to_exclude_certain_family_members
-from ..utils.file_ops import guarantee_existence
 from ..utils.iterables import list_difference_update, list_update
 from ..utils.module_ops import scene_classes_from_file
 
@@ -249,11 +248,8 @@ class Scene:
             scene_name=scene_name,
         )
         if self._log_file_path is not None:
-            set_file_logger(
-                scene_name=scene_name,
-                module_name=module_name,
-                log_dir=guarantee_existence(self._log_file_path.parent),
-            )
+            self._log_file_path.parent.mkdir(parents=True, exist_ok=True)
+            set_file_logger(self._log_file_path)
         self.renderer.init_scene(self, self.session_spec)
 
         self.mobjects: list[Mobject] = []

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -34,12 +34,10 @@ with warnings.catch_warnings():
 from manim import __version__
 
 from .. import config, logger
-from .._config.logger_utils import set_file_logger
 from .._config.output import OutputSpec
+from .._config.output_plan import OutputPlan
 from ..constants import RendererType
 from ..utils.file_ops import (
-    add_extension_if_not_present,
-    add_version_before_extension,
     guarantee_existence,
     modify_atime,
 )
@@ -219,17 +217,17 @@ class SceneFileWriter:
 
     """
 
-    force_output_as_scene_name = False
-
     def __init__(
         self,
         renderer: CairoRenderer | OpenGLRenderer,
         scene_name: str,
         output_spec: OutputSpec,
+        output_plan: OutputPlan,
         **kwargs: Any,
     ) -> None:
         self.renderer = renderer
         self.output_spec = output_spec
+        self.output_plan = output_plan
         self._inflight_encode_jobs: list[_PartialMovieEncodeJob] = []
         self._inflight_by_path: dict[str, _PartialMovieEncodeJob] = {}
         self._current_encode_job: _PartialMovieEncodeJob | None = None
@@ -246,85 +244,41 @@ class SceneFileWriter:
         )
 
     def init_output_directories(self, scene_name: str) -> None:
-        """Initialise output directories.
-
-        Notes
-        -----
-        The directories are read from ``config``, for example
-        ``config['media_dir']``.  If the target directories don't already
-        exist, they will be created.
-
-        """
+        """Initialize compatibility path attributes from the resolved plan."""
+        plan = self.output_plan
+        self.output_name = Path(plan.output_stem)
         if not self.output_spec.enabled:
             return
 
-        module_name = config.get_dir("input_file").stem if config["input_file"] else ""
-
-        if SceneFileWriter.force_output_as_scene_name:
-            self.output_name = Path(scene_name)
-        elif config["output_file"] and not config["write_all"]:
-            self.output_name = config.get_dir("output_file")
-        else:
-            self.output_name = Path(scene_name)
-
-        if config["media_dir"]:
-            image_dir = guarantee_existence(
-                config.get_dir(
-                    "images_dir", module_name=module_name, scene_name=scene_name
-                ),
-            )
-            self.image_file_path = image_dir / add_extension_if_not_present(
-                self.output_name, ".png"
-            )
-            if self.output_spec.is_image_sequence:
-                self.image_sequence_directory = guarantee_existence(
-                    self.image_file_path.with_suffix(""),
-                )
+        image_path = plan.fallback_image
+        if self.output_spec.is_still:
+            image_path = plan.primary_artifact
+        elif self.output_spec.is_image_sequence:
+            sequence_dir = plan.image_sequence_dir
+            assert sequence_dir is not None
+            self.image_sequence_directory = guarantee_existence(sequence_dir)
+            image_path = sequence_dir.with_suffix(".png")
+        assert image_path is not None
+        guarantee_existence(image_path.parent)
+        self.image_file_path = image_path
 
         if self.output_spec.is_video:
-            movie_dir = guarantee_existence(
-                config.get_dir(
-                    "video_dir", module_name=module_name, scene_name=scene_name
-                ),
-            )
-            self.movie_file_path = movie_dir / add_extension_if_not_present(
-                self.output_name, self.output_spec.segment_extension
-            )
-
-            # TODO: /dev/null would be good in case sections_output_dir is used without being set (doesn't work on Windows), everyone likes defensive programming, right?
-            self.sections_output_dir = Path("")
-            if self.output_spec.save_sections:
-                self.sections_output_dir = guarantee_existence(
-                    config.get_dir(
-                        "sections_dir", module_name=module_name, scene_name=scene_name
-                    )
-                )
-
+            primary_artifact = plan.primary_artifact
+            partial_movie_directory = plan.segment_cache_dir
+            assert primary_artifact is not None
+            assert partial_movie_directory is not None
+            guarantee_existence(primary_artifact.parent)
+            self.movie_file_path = primary_artifact
             if self.output_spec.is_gif:
-                self.gif_file_path = add_extension_if_not_present(
-                    self.output_name, ".gif"
-                )
+                self.gif_file_path = primary_artifact
 
-                if not config["output_file"]:
-                    self.gif_file_path = add_version_before_extension(
-                        self.gif_file_path
-                    )
-
-                self.gif_file_path = movie_dir / self.gif_file_path
+            self.sections_output_dir = Path("")
+            if plan.sections_dir is not None:
+                self.sections_output_dir = guarantee_existence(plan.sections_dir)
 
             self.partial_movie_directory = guarantee_existence(
-                config.get_dir(
-                    "partial_movie_dir",
-                    scene_name=scene_name,
-                    module_name=module_name,
-                ),
+                partial_movie_directory,
             )
-
-            if config["log_to_file"]:
-                log_dir = guarantee_existence(config.get_dir("log_dir"))
-                set_file_logger(
-                    scene_name=scene_name, module_name=module_name, log_dir=log_dir
-                )
 
     def finish_last_section(self) -> None:
         """Delete current section if it is empty."""
@@ -604,9 +558,6 @@ class SceneFileWriter:
         """
         if not self.output_spec.enabled:
             return
-        if not config["output_file"]:
-            self.image_file_path = add_version_before_extension(self.image_file_path)
-
         image.save(self.image_file_path)
         self.print_file_ready_message(self.image_file_path)
 

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -37,10 +37,7 @@ from .. import config, logger
 from .._config.output import OutputSpec
 from .._config.output_plan import OutputPlan
 from ..constants import RendererType
-from ..utils.file_ops import (
-    guarantee_existence,
-    modify_atime,
-)
+from ..utils.file_ops import modify_atime
 from ..utils.sounds import get_full_sound_file_path
 from .section import DefaultSectionType, Section
 
@@ -256,10 +253,9 @@ class SceneFileWriter:
         elif self.output_spec.is_image_sequence:
             sequence_dir = plan.image_sequence_dir
             assert sequence_dir is not None
-            self.image_sequence_directory = guarantee_existence(sequence_dir)
+            self.image_sequence_directory = sequence_dir
             image_path = sequence_dir.with_suffix(".png")
         assert image_path is not None
-        guarantee_existence(image_path.parent)
         self.image_file_path = image_path
 
         if self.output_spec.is_video:
@@ -267,18 +263,15 @@ class SceneFileWriter:
             partial_movie_directory = plan.segment_cache_dir
             assert primary_artifact is not None
             assert partial_movie_directory is not None
-            guarantee_existence(primary_artifact.parent)
             self.movie_file_path = primary_artifact
             if self.output_spec.is_gif:
                 self.gif_file_path = primary_artifact
 
             self.sections_output_dir = Path("")
             if plan.sections_dir is not None:
-                self.sections_output_dir = guarantee_existence(plan.sections_dir)
+                self.sections_output_dir = plan.sections_dir
 
-            self.partial_movie_directory = guarantee_existence(
-                partial_movie_directory,
-            )
+            self.partial_movie_directory = partial_movie_directory
 
     def finish_last_section(self) -> None:
         """Delete current section if it is empty."""
@@ -293,8 +286,12 @@ class SceneFileWriter:
         section_video: str | None = None
         # don't save when None
         if self.output_spec.save_sections and not skip_animations:
-            # relative to index file
-            section_video = f"{self.output_name}_{len(self.sections):04}_{name}{self.output_spec.segment_extension}"
+            section_path = self.output_plan.section_path(len(self.sections), name)
+            assert self.output_plan.sections_dir is not None
+            # Section stores paths relative to its index file.
+            section_video = section_path.relative_to(
+                self.output_plan.sections_dir,
+            ).as_posix()
 
         self.sections.append(
             Section(
@@ -329,10 +326,7 @@ class SceneFileWriter:
             self.partial_movie_files.append(None)
             self.sections[-1].partial_movie_files.append(None)
         else:
-            new_partial_movie_file = str(
-                self.partial_movie_directory
-                / f"{hash_animation}{self.output_spec.segment_extension}"
-            )
+            new_partial_movie_file = str(self.output_plan.segment_path(hash_animation))
             self.partial_movie_files.append(new_partial_movie_file)
             self.sections[-1].partial_movie_files.append(new_partial_movie_file)
 
@@ -532,20 +526,12 @@ class SceneFileWriter:
                     if config.renderer == RendererType.OPENGL
                     else Image.fromarray(frame_or_renderer)
                 )
-            target_dir = self.image_sequence_directory
-            extension = self.image_file_path.suffix
-            self.output_image(
-                image,
-                target_dir,
-                extension,
-                config["zero_pad"],
-            )
+            self.output_image(image)
 
-    def output_image(
-        self, image: Image.Image, target_dir: StrPath, ext: str, zero_pad: int
-    ) -> None:
-        file_name = f"{self.frame_count:0{zero_pad}d}{ext}"
-        image.save(Path(target_dir) / file_name)
+    def output_image(self, image: Image.Image) -> None:
+        file_path = self.output_plan.image_frame_path(self.frame_count)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        image.save(file_path)
         self.frame_count += 1
 
     def save_image(self, image: Image.Image) -> None:
@@ -558,6 +544,7 @@ class SceneFileWriter:
         """
         if not self.output_spec.enabled:
             return
+        self.image_file_path.parent.mkdir(parents=True, exist_ok=True)
         image.save(self.image_file_path)
         self.print_file_ready_message(self.image_file_path)
 
@@ -596,6 +583,8 @@ class SceneFileWriter:
                     "open_partial_movie_stream() called for a play that has no "
                     "partial movie file path.",
                 )
+        file_path = Path(file_path)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
         path_key = str(file_path)
         if path_key in self._inflight_by_path:
             self._join_job_and_drain_on_failure(self._inflight_by_path[path_key])
@@ -767,10 +756,7 @@ class SceneFileWriter:
             or not self.output_spec.is_video
         ):
             return False
-        path = (
-            self.partial_movie_directory
-            / f"{hash_invocation}{self.output_spec.segment_extension}"
-        )
+        path = self.output_plan.segment_path(hash_invocation)
         path_key = str(path)
         if path_key in self._inflight_by_path:
             self._join_job_and_drain_on_failure(self._inflight_by_path[path_key])
@@ -783,7 +769,10 @@ class SceneFileWriter:
         create_gif: bool = False,
         includes_sound: bool = False,
     ) -> None:
-        file_list = self.partial_movie_directory / "partial_movie_file_list.txt"
+        file_list = self.output_plan.concat_manifest
+        assert file_list is not None
+        file_list.parent.mkdir(parents=True, exist_ok=True)
+        output_file.parent.mkdir(parents=True, exist_ok=True)
         logger.debug(
             f"Partial movie files to combine ({len(input_files)} files): %(p)s",
             {"p": input_files[:5]},
@@ -1001,12 +990,16 @@ class SceneFileWriter:
             # only if section does want to be saved
             if section.video is not None:
                 logger.info(f"Combining partial files for section '{section.name}'")
+                section_path = self.sections_output_dir / section.video
                 self.combine_files(
                     section.get_clean_partial_movie_files(),
-                    self.sections_output_dir / section.video,
+                    section_path,
                 )
                 sections_index.append(section.get_dict(self.sections_output_dir))
-        with (self.sections_output_dir / f"{self.output_name}.json").open("w") as file:
+        section_index = self.output_plan.section_index
+        assert section_index is not None
+        section_index.parent.mkdir(parents=True, exist_ok=True)
+        with section_index.open("w") as file:
             json.dump(sections_index, file, indent=4)
 
     def _cached_partial_movie_files(self) -> list[Path]:
@@ -1019,6 +1012,8 @@ class SceneFileWriter:
         ``max_files_cached`` and may vanish again before they could be
         deleted.
         """
+        if not self.partial_movie_directory.exists():
+            return []
         return [
             self.partial_movie_directory / file_name
             for file_name in self.partial_movie_directory.iterdir()
@@ -1068,10 +1063,9 @@ class SceneFileWriter:
         """Writes the subcaption file next to the primary video artifact."""
         if not self.output_spec.is_video:
             return
-        media_path = (
-            self.gif_file_path if self.output_spec.is_gif else self.movie_file_path
-        )
-        subcaption_file = Path(media_path).with_suffix(".srt")
+        subcaption_file = self.output_plan.subcaption_file
+        assert subcaption_file is not None
+        subcaption_file.parent.mkdir(parents=True, exist_ok=True)
         subcaption_file.write_text(srt.compose(self.subcaptions), encoding="utf-8")
         logger.info(f"Subcaption file has been written as {subcaption_file}")
 

--- a/manim/scene/scene_file_writer.py
+++ b/manim/scene/scene_file_writer.py
@@ -228,7 +228,6 @@ class SceneFileWriter:
         self._inflight_encode_jobs: list[_PartialMovieEncodeJob] = []
         self._inflight_by_path: dict[str, _PartialMovieEncodeJob] = {}
         self._current_encode_job: _PartialMovieEncodeJob | None = None
-        self.init_output_directories(scene_name)
         self.init_audio()
         self.frame_count = 0
         self.partial_movie_files: list[str | None] = []
@@ -240,38 +239,59 @@ class SceneFileWriter:
             name="autocreated", type_=DefaultSectionType.NORMAL, skip_animations=False
         )
 
-    def init_output_directories(self, scene_name: str) -> None:
-        """Initialize compatibility path attributes from the resolved plan."""
-        plan = self.output_plan
-        self.output_name = Path(plan.output_stem)
-        if not self.output_spec.enabled:
-            return
+    @property
+    def output_name(self) -> Path:
+        """Return the planned logical output stem as a compatibility view."""
+        return Path(self.output_plan.output_stem)
 
-        image_path = plan.fallback_image
-        if self.output_spec.is_still:
-            image_path = plan.primary_artifact
-        elif self.output_spec.is_image_sequence:
-            sequence_dir = plan.image_sequence_dir
-            assert sequence_dir is not None
-            self.image_sequence_directory = sequence_dir
-            image_path = sequence_dir.with_suffix(".png")
-        assert image_path is not None
-        self.image_file_path = image_path
+    @property
+    def image_file_path(self) -> Path:
+        """Return the planned still or video-fallback image path."""
+        if self.output_spec.is_image_sequence:
+            return self.image_sequence_directory.with_suffix(".png")
+        path = (
+            self.output_plan.primary_artifact
+            if self.output_spec.is_still
+            else self.output_plan.fallback_image
+        )
+        if path is None:
+            raise AttributeError("This output plan does not contain an image path.")
+        return path
 
-        if self.output_spec.is_video:
-            primary_artifact = plan.primary_artifact
-            partial_movie_directory = plan.segment_cache_dir
-            assert primary_artifact is not None
-            assert partial_movie_directory is not None
-            self.movie_file_path = primary_artifact
-            if self.output_spec.is_gif:
-                self.gif_file_path = primary_artifact
+    @property
+    def image_sequence_directory(self) -> Path:
+        """Return the planned PNG-sequence directory."""
+        path = self.output_plan.image_sequence_dir
+        if path is None:
+            raise AttributeError("This output plan does not contain an image sequence.")
+        return path
 
-            self.sections_output_dir = Path("")
-            if plan.sections_dir is not None:
-                self.sections_output_dir = plan.sections_dir
+    @property
+    def movie_file_path(self) -> Path:
+        """Return the planned primary video artifact path."""
+        if not self.output_spec.is_video or self.output_plan.primary_artifact is None:
+            raise AttributeError("This output plan does not contain a video artifact.")
+        return self.output_plan.primary_artifact
 
-            self.partial_movie_directory = partial_movie_directory
+    @property
+    def gif_file_path(self) -> Path:
+        """Return the planned GIF artifact path."""
+        if not self.output_spec.is_gif:
+            raise AttributeError("This output plan does not contain a GIF artifact.")
+        return self.movie_file_path
+
+    @property
+    def sections_output_dir(self) -> Path:
+        """Return the planned sections directory, or the legacy empty path."""
+        return self.output_plan.sections_dir or Path("")
+
+    @property
+    def partial_movie_directory(self) -> Path:
+        """Return the planned silent-segment cache directory."""
+        path = self.output_plan.segment_cache_dir
+        if path is None:
+            raise AttributeError("This output plan does not contain video segments.")
+        return path
 
     def finish_last_section(self) -> None:
         """Delete current section if it is empty."""
@@ -329,37 +349,6 @@ class SceneFileWriter:
             new_partial_movie_file = str(self.output_plan.segment_path(hash_animation))
             self.partial_movie_files.append(new_partial_movie_file)
             self.sections[-1].partial_movie_files.append(new_partial_movie_file)
-
-    def get_resolution_directory(self) -> str:
-        """Get the name of the resolution directory directly containing
-        the video file.
-
-        This method gets the name of the directory that immediately contains the
-        video file. This name is ``<height_in_pixels_of_video>p<frame_rate>``.
-        For example, if you are rendering an 854x480 px animation at 15fps,
-        the name of the directory that immediately contains the video,  file
-        will be ``480p15``.
-
-        The file structure should look something like::
-
-            MEDIA_DIR
-                |--Tex
-                |--texts
-                |--videos
-                    |--<name_of_file_containing_scene>
-                        |--<height_in_pixels_of_video>p<frame_rate>
-                            |--partial_movie_files
-                            |--<scene_name>.mp4
-                            |--<scene_name>.srt
-
-        Returns
-        -------
-        :class:`str`
-            The name of the directory.
-        """
-        pixel_height = config["pixel_height"]
-        frame_rate = config["frame_rate"]
-        return f"{pixel_height}p{frame_rate}"
 
     # Sound
     def init_audio(self) -> None:

--- a/manim/utils/docbuild/manim_directive.py
+++ b/manim/utils/docbuild/manim_directive.py
@@ -298,15 +298,21 @@ class ManimDirective(Directive):
         code = [
             "from manim import *",
             *user_code,
-            f"{clsname}().render()",
+            f"_manim_rendered_scene = {clsname}()",
+            "_manim_rendered_scene.render()",
         ]
+        render_namespace = globals()
 
         try:
             with tempconfig(example_config):
-                run_time = timeit(lambda: exec("\n".join(code), globals()), number=1)
-                video_dir = config.get_dir("video_dir")
-                images_dir = config.get_dir("images_dir")
+                run_time = timeit(
+                    lambda: exec("\n".join(code), render_namespace),
+                    number=1,
+                )
+                rendered_scene = render_namespace.pop("_manim_rendered_scene")
+                filesrc = rendered_scene.renderer.file_writer.final_file_path
         except Exception as e:
+            render_namespace.pop("_manim_rendered_scene", None)
             raise RuntimeError(f"Error while rendering example {clsname}") from e
 
         _write_rendering_stats(
@@ -317,16 +323,11 @@ class ManimDirective(Directive):
 
         # copy video file to output directory
         if not (save_as_gif or save_last_frame):
-            filename = f"{output_file}.mp4"
-            filesrc = video_dir / filename
+            filename = filesrc.name
             destfile = Path(dest_dir, filename)
             shutil.copyfile(filesrc, destfile)
-        elif save_as_gif:
-            filename = f"{output_file}.gif"
-            filesrc = video_dir / filename
-        elif save_last_frame:
-            filename = f"{output_file}.png"
-            filesrc = images_dir / filename
+        elif save_as_gif or save_last_frame:
+            filename = filesrc.name
         else:
             raise ValueError("Invalid combination of render flags received.")
         rendered_template = jinja2.Template(TEMPLATE).render(

--- a/manim/utils/docbuild/manim_directive.py
+++ b/manim/utils/docbuild/manim_directive.py
@@ -326,10 +326,6 @@ class ManimDirective(Directive):
             filename = filesrc.name
             destfile = Path(dest_dir, filename)
             shutil.copyfile(filesrc, destfile)
-        elif save_as_gif or save_last_frame:
-            filename = filesrc.name
-        else:
-            raise ValueError("Invalid combination of render flags received.")
         rendered_template = jinja2.Template(TEMPLATE).render(
             clsname=clsname,
             clsname_lowercase=clsname.lower(),

--- a/manim/utils/ipython_magic.py
+++ b/manim/utils/ipython_magic.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any
 
 from manim import config, logger, tempconfig
-from manim.__main__ import main
 from manim.renderer.shader import shader_program_cache
 
 from ..constants import RendererType
@@ -119,6 +118,10 @@ else:
             """
             if cell:
                 exec(cell, local_ns)
+
+            # Import lazily to keep package initialization independent of the CLI
+            # entry point and avoid a manim -> IPython magic -> CLI import cycle.
+            from manim.__main__ import main
 
             args = line.split()
             if not len(args) or "-h" in args or "--help" in args or "--version" in args:

--- a/manim/utils/module_ops.py
+++ b/manim/utils/module_ops.py
@@ -16,7 +16,6 @@ from manim.constants import (
     NO_SCENE_MESSAGE,
     SCENE_NOT_FOUND_MESSAGE,
 )
-from manim.scene.scene_file_writer import SceneFileWriter
 
 if TYPE_CHECKING:
     from manim.scene.scene import Scene
@@ -112,7 +111,6 @@ def get_scenes_to_render(scene_classes: list[type[Scene]]) -> list[type[Scene]]:
 
 def prompt_user_for_choice(scene_classes: list[type[Scene]]) -> list[type[Scene]]:
     num_to_class = {}
-    SceneFileWriter.force_output_as_scene_name = True
     for count, scene_class in enumerate(scene_classes, 1):
         name = scene_class.__name__
         console.print(f"{count}: {name}", style="logging.level.info")

--- a/manim/utils/testing/_test_class_makers.py
+++ b/manim/utils/testing/_test_class_makers.py
@@ -53,9 +53,6 @@ class DummySceneFileWriter(SceneFileWriter):
         super().__init__(renderer, scene_name, **kwargs)
         self.i = 0
 
-    def init_output_directories(self, scene_name: str) -> None:
-        pass
-
     def add_partial_movie_file(self, hash_animation: str | None) -> None:
         pass
 

--- a/tests/control_data/videos_data/SceneWithSections.json
+++ b/tests/control_data/videos_data/SceneWithSections.json
@@ -12,7 +12,7 @@
     "section_dir_layout": [
         "SceneWithSections.json",
         "SceneWithSections_0004_unnamed.mp4",
-        "SceneWithSections_0003_Prepare For Unforeseen Consequences..mp4",
+        "SceneWithSections_0003_Prepare-For-Unforeseen-Consequences.mp4",
         "SceneWithSections_0002_test.mp4",
         "SceneWithSections_0001_unnamed.mp4",
         "SceneWithSections_0000_autocreated.mp4",
@@ -58,7 +58,7 @@
         {
             "name": "Prepare For Unforeseen Consequences.",
             "type": "default.normal",
-            "video": "SceneWithSections_0003_Prepare For Unforeseen Consequences..mp4",
+            "video": "SceneWithSections_0003_Prepare-For-Unforeseen-Consequences.mp4",
             "codec_name": "h264",
             "width": 854,
             "height": 480,

--- a/tests/control_data/videos_data/SceneWithSkipAnimations.json
+++ b/tests/control_data/videos_data/SceneWithSkipAnimations.json
@@ -11,16 +11,16 @@
     },
     "section_dir_layout": [
         "ElaborateSceneWithSections.json",
-        "ElaborateSceneWithSections_0003_fade out.mp4",
-        "ElaborateSceneWithSections_0001_transform to circle.mp4",
-        "ElaborateSceneWithSections_0000_create square.mp4",
+        "ElaborateSceneWithSections_0003_fade-out.mp4",
+        "ElaborateSceneWithSections_0001_transform-to-circle.mp4",
+        "ElaborateSceneWithSections_0000_create-square.mp4",
         "."
     ],
     "section_index": [
         {
             "name": "create square",
             "type": "default.normal",
-            "video": "ElaborateSceneWithSections_0000_create square.mp4",
+            "video": "ElaborateSceneWithSections_0000_create-square.mp4",
             "codec_name": "h264",
             "width": 854,
             "height": 480,
@@ -32,7 +32,7 @@
         {
             "name": "transform to circle",
             "type": "default.normal",
-            "video": "ElaborateSceneWithSections_0001_transform to circle.mp4",
+            "video": "ElaborateSceneWithSections_0001_transform-to-circle.mp4",
             "codec_name": "h264",
             "width": 854,
             "height": 480,
@@ -44,7 +44,7 @@
         {
             "name": "fade out",
             "type": "default.normal",
-            "video": "ElaborateSceneWithSections_0003_fade out.mp4",
+            "video": "ElaborateSceneWithSections_0003_fade-out.mp4",
             "codec_name": "h264",
             "width": 854,
             "height": 480,

--- a/tests/module/test_output_path_behavior.py
+++ b/tests/module/test_output_path_behavior.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from PIL import Image
+
+from manim import __version__
+from manim._config.output import OutputFormat, OutputSpec
+from manim.scene.scene_file_writer import SceneFileWriter
+
+
+def _make_writer(
+    config,
+    tmp_path: Path,
+    output_format: OutputFormat,
+    *,
+    transparent: bool = False,
+    save_sections: bool = False,
+    output_file: str | Path = "",
+    write_all: bool = False,
+) -> SceneFileWriter:
+    config.media_dir = tmp_path
+    config.input_file = tmp_path / "nested" / "example.scene.py"
+    config.pixel_height = 480
+    config.frame_rate = 15
+    config.output_file = output_file
+    config.write_all = write_all
+
+    renderer = Mock()
+    renderer.num_plays = 0
+    return SceneFileWriter(
+        renderer,
+        "ExampleScene",
+        OutputSpec(output_format, transparent, save_sections),
+    )
+
+
+@pytest.mark.parametrize(
+    ("output_format", "extension"),
+    [
+        (OutputFormat.MP4, ".mp4"),
+        (OutputFormat.MOV, ".mov"),
+        (OutputFormat.WEBM, ".webm"),
+    ],
+)
+def test_default_video_paths(config, tmp_path, output_format, extension):
+    writer = _make_writer(config, tmp_path, output_format)
+    quality_dir = tmp_path / "videos" / "example.scene" / "480p15"
+
+    assert writer.movie_file_path == quality_dir / f"ExampleScene{extension}"
+    assert writer.partial_movie_directory == (
+        quality_dir / "partial_movie_files" / "ExampleScene"
+    )
+
+
+@pytest.mark.parametrize(
+    ("transparent", "segment_extension"),
+    [(False, ".mp4"), (True, ".mov")],
+)
+def test_gif_primary_and_segment_paths(
+    config,
+    tmp_path,
+    transparent,
+    segment_extension,
+):
+    writer = _make_writer(
+        config,
+        tmp_path,
+        OutputFormat.GIF,
+        transparent=transparent,
+    )
+    quality_dir = tmp_path / "videos" / "example.scene" / "480p15"
+
+    assert writer.movie_file_path == quality_dir / f"ExampleScene{segment_extension}"
+    assert writer.gif_file_path == (
+        quality_dir / f"ExampleScene_ManimCE_v{__version__}.gif"
+    )
+    writer.add_partial_movie_file("cache-key")
+    assert writer.partial_movie_files == [
+        str(
+            quality_dir
+            / "partial_movie_files"
+            / "ExampleScene"
+            / f"cache-key{segment_extension}"
+        )
+    ]
+
+
+def test_default_png_and_video_fallback_paths(config, tmp_path):
+    png_writer = _make_writer(config, tmp_path, OutputFormat.PNG)
+    expected = (
+        tmp_path
+        / "images"
+        / "example.scene"
+        / f"ExampleScene_ManimCE_v{__version__}.png"
+    )
+
+    png_writer.save_image(Image.new("RGBA", (1, 1)))
+    assert png_writer.final_file_path == expected
+
+    video_writer = _make_writer(config, tmp_path, OutputFormat.MP4)
+    video_writer.save_image(Image.new("RGBA", (1, 1)))
+    assert video_writer.final_file_path == expected
+
+
+def test_png_sequence_path_and_zero_padding(config, tmp_path):
+    config.zero_pad = 3
+    writer = _make_writer(config, tmp_path, OutputFormat.PNG_SEQUENCE)
+
+    expected_dir = tmp_path / "images" / "example.scene" / "ExampleScene"
+    assert writer.image_sequence_directory == expected_dir
+
+    writer.output_image(
+        Image.new("RGBA", (1, 1)), expected_dir, ".png", config.zero_pad
+    )
+    assert (expected_dir / "000.png").is_file()
+
+
+def test_output_suffixes_are_currently_appended_when_they_differ(config, tmp_path):
+    matching = _make_writer(
+        config,
+        tmp_path,
+        OutputFormat.MP4,
+        output_file="movie.mp4",
+    )
+    assert matching.movie_file_path.name == "movie.mp4"
+
+    differing = _make_writer(
+        config,
+        tmp_path,
+        OutputFormat.MP4,
+        output_file="movie.mov",
+    )
+    assert differing.movie_file_path.name == "movie.mov.mp4"
+
+
+def test_write_all_ignores_requested_output_name(config, tmp_path):
+    writer = _make_writer(
+        config,
+        tmp_path,
+        OutputFormat.MP4,
+        output_file="shared-name",
+        write_all=True,
+    )
+
+    assert writer.output_name == Path("ExampleScene")
+    assert writer.movie_file_path.name == "ExampleScene.mp4"
+
+
+def test_sections_use_configured_directory_for_simple_output_name(config, tmp_path):
+    writer = _make_writer(
+        config,
+        tmp_path,
+        OutputFormat.MP4,
+        save_sections=True,
+        output_file="movie",
+    )
+    writer.next_section("intro", skip_animations=False, type_="default.normal")
+
+    section = writer.sections[-1]
+    assert writer.sections_output_dir == (
+        tmp_path / "videos" / "example.scene" / "480p15" / "sections"
+    )
+    assert section.video == "movie_0000_intro.mp4"
+    assert writer.sections_output_dir / section.video == (
+        writer.sections_output_dir / "movie_0000_intro.mp4"
+    )
+
+
+def test_nested_and_absolute_output_names_leak_into_current_section_paths(
+    config,
+    tmp_path,
+):
+    nested = _make_writer(
+        config,
+        tmp_path,
+        OutputFormat.MP4,
+        save_sections=True,
+        output_file="exports/movie",
+    )
+    nested.next_section("intro", skip_animations=False, type_="default.normal")
+    assert nested.sections_output_dir / nested.sections[-1].video == (
+        nested.sections_output_dir / "exports" / "movie_0000_intro.mp4"
+    )
+
+    absolute_name = tmp_path / "exports" / "movie"
+    absolute = _make_writer(
+        config,
+        tmp_path,
+        OutputFormat.MP4,
+        save_sections=True,
+        output_file=absolute_name,
+    )
+    absolute.next_section("intro", skip_animations=False, type_="default.normal")
+    assert Path(absolute.sections[-1].video).is_absolute()
+    assert absolute.sections_output_dir / absolute.sections[-1].video == (
+        tmp_path / "exports" / "movie_0000_intro.mp4"
+    )
+
+
+def test_no_output_plans_no_media_directories(config, tmp_path):
+    media_root = tmp_path / "unused-media"
+    writer = _make_writer(config, media_root, OutputFormat.NONE)
+
+    assert not hasattr(writer, "movie_file_path")
+    assert not hasattr(writer, "image_file_path")
+    assert not media_root.exists()

--- a/tests/module/test_output_path_behavior.py
+++ b/tests/module/test_output_path_behavior.py
@@ -138,7 +138,7 @@ def test_png_sequence_path_and_zero_padding(config, tmp_path):
     assert (expected_dir / "000.png").is_file()
 
 
-def test_resolved_output_suffix_is_applied_once(config, tmp_path):
+def test_resolved_output_suffix_preserves_a_different_suffix(config, tmp_path):
     matching = _make_writer(
         config,
         tmp_path,
@@ -153,7 +153,7 @@ def test_resolved_output_suffix_is_applied_once(config, tmp_path):
         OutputFormat.MP4,
         output_file="movie.mov",
     )
-    assert differing.movie_file_path.name == "movie.mp4"
+    assert differing.movie_file_path.name == "movie.mov.mp4"
 
 
 def test_sections_use_configured_directory_for_simple_output_name(config, tmp_path):

--- a/tests/module/test_output_path_behavior.py
+++ b/tests/module/test_output_path_behavior.py
@@ -8,6 +8,12 @@ from PIL import Image
 
 from manim import __version__
 from manim._config.output import OutputFormat, OutputSpec
+from manim._config.output_plan import (
+    resolve_media_layout,
+    resolve_module_name,
+    resolve_output_plan,
+    resolve_requested_output_name,
+)
 from manim.scene.scene_file_writer import SceneFileWriter
 
 
@@ -19,21 +25,35 @@ def _make_writer(
     transparent: bool = False,
     save_sections: bool = False,
     output_file: str | Path = "",
-    write_all: bool = False,
 ) -> SceneFileWriter:
     config.media_dir = tmp_path
     config.input_file = tmp_path / "nested" / "example.scene.py"
     config.pixel_height = 480
     config.frame_rate = 15
     config.output_file = output_file
-    config.write_all = write_all
 
+    output = OutputSpec(output_format, transparent, save_sections)
+    module_name = resolve_module_name(config)
+    layout = resolve_media_layout(
+        config,
+        output,
+        module_name=module_name,
+        scene_name="ExampleScene",
+        working_directory=Path.cwd(),
+    )
+    output_plan = resolve_output_plan(
+        layout,
+        output,
+        scene_name="ExampleScene",
+        requested_output_name=resolve_requested_output_name(config),
+    )
     renderer = Mock()
     renderer.num_plays = 0
     return SceneFileWriter(
         renderer,
         "ExampleScene",
-        OutputSpec(output_format, transparent, save_sections),
+        output,
+        output_plan,
     )
 
 
@@ -73,7 +93,9 @@ def test_gif_primary_and_segment_paths(
     )
     quality_dir = tmp_path / "videos" / "example.scene" / "480p15"
 
-    assert writer.movie_file_path == quality_dir / f"ExampleScene{segment_extension}"
+    assert writer.movie_file_path == (
+        quality_dir / f"ExampleScene_ManimCE_v{__version__}.gif"
+    )
     assert writer.gif_file_path == (
         quality_dir / f"ExampleScene_ManimCE_v{__version__}.gif"
     )
@@ -118,7 +140,7 @@ def test_png_sequence_path_and_zero_padding(config, tmp_path):
     assert (expected_dir / "000.png").is_file()
 
 
-def test_output_suffixes_are_currently_appended_when_they_differ(config, tmp_path):
+def test_resolved_output_suffix_is_applied_once(config, tmp_path):
     matching = _make_writer(
         config,
         tmp_path,
@@ -133,20 +155,7 @@ def test_output_suffixes_are_currently_appended_when_they_differ(config, tmp_pat
         OutputFormat.MP4,
         output_file="movie.mov",
     )
-    assert differing.movie_file_path.name == "movie.mov.mp4"
-
-
-def test_write_all_ignores_requested_output_name(config, tmp_path):
-    writer = _make_writer(
-        config,
-        tmp_path,
-        OutputFormat.MP4,
-        output_file="shared-name",
-        write_all=True,
-    )
-
-    assert writer.output_name == Path("ExampleScene")
-    assert writer.movie_file_path.name == "ExampleScene.mp4"
+    assert differing.movie_file_path.name == "movie.mp4"
 
 
 def test_sections_use_configured_directory_for_simple_output_name(config, tmp_path):
@@ -169,7 +178,7 @@ def test_sections_use_configured_directory_for_simple_output_name(config, tmp_pa
     )
 
 
-def test_nested_and_absolute_output_names_leak_into_current_section_paths(
+def test_nested_and_absolute_output_names_do_not_relocate_sections(
     config,
     tmp_path,
 ):
@@ -182,7 +191,7 @@ def test_nested_and_absolute_output_names_leak_into_current_section_paths(
     )
     nested.next_section("intro", skip_animations=False, type_="default.normal")
     assert nested.sections_output_dir / nested.sections[-1].video == (
-        nested.sections_output_dir / "exports" / "movie_0000_intro.mp4"
+        nested.sections_output_dir / "movie_0000_intro.mp4"
     )
 
     absolute_name = tmp_path / "exports" / "movie"
@@ -194,9 +203,9 @@ def test_nested_and_absolute_output_names_leak_into_current_section_paths(
         output_file=absolute_name,
     )
     absolute.next_section("intro", skip_animations=False, type_="default.normal")
-    assert Path(absolute.sections[-1].video).is_absolute()
+    assert not Path(absolute.sections[-1].video).is_absolute()
     assert absolute.sections_output_dir / absolute.sections[-1].video == (
-        tmp_path / "exports" / "movie_0000_intro.mp4"
+        absolute.sections_output_dir / "movie_0000_intro.mp4"
     )
 
 

--- a/tests/module/test_output_path_behavior.py
+++ b/tests/module/test_output_path_behavior.py
@@ -24,6 +24,7 @@ def _make_writer(
     *,
     transparent: bool = False,
     save_sections: bool = False,
+    fallback_to_still: bool = False,
     output_file: str | Path = "",
 ) -> SceneFileWriter:
     config.media_dir = tmp_path
@@ -32,7 +33,12 @@ def _make_writer(
     config.frame_rate = 15
     config.output_file = output_file
 
-    output = OutputSpec(output_format, transparent, save_sections)
+    output = OutputSpec(
+        output_format,
+        transparent,
+        save_sections,
+        fallback_to_still,
+    )
     module_name = resolve_module_name(config)
     layout = resolve_media_layout(
         config,
@@ -110,7 +116,7 @@ def test_gif_primary_and_segment_paths(
     ]
 
 
-def test_default_png_and_video_fallback_paths(config, tmp_path):
+def test_default_png_and_automatic_video_fallback_paths(config, tmp_path):
     png_writer = _make_writer(config, tmp_path, OutputFormat.PNG)
     expected = (
         tmp_path
@@ -122,7 +128,12 @@ def test_default_png_and_video_fallback_paths(config, tmp_path):
     png_writer.save_image(Image.new("RGBA", (1, 1)))
     assert png_writer.final_file_path == expected
 
-    video_writer = _make_writer(config, tmp_path, OutputFormat.MP4)
+    video_writer = _make_writer(
+        config,
+        tmp_path,
+        OutputFormat.MP4,
+        fallback_to_still=True,
+    )
     video_writer.save_image(Image.new("RGBA", (1, 1)))
     assert video_writer.final_file_path == expected
 

--- a/tests/module/test_output_path_behavior.py
+++ b/tests/module/test_output_path_behavior.py
@@ -134,9 +134,7 @@ def test_png_sequence_path_and_zero_padding(config, tmp_path):
     expected_dir = tmp_path / "images" / "example.scene" / "ExampleScene"
     assert writer.image_sequence_directory == expected_dir
 
-    writer.output_image(
-        Image.new("RGBA", (1, 1)), expected_dir, ".png", config.zero_pad
-    )
+    writer.output_image(Image.new("RGBA", (1, 1)))
     assert (expected_dir / "000.png").is_file()
 
 

--- a/tests/module/test_output_plan.py
+++ b/tests/module/test_output_plan.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from manim import __version__
+from manim import Scene, __version__
 from manim._config.output import OutputFormat, OutputSpec
 from manim._config.output_plan import (
     MediaLayoutSpec,
@@ -15,6 +15,7 @@ from manim._config.output_plan import (
     resolve_output_plan,
     resolve_requested_output_name,
 )
+from manim.cli.render.commands import _validate_scene_batch_output_name
 
 
 def _layout(tmp_path: Path, *, sections: bool = False) -> MediaLayoutSpec:
@@ -308,6 +309,37 @@ def test_config_adapter_skips_unused_output_directories(config, tmp_path):
     )
 
     assert layout == MediaLayoutSpec(None, None, None, None, None, zero_pad=4)
+
+
+def test_scene_and_writer_share_immutable_output_plan(config, tmp_path):
+    initial_media_dir = tmp_path / "initial"
+    config.media_dir = initial_media_dir
+    config.input_file = tmp_path / "example.py"
+    config.format = "mp4"
+
+    scene = Scene()
+    plan = scene.output_plan
+
+    config.media_dir = tmp_path / "changed"
+    config.output_file = "changed-name"
+
+    assert scene.renderer.file_writer.output_plan is plan
+    assert plan.primary_artifact == (
+        initial_media_dir / "videos" / "example" / "1080p60" / "Scene.mp4"
+    )
+
+
+def test_cli_batch_output_name_validation(config):
+    config.output_file = "movie"
+    config.write_all = False
+
+    _validate_scene_batch_output_name([object])
+    with pytest.raises(ValueError, match="exactly one scene"):
+        _validate_scene_batch_output_name([object, object])
+
+    config.write_all = True
+    with pytest.raises(ValueError, match="exactly one scene"):
+        _validate_scene_batch_output_name([object])
 
 
 def test_requested_name_and_log_path_resolution(config, tmp_path):

--- a/tests/module/test_output_plan.py
+++ b/tests/module/test_output_plan.py
@@ -320,6 +320,7 @@ def test_scene_and_writer_share_immutable_output_plan(config, tmp_path):
     scene = Scene()
     plan = scene.output_plan
 
+    assert not initial_media_dir.exists()
     config.media_dir = tmp_path / "changed"
     config.output_file = "changed-name"
 

--- a/tests/module/test_output_plan.py
+++ b/tests/module/test_output_plan.py
@@ -340,7 +340,11 @@ def test_config_adapter_captures_exact_required_directories(config, tmp_path):
     config.frame_rate = 15
     config.zero_pad = 3
     config.log_to_file = True
-    output = _output(OutputFormat.MP4, save_sections=True)
+    output = _output(
+        OutputFormat.MP4,
+        save_sections=True,
+        fallback_to_still=True,
+    )
 
     module_name = resolve_module_name(config)
     layout = resolve_media_layout(
@@ -362,6 +366,30 @@ def test_config_adapter_captures_exact_required_directories(config, tmp_path):
     assert layout.log_dir == tmp_path / "relative-media" / "logs"
     assert layout.zero_pad == 3
     assert not (tmp_path / "relative-media").exists()
+
+
+def test_explicit_video_skips_the_unused_fallback_directory(config, tmp_path):
+    config.media_dir = "explicit-video"
+    config.images_dir = "{unused_placeholder}"
+    output = _output(OutputFormat.MP4)
+
+    layout = resolve_media_layout(
+        config,
+        output,
+        module_name="example",
+        scene_name="ExampleScene",
+        working_directory=tmp_path,
+    )
+    plan = resolve_output_plan(
+        layout,
+        output,
+        scene_name="ExampleScene",
+        requested_output_name=None,
+    )
+
+    assert layout.images_dir is None
+    assert layout.video_dir is not None
+    assert plan.fallback_image is None
 
 
 def test_config_adapter_skips_unused_output_directories(config, tmp_path):

--- a/tests/module/test_output_plan.py
+++ b/tests/module/test_output_plan.py
@@ -152,7 +152,7 @@ def test_resolve_no_output_plan_without_layout_directories(tmp_path):
     [
         ("movie", "movie.mp4"),
         ("movie.mp4", "movie.mp4"),
-        ("movie.mov", "movie.mp4"),
+        ("movie.mov", "movie.mov.mp4"),
     ],
 )
 def test_resolved_format_controls_custom_output_suffix(
@@ -184,8 +184,8 @@ def test_absolute_output_name_only_relocates_primary_and_fallback(tmp_path):
         requested_output_name=requested,
     )
 
-    assert plan.primary_artifact == tmp_path / "exports" / "movie.mp4"
-    assert plan.fallback_image == tmp_path / "exports" / "movie.png"
+    assert plan.primary_artifact == tmp_path / "exports" / "movie.mov.mp4"
+    assert plan.fallback_image == tmp_path / "exports" / "movie.mov.png"
     assert plan.section_index == layout.sections_dir / "movie.json"
     assert plan.section_path(0, "intro") == (
         layout.sections_dir / "movie_0000_intro.mp4"

--- a/tests/module/test_output_plan.py
+++ b/tests/module/test_output_plan.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from manim import __version__
+from manim._config.output import OutputFormat, OutputSpec
+from manim._config.output_plan import (
+    MediaLayoutSpec,
+    resolve_file_log_path,
+    resolve_media_layout,
+    resolve_module_name,
+    resolve_output_plan,
+    resolve_requested_output_name,
+)
+
+
+def _layout(tmp_path: Path, *, sections: bool = False) -> MediaLayoutSpec:
+    root = tmp_path / "not-created"
+    return MediaLayoutSpec(
+        video_dir=root / "videos",
+        images_dir=root / "images",
+        sections_dir=root / "sections" if sections else None,
+        partial_movie_dir=root / "segments",
+        log_dir=root / "logs",
+        zero_pad=4,
+    )
+
+
+def _output(
+    output_format: OutputFormat,
+    *,
+    transparent: bool = False,
+    save_sections: bool = False,
+) -> OutputSpec:
+    return OutputSpec(output_format, transparent, save_sections)
+
+
+@pytest.mark.parametrize(
+    ("output_format", "extension"),
+    [
+        (OutputFormat.MP4, ".mp4"),
+        (OutputFormat.MOV, ".mov"),
+        (OutputFormat.WEBM, ".webm"),
+    ],
+)
+def test_resolve_video_plan(tmp_path, output_format, extension):
+    layout = _layout(tmp_path)
+
+    plan = resolve_output_plan(
+        layout,
+        _output(output_format),
+        scene_name="ExampleScene",
+        requested_output_name=None,
+    )
+
+    assert plan.primary_artifact == layout.video_dir / f"ExampleScene{extension}"
+    assert plan.fallback_image == (
+        layout.images_dir / f"ExampleScene_ManimCE_v{__version__}.png"
+    )
+    assert plan.segment_cache_dir == layout.partial_movie_dir
+    assert plan.segment_path("cache-key") == (
+        layout.partial_movie_dir / f"cache-key{extension}"
+    )
+    assert plan.concat_manifest == (
+        layout.partial_movie_dir / "partial_movie_file_list.txt"
+    )
+    assert plan.subcaption_file == layout.video_dir / "ExampleScene.srt"
+
+
+@pytest.mark.parametrize(
+    ("transparent", "segment_extension"),
+    [(False, ".mp4"), (True, ".mov")],
+)
+def test_resolve_gif_plan(tmp_path, transparent, segment_extension):
+    layout = _layout(tmp_path)
+
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.GIF, transparent=transparent),
+        scene_name="ExampleScene",
+        requested_output_name=None,
+    )
+
+    assert plan.primary_artifact == (
+        layout.video_dir / f"ExampleScene_ManimCE_v{__version__}.gif"
+    )
+    assert plan.segment_extension == segment_extension
+    assert plan.segment_path("hash") == layout.partial_movie_dir / (
+        f"hash{segment_extension}"
+    )
+
+
+def test_resolve_png_plan(tmp_path):
+    layout = _layout(tmp_path)
+
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.PNG),
+        scene_name="ExampleScene",
+        requested_output_name=None,
+    )
+
+    assert plan.primary_artifact == (
+        layout.images_dir / f"ExampleScene_ManimCE_v{__version__}.png"
+    )
+    assert plan.fallback_image is None
+    with pytest.raises(ValueError, match="does not contain an image sequence"):
+        plan.image_frame_path(0)
+
+
+def test_resolve_png_sequence_plan(tmp_path):
+    layout = _layout(tmp_path)
+
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.PNG_SEQUENCE),
+        scene_name="ExampleScene",
+        requested_output_name=None,
+    )
+
+    assert plan.primary_artifact == layout.images_dir / "ExampleScene"
+    assert plan.image_sequence_dir == layout.images_dir / "ExampleScene"
+    assert plan.image_frame_path(0) == layout.images_dir / "ExampleScene" / "0000.png"
+    assert plan.image_frame_path(42) == (
+        layout.images_dir / "ExampleScene" / "0042.png"
+    )
+
+
+def test_resolve_no_output_plan_without_layout_directories(tmp_path):
+    layout = MediaLayoutSpec(None, None, None, None, None, zero_pad=4)
+
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.NONE),
+        scene_name="ExampleScene",
+        requested_output_name=None,
+    )
+
+    assert plan.primary_artifact is None
+    assert plan.fallback_image is None
+    assert plan.segment_cache_dir is None
+    assert plan.image_sequence_dir is None
+    assert not (tmp_path / "not-created").exists()
+
+
+@pytest.mark.parametrize(
+    ("requested_name", "expected_name"),
+    [
+        ("movie", "movie.mp4"),
+        ("movie.mp4", "movie.mp4"),
+        ("movie.mov", "movie.mp4"),
+    ],
+)
+def test_resolved_format_controls_custom_output_suffix(
+    tmp_path,
+    requested_name,
+    expected_name,
+):
+    layout = _layout(tmp_path)
+
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.MP4),
+        scene_name="ExampleScene",
+        requested_output_name=Path(requested_name),
+    )
+
+    assert plan.primary_artifact == layout.video_dir / expected_name
+    assert plan.output_stem == "movie"
+
+
+def test_absolute_output_name_only_relocates_primary_and_fallback(tmp_path):
+    layout = _layout(tmp_path, sections=True)
+    requested = tmp_path / "exports" / "movie.mov"
+
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.MP4, save_sections=True),
+        scene_name="ExampleScene",
+        requested_output_name=requested,
+    )
+
+    assert plan.primary_artifact == tmp_path / "exports" / "movie.mp4"
+    assert plan.fallback_image == tmp_path / "exports" / "movie.png"
+    assert plan.section_index == layout.sections_dir / "movie.json"
+    assert plan.section_path(0, "intro") == (
+        layout.sections_dir / "movie_0000_intro.mp4"
+    )
+    assert plan.segment_cache_dir == layout.partial_movie_dir
+
+
+def test_nested_output_name_keeps_sections_in_configured_directory(tmp_path):
+    layout = _layout(tmp_path, sections=True)
+
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.MP4, save_sections=True),
+        scene_name="ExampleScene",
+        requested_output_name=Path("exports/movie.mp4"),
+    )
+
+    assert plan.primary_artifact == layout.video_dir / "exports" / "movie.mp4"
+    assert plan.section_path(3, "ending") == (
+        layout.sections_dir / "movie_0003_ending.mp4"
+    )
+
+
+def test_plan_resolution_does_not_create_directories(tmp_path):
+    layout = _layout(tmp_path, sections=True)
+    missing_root = tmp_path / "not-created"
+
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.MP4, save_sections=True),
+        scene_name="ExampleScene",
+        requested_output_name=None,
+    )
+
+    assert plan.primary_artifact is not None
+    assert not missing_root.exists()
+
+
+def test_plans_are_immutable_hashable_values(tmp_path):
+    layout = _layout(tmp_path)
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.MP4),
+        scene_name="ExampleScene",
+        requested_output_name=None,
+    )
+
+    assert hash(layout)
+    assert hash(plan)
+    with pytest.raises(FrozenInstanceError):
+        plan.primary_artifact = tmp_path / "other.mp4"
+
+
+@pytest.mark.parametrize("scene_name", ["", None])
+def test_scene_name_is_required(tmp_path, scene_name):
+    with pytest.raises(ValueError, match="scene name"):
+        resolve_output_plan(
+            _layout(tmp_path),
+            _output(OutputFormat.MP4),
+            scene_name=scene_name,
+            requested_output_name=None,
+        )
+
+
+def test_dynamic_path_methods_validate_inputs(tmp_path):
+    layout = _layout(tmp_path, sections=True)
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.MP4, save_sections=True),
+        scene_name="ExampleScene",
+        requested_output_name=None,
+    )
+
+    with pytest.raises(ValueError, match="cache key"):
+        plan.segment_path("../escape")
+    with pytest.raises(ValueError, match="non-negative"):
+        plan.section_path(-1, "intro")
+
+
+def test_config_adapter_captures_exact_required_directories(config, tmp_path):
+    config.media_dir = "relative-media"
+    config.input_file = tmp_path / "source" / "example.py"
+    config.pixel_height = 480
+    config.frame_rate = 15
+    config.zero_pad = 3
+    config.log_to_file = True
+    output = _output(OutputFormat.MP4, save_sections=True)
+
+    module_name = resolve_module_name(config)
+    layout = resolve_media_layout(
+        config,
+        output,
+        module_name=module_name,
+        scene_name="ExampleScene",
+        working_directory=tmp_path,
+    )
+
+    quality_dir = tmp_path / "relative-media" / "videos" / "example" / "480p15"
+    assert module_name == "example"
+    assert layout.video_dir == quality_dir
+    assert layout.images_dir == tmp_path / "relative-media" / "images" / "example"
+    assert layout.sections_dir == quality_dir / "sections"
+    assert layout.partial_movie_dir == (
+        quality_dir / "partial_movie_files" / "ExampleScene"
+    )
+    assert layout.log_dir == tmp_path / "relative-media" / "logs"
+    assert layout.zero_pad == 3
+    assert not (tmp_path / "relative-media").exists()
+
+
+def test_config_adapter_skips_unused_output_directories(config, tmp_path):
+    config.media_dir = "unused-media"
+    config.log_to_file = False
+
+    layout = resolve_media_layout(
+        config,
+        _output(OutputFormat.NONE),
+        module_name="",
+        scene_name="ExampleScene",
+        working_directory=tmp_path,
+    )
+
+    assert layout == MediaLayoutSpec(None, None, None, None, None, zero_pad=4)
+
+
+def test_requested_name_and_log_path_resolution(config, tmp_path):
+    config.output_file = "exports/movie.mp4"
+    config.log_to_file = True
+    config.media_dir = tmp_path
+    module_name = resolve_module_name(config)
+    layout = resolve_media_layout(
+        config,
+        _output(OutputFormat.NONE),
+        module_name=module_name,
+        scene_name="ExampleScene",
+        working_directory=tmp_path,
+    )
+
+    assert resolve_requested_output_name(config) == Path("exports/movie.mp4")
+    assert (
+        resolve_file_log_path(
+            layout,
+            module_name=module_name,
+            scene_name="ExampleScene",
+        )
+        == tmp_path / "logs" / "_ExampleScene.log"
+    )

--- a/tests/module/test_output_plan.py
+++ b/tests/module/test_output_plan.py
@@ -35,8 +35,14 @@ def _output(
     *,
     transparent: bool = False,
     save_sections: bool = False,
+    fallback_to_still: bool = False,
 ) -> OutputSpec:
-    return OutputSpec(output_format, transparent, save_sections)
+    return OutputSpec(
+        output_format,
+        transparent,
+        save_sections,
+        fallback_to_still,
+    )
 
 
 @pytest.mark.parametrize(
@@ -58,9 +64,7 @@ def test_resolve_video_plan(tmp_path, output_format, extension):
     )
 
     assert plan.primary_artifact == layout.video_dir / f"ExampleScene{extension}"
-    assert plan.fallback_image == (
-        layout.images_dir / f"ExampleScene_ManimCE_v{__version__}.png"
-    )
+    assert plan.fallback_image is None
     assert plan.segment_cache_dir == layout.partial_movie_dir
     assert plan.segment_path("cache-key") == (
         layout.partial_movie_dir / f"cache-key{extension}"
@@ -91,6 +95,22 @@ def test_resolve_gif_plan(tmp_path, transparent, segment_extension):
     assert plan.segment_extension == segment_extension
     assert plan.segment_path("hash") == layout.partial_movie_dir / (
         f"hash{segment_extension}"
+    )
+
+
+def test_resolve_automatic_video_plan_with_fallback(tmp_path):
+    layout = _layout(tmp_path)
+
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.MP4, fallback_to_still=True),
+        scene_name="ExampleScene",
+        requested_output_name=None,
+    )
+
+    assert plan.primary_artifact == layout.video_dir / "ExampleScene.mp4"
+    assert plan.fallback_image == (
+        layout.images_dir / f"ExampleScene_ManimCE_v{__version__}.png"
     )
 
 
@@ -179,7 +199,11 @@ def test_absolute_output_name_only_relocates_primary_and_fallback(tmp_path):
 
     plan = resolve_output_plan(
         layout,
-        _output(OutputFormat.MP4, save_sections=True),
+        _output(
+            OutputFormat.MP4,
+            save_sections=True,
+            fallback_to_still=True,
+        ),
         scene_name="ExampleScene",
         requested_output_name=requested,
     )
@@ -263,6 +287,50 @@ def test_dynamic_path_methods_validate_inputs(tmp_path):
         plan.segment_path("../escape")
     with pytest.raises(ValueError, match="non-negative"):
         plan.section_path(-1, "intro")
+    with pytest.raises(TypeError, match="strings"):
+        plan.section_path(0, 1)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("name", "slug"),
+    [
+        ("1", "1"),
+        ("create square", "create-square"),
+        ("Chapter 1: Why/How?", "Chapter-1-Why-How"),
+        ("../../../escape", "escape"),
+        ("Überblick № 2", "Überblick-No-2"),
+        ("!!!", "section"),
+    ],
+)
+def test_section_paths_use_safe_human_readable_slugs(tmp_path, name, slug):
+    layout = _layout(tmp_path, sections=True)
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.MP4, save_sections=True),
+        scene_name="ExampleScene",
+        requested_output_name=None,
+    )
+
+    assert plan.section_path(3, name) == (
+        layout.sections_dir / f"ExampleScene_0003_{slug}.mp4"
+    )
+
+
+def test_section_ordinal_keeps_duplicate_slugs_unique(tmp_path):
+    layout = _layout(tmp_path, sections=True)
+    plan = resolve_output_plan(
+        layout,
+        _output(OutputFormat.MP4, save_sections=True),
+        scene_name="ExampleScene",
+        requested_output_name=None,
+    )
+
+    first = plan.section_path(1, "intro!")
+    second = plan.section_path(2, "intro?")
+
+    assert first.name == "ExampleScene_0001_intro.mp4"
+    assert second.name == "ExampleScene_0002_intro.mp4"
+    assert first != second
 
 
 def test_config_adapter_captures_exact_required_directories(config, tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,15 +54,6 @@ def test_tempconfig(config):
             assert config[k] == v
 
 
-def test_custom_folders_config_option_was_removed():
-    candidate = ManimConfig()
-
-    assert not hasattr(ManimConfig, "custom_folders")
-    assert "custom_folders" not in candidate
-    with pytest.raises(AttributeError):
-        candidate["custom_folders"] = True
-
-
 def test_tempconfig_restores_renderer_class_bases(config):
     with tempconfig({"renderer": "opengl"}):
         assert config.renderer == RendererType.OPENGL

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,7 @@ from manim.constants import RendererType
 from manim.mobject.opengl.opengl_vectorized_mobject import OpenGLVMobject
 from manim.mobject.types.vectorized_mobject import VMobject
 from manim.renderer.protocol import RendererCapabilities
-from tests.assert_utils import assert_dir_exists, assert_dir_filled, assert_file_exists
+from tests.assert_utils import assert_dir_filled, assert_file_exists
 
 
 def _resolve_session(config):
@@ -379,8 +379,7 @@ def test_custom_dirs(tmp_path, config):
     assert_dir_filled(tmp_path / "test_partial_movie_dir")
     assert_file_exists(tmp_path / "test_partial_movie_dir/partial_movie_file_list.txt")
 
-    # TODO: another example with image output would be nice
-    assert_dir_exists(tmp_path / "test_images")
+    assert not (tmp_path / "test_images").exists()
 
     assert_dir_filled(tmp_path / "test_text")
     assert_dir_filled(tmp_path / "test_tex")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,6 +54,15 @@ def test_tempconfig(config):
             assert config[k] == v
 
 
+def test_custom_folders_config_option_was_removed():
+    candidate = ManimConfig()
+
+    assert not hasattr(ManimConfig, "custom_folders")
+    assert "custom_folders" not in candidate
+    with pytest.raises(AttributeError):
+        candidate["custom_folders"] = True
+
+
 def test_tempconfig_restores_renderer_class_bases(config):
     with tempconfig({"renderer": "opengl"}):
         assert config.renderer == RendererType.OPENGL

--- a/tests/test_logging/test_logging.py
+++ b/tests/test_logging/test_logging.py
@@ -30,6 +30,29 @@ def test_logging_to_file(tmp_path, python_version):
     assert exitcode == 0, err
 
 
+def test_library_logging_without_media_output(tmp_path, python_version):
+    script = f"""
+from manim import Scene, tempconfig
+
+class LibraryScene(Scene):
+    pass
+
+with tempconfig({{
+    "format": "none",
+    "log_to_file": True,
+    "media_dir": {str(tmp_path)!r},
+}}):
+    LibraryScene().render()
+"""
+
+    _, err, exitcode = capture([python_version, "-c", script])
+
+    assert exitcode == 0, err
+    assert (tmp_path / "logs" / "_LibraryScene.log").is_file()
+    assert not (tmp_path / "videos").exists()
+    assert not (tmp_path / "images").exists()
+
+
 def test_error_logging(tmp_path, python_version):
     path_error_scene = Path("tests/test_logging/basic_scenes_error.py")
 

--- a/tests/test_scene_rendering/opengl/test_cli_flags_opengl.py
+++ b/tests/test_scene_rendering/opengl/test_cli_flags_opengl.py
@@ -209,8 +209,9 @@ def test_no_image_output_with_interactive_embed(
         "running an interactive static scene rendered a video"
     )
 
-    is_empty = not any((tmp_path / "images" / "simple_scenes").iterdir())
-    assert is_empty, "running an interactive static scene rendered an image"
+    assert not (tmp_path / "images").exists(), (
+        "running an interactive static scene rendered an image"
+    )
 
 
 @pytest.mark.slow
@@ -240,8 +241,9 @@ def test_default_video_output_with_non_static_scene(
         "default output did not render the non-static scene as a video"
     )
 
-    is_empty = not any((tmp_path / "images" / "simple_scenes").iterdir())
-    assert is_empty, "default video output unexpectedly rendered an image"
+    assert not (tmp_path / "images").exists(), (
+        "default video output unexpectedly rendered an image"
+    )
 
 
 @pytest.mark.slow

--- a/tests/test_scene_rendering/opengl/test_cli_flags_opengl.py
+++ b/tests/test_scene_rendering/opengl/test_cli_flags_opengl.py
@@ -362,33 +362,6 @@ def test_a_flag(tmp_path, manim_cfg_file, infallible_scenes_path):
 
 
 @pytest.mark.slow
-def test_custom_folders(tmp_path, manim_cfg_file, simple_scenes_path):
-    scene_name = "SquareToCircle"
-    command = [
-        sys.executable,
-        "-m",
-        "manim",
-        "--renderer",
-        "opengl",
-        "-ql",
-        "-s",
-        "--media_dir",
-        str(tmp_path),
-        "--custom_folders",
-        str(simple_scenes_path),
-        scene_name,
-    ]
-    out, err, exit_code = capture(command)
-    assert exit_code == 0, err
-
-    exists = (tmp_path / "videos").exists()
-    assert not exists, "--custom_folders produced a 'videos/' dir"
-
-    exists = add_version_before_extension(tmp_path / "SquareToCircle.png").exists()
-    assert exists, "--custom_folders did not produce the output file"
-
-
-@pytest.mark.slow
 def test_dash_as_filename(tmp_path):
     code = (
         "class Test(Scene):\n"

--- a/tests/test_scene_rendering/test_cli_flags.py
+++ b/tests/test_scene_rendering/test_cli_flags.py
@@ -253,29 +253,16 @@ def test_a_flag(tmp_path, manim_cfg_file, infallible_scenes_path):
     )
 
 
-@pytest.mark.slow
-def test_custom_folders(tmp_path, manim_cfg_file, simple_scenes_path):
-    scene_name = "SquareToCircle"
-    command = [
-        sys.executable,
-        "-m",
-        "manim",
-        "-ql",
-        "-s",
-        "--media_dir",
-        str(tmp_path),
-        "--custom_folders",
-        str(simple_scenes_path),
-        scene_name,
-    ]
-    out, err, exit_code = capture(command)
-    assert exit_code == 0, err
+def test_custom_folders_option_was_removed(simple_scenes_path):
+    runner = CliRunner()
 
-    exists = (tmp_path / "videos").exists()
-    assert not exists, "--custom_folders produced a 'videos/' dir"
+    result = runner.invoke(
+        main,
+        ["--custom_folders", str(simple_scenes_path), "SquareToCircle"],
+    )
 
-    exists = add_version_before_extension(tmp_path / "SquareToCircle.png").exists()
-    assert exists, "--custom_folders did not produce the output file"
+    assert result.exit_code == 2
+    assert "No such option: --custom_folders" in result.output
 
 
 @pytest.mark.slow

--- a/tests/test_scene_rendering/test_cli_flags.py
+++ b/tests/test_scene_rendering/test_cli_flags.py
@@ -253,6 +253,41 @@ def test_a_flag(tmp_path, manim_cfg_file, infallible_scenes_path):
     )
 
 
+@pytest.mark.parametrize(
+    "scene_selection",
+    [
+        ("-a",),
+        ("Wait1", "Wait3"),
+    ],
+)
+def test_output_file_rejects_multi_scene_render(
+    tmp_path,
+    infallible_scenes_path,
+    scene_selection,
+):
+    command = [
+        sys.executable,
+        "-m",
+        "manim",
+        "--media_dir",
+        str(tmp_path),
+        "-o",
+        "shared-name",
+    ]
+    if scene_selection == ("-a",):
+        command.extend(["-a", str(infallible_scenes_path)])
+    else:
+        command.extend([str(infallible_scenes_path), *scene_selection])
+
+    out, err, exit_code = capture(command)
+
+    assert exit_code == 1
+    assert "--output_file can only be used when rendering exactly one scene" in (
+        err or out
+    )
+    assert not tmp_path.exists() or not any(tmp_path.iterdir())
+
+
 def test_custom_folders_option_was_removed(simple_scenes_path):
     runner = CliRunner()
 
@@ -311,7 +346,8 @@ def test_custom_output_name_gif(tmp_path, simple_scenes_path):
 @pytest.mark.slow
 def test_custom_output_name_mp4(tmp_path, simple_scenes_path):
     scene_name = "SquareToCircle"
-    custom_name = "custom_name"
+    requested_name = "custom_name.mov"
+    expected_name = "custom_name"
     command = [
         sys.executable,
         "-m",
@@ -320,7 +356,7 @@ def test_custom_output_name_mp4(tmp_path, simple_scenes_path):
         "--media_dir",
         str(tmp_path),
         "-o",
-        custom_name,
+        requested_name,
         str(simple_scenes_path),
         scene_name,
     ]
@@ -332,18 +368,18 @@ def test_custom_output_name_mp4(tmp_path, simple_scenes_path):
     )
 
     assert not wrong_mp4_path.exists(), (
-        "The mp4 file does not respect the custom name: " + custom_name + ".mp4"
+        "The mp4 file does not respect the custom name: " + expected_name + ".mp4"
     )
 
     unexpected_gif_path = add_version_before_extension(
-        tmp_path / "videos" / "simple_scenes" / "480p15" / f"{custom_name}.gif"
+        tmp_path / "videos" / "simple_scenes" / "480p15" / f"{expected_name}.gif"
     )
     assert not unexpected_gif_path.exists(), "Found an unexpected gif file at " + str(
         unexpected_gif_path
     )
 
     expected_mp4_path = (
-        tmp_path / "videos" / "simple_scenes" / "480p15" / str(custom_name + ".mp4")
+        tmp_path / "videos" / "simple_scenes" / "480p15" / str(expected_name + ".mp4")
     )
 
     assert expected_mp4_path.exists(), "mp4 file not found at " + str(expected_mp4_path)

--- a/tests/test_scene_rendering/test_cli_flags.py
+++ b/tests/test_scene_rendering/test_cli_flags.py
@@ -347,7 +347,7 @@ def test_custom_output_name_gif(tmp_path, simple_scenes_path):
 def test_custom_output_name_mp4(tmp_path, simple_scenes_path):
     scene_name = "SquareToCircle"
     requested_name = "custom_name.mov"
-    expected_name = "custom_name"
+    expected_name = requested_name
     command = [
         sys.executable,
         "-m",

--- a/tests/test_scene_rendering/test_cli_flags.py
+++ b/tests/test_scene_rendering/test_cli_flags.py
@@ -288,18 +288,6 @@ def test_output_file_rejects_multi_scene_render(
     assert not tmp_path.exists() or not any(tmp_path.iterdir())
 
 
-def test_custom_folders_option_was_removed(simple_scenes_path):
-    runner = CliRunner()
-
-    result = runner.invoke(
-        main,
-        ["--custom_folders", str(simple_scenes_path), "SquareToCircle"],
-    )
-
-    assert result.exit_code == 2
-    assert "No such option: --custom_folders" in result.output
-
-
 @pytest.mark.slow
 def test_custom_output_name_gif(tmp_path, simple_scenes_path):
     scene_name = "SquareToCircle"

--- a/tests/test_scene_rendering/test_file_writer.py
+++ b/tests/test_scene_rendering/test_file_writer.py
@@ -229,6 +229,7 @@ def test_clean_cache_ignores_hidden_files(config, tmp_path):
     with tempconfig({"media_dir": tmp_path, "format": "mp4"}):
         writer = _new_file_writer("CacheCleaningScene")
         cache_dir = writer.partial_movie_directory
+        cache_dir.mkdir(parents=True)
 
         for name in ["00001.mp4", ".DS_Store", "._00001.mp4"]:
             (cache_dir / name).touch()
@@ -254,6 +255,7 @@ def test_flush_cache_directory_ignores_hidden_files(config, tmp_path):
     with tempconfig({"media_dir": tmp_path, "format": "mp4"}):
         writer = _new_file_writer("CacheFlushingScene")
         cache_dir = writer.partial_movie_directory
+        cache_dir.mkdir(parents=True)
 
         for name in ["00001.mp4", "00002.mp4", ".DS_Store", "._00001.mp4"]:
             (cache_dir / name).touch()
@@ -275,6 +277,7 @@ def test_clean_cache_tolerates_vanishing_files(config, tmp_path, monkeypatch):
     with tempconfig({"media_dir": tmp_path, "format": "mp4"}):
         writer = _new_file_writer("VanishingFileScene")
         cache_dir = writer.partial_movie_directory
+        cache_dir.mkdir(parents=True)
 
         survivor = cache_dir / "00001.mp4"
         survivor.touch()
@@ -293,6 +296,7 @@ def test_clean_cache_does_not_evict_for_vanished_file(config, tmp_path, monkeypa
     with tempconfig({"media_dir": tmp_path, "format": "mp4"}):
         writer = _new_file_writer("VanishedFileEvictionScene")
         cache_dir = writer.partial_movie_directory
+        cache_dir.mkdir(parents=True)
 
         survivors = [cache_dir / f"{index:05}.mp4" for index in range(2)]
         for survivor in survivors:

--- a/tests/test_scene_rendering/test_file_writer.py
+++ b/tests/test_scene_rendering/test_file_writer.py
@@ -8,7 +8,14 @@ import numpy as np
 import pytest
 
 from manim import DR, Circle, Create, Scene, Star, tempconfig
+from manim._config import config
 from manim._config.output import OutputFormat, OutputSpec
+from manim._config.output_plan import (
+    resolve_media_layout,
+    resolve_module_name,
+    resolve_output_plan,
+    resolve_requested_output_name,
+)
 from manim.scene.scene_file_writer import SceneFileWriter, to_av_frame_rate
 from manim.utils.commands import capture, get_video_metadata
 
@@ -192,16 +199,27 @@ def test_frame_rates():
 def _new_file_writer(scene_name: str) -> SceneFileWriter:
     renderer = Mock()
     renderer.num_plays = 0
-    return SceneFileWriter(
-        renderer,
-        scene_name,
-        OutputSpec(
-            OutputFormat.MP4,
-            transparent=False,
-            save_sections=False,
-            fallback_to_still=False,
-        ),
+    output = OutputSpec(
+        OutputFormat.MP4,
+        transparent=False,
+        save_sections=False,
+        fallback_to_still=False,
     )
+    module_name = resolve_module_name(config)
+    layout = resolve_media_layout(
+        config,
+        output,
+        module_name=module_name,
+        scene_name=scene_name,
+        working_directory=Path.cwd(),
+    )
+    plan = resolve_output_plan(
+        layout,
+        output,
+        scene_name=scene_name,
+        requested_output_name=resolve_requested_output_name(config),
+    )
+    return SceneFileWriter(renderer, scene_name, output, plan)
 
 
 def test_clean_cache_ignores_hidden_files(config, tmp_path):

--- a/tests/test_scene_rendering/test_parallel_encoding.py
+++ b/tests/test_scene_rendering/test_parallel_encoding.py
@@ -23,6 +23,7 @@ from manim._config.output_plan import (
     resolve_requested_output_name,
 )
 from manim.cli.render.commands import render
+from manim.scene.scene_file_writer import SceneFileWriter
 from manim.utils.exceptions import RerunSceneException
 
 _ENCODER_THREAD_PREFIX = "partial-movie-encoder-"
@@ -42,7 +43,10 @@ _UNIQUE_PLAYS = 6
 _TOTAL_PLAYS = _UNIQUE_PLAYS + 2
 
 
-def _plan_for(scene_name: str, output: OutputSpec):
+def _make_writer(
+    scene_name: str,
+    output: OutputSpec = _VIDEO_OUTPUT,
+) -> SceneFileWriter:
     module_name = resolve_module_name(config)
     layout = resolve_media_layout(
         config,
@@ -51,12 +55,14 @@ def _plan_for(scene_name: str, output: OutputSpec):
         scene_name=scene_name,
         working_directory=Path.cwd(),
     )
-    return resolve_output_plan(
+    plan = resolve_output_plan(
         layout,
         output,
         scene_name=scene_name,
         requested_output_name=resolve_requested_output_name(config),
     )
+    renderer = Mock(num_plays=0)
+    return SceneFileWriter(renderer, scene_name, output, plan)
 
 
 _SCENE_NAME = "ParallelEncodingCacheScene"
@@ -365,8 +371,6 @@ def test_write_frame_fails_fast_after_encoder_failure(
     tmp_path,
     monkeypatch,
 ):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     expected_exception = RuntimeError("encode failed")
     stream = Mock()
     container = Mock()
@@ -378,14 +382,7 @@ def test_write_frame_fails_fast_after_encoder_failure(
 
     stream.encode.side_effect = encode
     config.media_dir = str(tmp_path)
-    renderer = Mock()
-    renderer.num_plays = 0
-    writer = SceneFileWriter(
-        renderer,
-        "FailFastScene",
-        _VIDEO_OUTPUT,
-        _plan_for("FailFastScene", _VIDEO_OUTPUT),
-    )
+    writer = _make_writer("FailFastScene")
     job = _new_encode_job(tmp_path, monkeypatch, "fail_fast", stream, container)
     job.path.write_bytes(b"stale")
     writer._current_encode_job = job
@@ -425,18 +422,9 @@ def test_frame_queue_configuration(
     encoder_queue_size,
     expected_queue_size,
 ):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     config.max_inflight_encoders = max_inflight_encoders
     config.encoder_queue_size = encoder_queue_size
-    renderer = Mock()
-    renderer.num_plays = 0
-    writer = SceneFileWriter(
-        renderer,
-        "FrameQueueSizeScene",
-        _VIDEO_OUTPUT,
-        _plan_for("FrameQueueSizeScene", _VIDEO_OUTPUT),
-    )
+    writer = _make_writer("FrameQueueSizeScene")
 
     writer.open_partial_movie_stream(tmp_path / "partial.mp4")
     job = writer._current_encode_job
@@ -454,17 +442,8 @@ def test_close_partial_movie_stream_respects_cap_and_joins_fifo(
     tmp_path,
     max_inflight_encoders,
 ):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     config.max_inflight_encoders = max_inflight_encoders
-    renderer = Mock()
-    renderer.num_plays = 0
-    writer = SceneFileWriter(
-        renderer,
-        "EncoderCapScene",
-        _VIDEO_OUTPUT,
-        _plan_for("EncoderCapScene", _VIDEO_OUTPUT),
-    )
+    writer = _make_writer("EncoderCapScene")
     jobs = [Mock(path=tmp_path / f"partial_{index}.mp4") for index in range(3)]
 
     for index, job in enumerate(jobs):
@@ -495,19 +474,10 @@ def test_close_partial_movie_stream_respects_cap_and_joins_fifo(
 
 
 def test_cap_join_failure_drains_all_inflight_jobs(config, tmp_path):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     primary_exception = RuntimeError("first join failed")
     secondary_exception = RuntimeError("second join failed")
     config.max_inflight_encoders = 3
-    renderer = Mock()
-    renderer.num_plays = 0
-    writer = SceneFileWriter(
-        renderer,
-        "EncoderCapFailureScene",
-        _VIDEO_OUTPUT,
-        _plan_for("EncoderCapFailureScene", _VIDEO_OUTPUT),
-    )
+    writer = _make_writer("EncoderCapFailureScene")
     jobs = [Mock(path=tmp_path / f"partial_{index}.mp4") for index in range(3)]
     jobs[0].join.side_effect = primary_exception
     jobs[1].join.side_effect = secondary_exception
@@ -530,16 +500,7 @@ def test_cap_join_failure_drains_all_inflight_jobs(config, tmp_path):
 
 
 def test_is_already_cached_joins_same_path_inflight_job(config, tmp_path):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
-    renderer = Mock()
-    renderer.num_plays = 0
-    writer = SceneFileWriter(
-        renderer,
-        "CachedInflightScene",
-        _VIDEO_OUTPUT,
-        _plan_for("CachedInflightScene", _VIDEO_OUTPUT),
-    )
+    writer = _make_writer("CachedInflightScene")
     hash_invocation = "same_path_hash"
     path = (
         writer.partial_movie_directory
@@ -557,17 +518,8 @@ def test_is_already_cached_joins_same_path_inflight_job(config, tmp_path):
 
 
 def test_same_path_join_failure_drains_unrelated_jobs(config, tmp_path):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     expected_exception = RuntimeError("same-path join failed")
-    renderer = Mock()
-    renderer.num_plays = 0
-    writer = SceneFileWriter(
-        renderer,
-        "CachedInflightFailureScene",
-        _VIDEO_OUTPUT,
-        _plan_for("CachedInflightFailureScene", _VIDEO_OUTPUT),
-    )
+    writer = _make_writer("CachedInflightFailureScene")
     hash_invocation = "failing_same_path_hash"
     path = (
         writer.partial_movie_directory
@@ -591,16 +543,7 @@ def test_same_path_join_failure_drains_unrelated_jobs(config, tmp_path):
 
 
 def test_open_partial_movie_stream_joins_same_path_inflight_job(config, tmp_path):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
-    renderer = Mock()
-    renderer.num_plays = 0
-    writer = SceneFileWriter(
-        renderer,
-        "OpenInflightScene",
-        _VIDEO_OUTPUT,
-        _plan_for("OpenInflightScene", _VIDEO_OUTPUT),
-    )
+    writer = _make_writer("OpenInflightScene")
     path = tmp_path / "same_path.mp4"
     inflight_job = Mock(path=path)
     writer._inflight_encode_jobs.append(inflight_job)
@@ -626,17 +569,8 @@ def test_finish_propagates_join_failure_and_clears_inflight_state(
     tmp_path,
     monkeypatch,
 ):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     expected_exception = RuntimeError("join failed")
-    renderer = Mock()
-    renderer.num_plays = 0
-    writer = SceneFileWriter(
-        renderer,
-        "JoinFailureScene",
-        _VIDEO_OUTPUT,
-        _plan_for("JoinFailureScene", _VIDEO_OUTPUT),
-    )
+    writer = _make_writer("JoinFailureScene")
     failing_job = Mock(path=tmp_path / "failing.mp4")
     failing_job.join.side_effect = expected_exception
     succeeding_job = Mock(path=tmp_path / "succeeding.mp4")
@@ -658,17 +592,8 @@ def test_finish_propagates_join_failure_and_clears_inflight_state(
 
 
 def _new_writer(config, tmp_path, scene_name):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     config.media_dir = str(tmp_path)
-    renderer = Mock()
-    renderer.num_plays = 0
-    return SceneFileWriter(
-        renderer,
-        scene_name,
-        _VIDEO_OUTPUT,
-        _plan_for(scene_name, _VIDEO_OUTPUT),
-    )
+    return _make_writer(scene_name)
 
 
 def _healthy_current_job(tmp_path, monkeypatch, name):
@@ -753,17 +678,8 @@ def test_abort_encode_jobs_cleanup_failure_logs_warning(
 
 
 def test_abort_encode_jobs_noop_on_dry_run_writer(config):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     with tempconfig({"dry_run": True}):
-        renderer = Mock()
-        renderer.num_plays = 0
-        writer = SceneFileWriter(
-            renderer,
-            "DryRunAbortScene",
-            _NO_OUTPUT,
-            _plan_for("DryRunAbortScene", _NO_OUTPUT),
-        )
+        writer = _make_writer("DryRunAbortScene", _NO_OUTPUT)
 
         writer.abort_encode_jobs()
         writer.abort_encode_jobs(reraise_encoder_failures=True)
@@ -1099,17 +1015,8 @@ def test_is_already_cached_false_after_joining_failed_path(config, tmp_path):
     The existing same-path test asserts the join happens but never checks the
     return value.
     """
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     with tempconfig({"media_dir": str(tmp_path)}):
-        renderer = Mock()
-        renderer.num_plays = 0
-        writer = SceneFileWriter(
-            renderer,
-            "CachedReturnScene",
-            _VIDEO_OUTPUT,
-            _plan_for("CachedReturnScene", _VIDEO_OUTPUT),
-        )
+        writer = _make_writer("CachedReturnScene")
         hash_invocation = "missing_partial_hash"
         path = (
             writer.partial_movie_directory
@@ -1124,17 +1031,8 @@ def test_is_already_cached_false_after_joining_failed_path(config, tmp_path):
 
 
 def test_is_already_cached_true_when_partial_exists(config, tmp_path):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     with tempconfig({"media_dir": str(tmp_path)}):
-        renderer = Mock()
-        renderer.num_plays = 0
-        writer = SceneFileWriter(
-            renderer,
-            "CachedReturnScene",
-            _VIDEO_OUTPUT,
-            _plan_for("CachedReturnScene", _VIDEO_OUTPUT),
-        )
+        writer = _make_writer("CachedReturnScene")
         hash_invocation = "present_partial_hash"
         path = (
             writer.partial_movie_directory
@@ -1147,34 +1045,16 @@ def test_is_already_cached_true_when_partial_exists(config, tmp_path):
 
 
 def test_close_partial_movie_stream_without_open_stream_raises(config, tmp_path):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     with tempconfig({"media_dir": str(tmp_path)}):
-        renderer = Mock()
-        renderer.num_plays = 0
-        writer = SceneFileWriter(
-            renderer,
-            "GuardScene",
-            _VIDEO_OUTPUT,
-            _plan_for("GuardScene", _VIDEO_OUTPUT),
-        )
+        writer = _make_writer("GuardScene")
 
         with pytest.raises(RuntimeError, match="without an open partial"):
             writer.close_partial_movie_stream()
 
 
 def test_open_partial_movie_stream_without_path_raises(config, tmp_path):
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     with tempconfig({"media_dir": str(tmp_path)}):
-        renderer = Mock()
-        renderer.num_plays = 0
-        writer = SceneFileWriter(
-            renderer,
-            "GuardScene",
-            _VIDEO_OUTPUT,
-            _plan_for("GuardScene", _VIDEO_OUTPUT),
-        )
+        writer = _make_writer("GuardScene")
         writer.partial_movie_files = [None]
 
         with pytest.raises(RuntimeError, match="partial movie file path"):
@@ -1187,17 +1067,8 @@ def test_write_frame_without_open_stream_drops_frame(config, tmp_path):
     Video output is enabled under the default test config, so the call reaches
     the drop branch in ``write_frame``.
     """
-    from manim.scene.scene_file_writer import SceneFileWriter
-
     with tempconfig({"media_dir": str(tmp_path)}):
-        renderer = Mock()
-        renderer.num_plays = 0
-        writer = SceneFileWriter(
-            renderer,
-            "DropFrameScene",
-            _VIDEO_OUTPUT,
-            _plan_for("DropFrameScene", _VIDEO_OUTPUT),
-        )
+        writer = _make_writer("DropFrameScene")
         assert writer._current_encode_job is None
 
         # Must not raise and must not create a job.

--- a/tests/test_scene_rendering/test_parallel_encoding.py
+++ b/tests/test_scene_rendering/test_parallel_encoding.py
@@ -16,6 +16,12 @@ from click.testing import CliRunner
 from manim import FadeIn, Scene, Square, capture, tempconfig
 from manim._config import config
 from manim._config.output import OutputFormat, OutputSpec
+from manim._config.output_plan import (
+    resolve_media_layout,
+    resolve_module_name,
+    resolve_output_plan,
+    resolve_requested_output_name,
+)
 from manim.cli.render.commands import render
 from manim.utils.exceptions import RerunSceneException
 
@@ -34,6 +40,24 @@ _NO_OUTPUT = OutputSpec(
 )
 _UNIQUE_PLAYS = 6
 _TOTAL_PLAYS = _UNIQUE_PLAYS + 2
+
+
+def _plan_for(scene_name: str, output: OutputSpec):
+    module_name = resolve_module_name(config)
+    layout = resolve_media_layout(
+        config,
+        output,
+        module_name=module_name,
+        scene_name=scene_name,
+        working_directory=Path.cwd(),
+    )
+    return resolve_output_plan(
+        layout,
+        output,
+        scene_name=scene_name,
+        requested_output_name=resolve_requested_output_name(config),
+    )
+
 
 _SCENE_NAME = "ParallelEncodingCacheScene"
 _SCENE_SOURCE = textwrap.dedent(
@@ -356,7 +380,12 @@ def test_write_frame_fails_fast_after_encoder_failure(
     config.media_dir = str(tmp_path)
     renderer = Mock()
     renderer.num_plays = 0
-    writer = SceneFileWriter(renderer, "FailFastScene", _VIDEO_OUTPUT)
+    writer = SceneFileWriter(
+        renderer,
+        "FailFastScene",
+        _VIDEO_OUTPUT,
+        _plan_for("FailFastScene", _VIDEO_OUTPUT),
+    )
     job = _new_encode_job(tmp_path, monkeypatch, "fail_fast", stream, container)
     job.path.write_bytes(b"stale")
     writer._current_encode_job = job
@@ -402,7 +431,12 @@ def test_frame_queue_configuration(
     config.encoder_queue_size = encoder_queue_size
     renderer = Mock()
     renderer.num_plays = 0
-    writer = SceneFileWriter(renderer, "FrameQueueSizeScene", _VIDEO_OUTPUT)
+    writer = SceneFileWriter(
+        renderer,
+        "FrameQueueSizeScene",
+        _VIDEO_OUTPUT,
+        _plan_for("FrameQueueSizeScene", _VIDEO_OUTPUT),
+    )
 
     writer.open_partial_movie_stream(tmp_path / "partial.mp4")
     job = writer._current_encode_job
@@ -425,7 +459,12 @@ def test_close_partial_movie_stream_respects_cap_and_joins_fifo(
     config.max_inflight_encoders = max_inflight_encoders
     renderer = Mock()
     renderer.num_plays = 0
-    writer = SceneFileWriter(renderer, "EncoderCapScene", _VIDEO_OUTPUT)
+    writer = SceneFileWriter(
+        renderer,
+        "EncoderCapScene",
+        _VIDEO_OUTPUT,
+        _plan_for("EncoderCapScene", _VIDEO_OUTPUT),
+    )
     jobs = [Mock(path=tmp_path / f"partial_{index}.mp4") for index in range(3)]
 
     for index, job in enumerate(jobs):
@@ -463,7 +502,12 @@ def test_cap_join_failure_drains_all_inflight_jobs(config, tmp_path):
     config.max_inflight_encoders = 3
     renderer = Mock()
     renderer.num_plays = 0
-    writer = SceneFileWriter(renderer, "EncoderCapFailureScene", _VIDEO_OUTPUT)
+    writer = SceneFileWriter(
+        renderer,
+        "EncoderCapFailureScene",
+        _VIDEO_OUTPUT,
+        _plan_for("EncoderCapFailureScene", _VIDEO_OUTPUT),
+    )
     jobs = [Mock(path=tmp_path / f"partial_{index}.mp4") for index in range(3)]
     jobs[0].join.side_effect = primary_exception
     jobs[1].join.side_effect = secondary_exception
@@ -490,7 +534,12 @@ def test_is_already_cached_joins_same_path_inflight_job(config, tmp_path):
 
     renderer = Mock()
     renderer.num_plays = 0
-    writer = SceneFileWriter(renderer, "CachedInflightScene", _VIDEO_OUTPUT)
+    writer = SceneFileWriter(
+        renderer,
+        "CachedInflightScene",
+        _VIDEO_OUTPUT,
+        _plan_for("CachedInflightScene", _VIDEO_OUTPUT),
+    )
     hash_invocation = "same_path_hash"
     path = (
         writer.partial_movie_directory
@@ -513,7 +562,12 @@ def test_same_path_join_failure_drains_unrelated_jobs(config, tmp_path):
     expected_exception = RuntimeError("same-path join failed")
     renderer = Mock()
     renderer.num_plays = 0
-    writer = SceneFileWriter(renderer, "CachedInflightFailureScene", _VIDEO_OUTPUT)
+    writer = SceneFileWriter(
+        renderer,
+        "CachedInflightFailureScene",
+        _VIDEO_OUTPUT,
+        _plan_for("CachedInflightFailureScene", _VIDEO_OUTPUT),
+    )
     hash_invocation = "failing_same_path_hash"
     path = (
         writer.partial_movie_directory
@@ -541,7 +595,12 @@ def test_open_partial_movie_stream_joins_same_path_inflight_job(config, tmp_path
 
     renderer = Mock()
     renderer.num_plays = 0
-    writer = SceneFileWriter(renderer, "OpenInflightScene", _VIDEO_OUTPUT)
+    writer = SceneFileWriter(
+        renderer,
+        "OpenInflightScene",
+        _VIDEO_OUTPUT,
+        _plan_for("OpenInflightScene", _VIDEO_OUTPUT),
+    )
     path = tmp_path / "same_path.mp4"
     inflight_job = Mock(path=path)
     writer._inflight_encode_jobs.append(inflight_job)
@@ -572,7 +631,12 @@ def test_finish_propagates_join_failure_and_clears_inflight_state(
     expected_exception = RuntimeError("join failed")
     renderer = Mock()
     renderer.num_plays = 0
-    writer = SceneFileWriter(renderer, "JoinFailureScene", _VIDEO_OUTPUT)
+    writer = SceneFileWriter(
+        renderer,
+        "JoinFailureScene",
+        _VIDEO_OUTPUT,
+        _plan_for("JoinFailureScene", _VIDEO_OUTPUT),
+    )
     failing_job = Mock(path=tmp_path / "failing.mp4")
     failing_job.join.side_effect = expected_exception
     succeeding_job = Mock(path=tmp_path / "succeeding.mp4")
@@ -599,7 +663,12 @@ def _new_writer(config, tmp_path, scene_name):
     config.media_dir = str(tmp_path)
     renderer = Mock()
     renderer.num_plays = 0
-    return SceneFileWriter(renderer, scene_name, _VIDEO_OUTPUT)
+    return SceneFileWriter(
+        renderer,
+        scene_name,
+        _VIDEO_OUTPUT,
+        _plan_for(scene_name, _VIDEO_OUTPUT),
+    )
 
 
 def _healthy_current_job(tmp_path, monkeypatch, name):
@@ -689,7 +758,12 @@ def test_abort_encode_jobs_noop_on_dry_run_writer(config):
     with tempconfig({"dry_run": True}):
         renderer = Mock()
         renderer.num_plays = 0
-        writer = SceneFileWriter(renderer, "DryRunAbortScene", _NO_OUTPUT)
+        writer = SceneFileWriter(
+            renderer,
+            "DryRunAbortScene",
+            _NO_OUTPUT,
+            _plan_for("DryRunAbortScene", _NO_OUTPUT),
+        )
 
         writer.abort_encode_jobs()
         writer.abort_encode_jobs(reraise_encoder_failures=True)
@@ -1030,7 +1104,12 @@ def test_is_already_cached_false_after_joining_failed_path(config, tmp_path):
     with tempconfig({"media_dir": str(tmp_path)}):
         renderer = Mock()
         renderer.num_plays = 0
-        writer = SceneFileWriter(renderer, "CachedReturnScene", _VIDEO_OUTPUT)
+        writer = SceneFileWriter(
+            renderer,
+            "CachedReturnScene",
+            _VIDEO_OUTPUT,
+            _plan_for("CachedReturnScene", _VIDEO_OUTPUT),
+        )
         hash_invocation = "missing_partial_hash"
         path = (
             writer.partial_movie_directory
@@ -1050,7 +1129,12 @@ def test_is_already_cached_true_when_partial_exists(config, tmp_path):
     with tempconfig({"media_dir": str(tmp_path)}):
         renderer = Mock()
         renderer.num_plays = 0
-        writer = SceneFileWriter(renderer, "CachedReturnScene", _VIDEO_OUTPUT)
+        writer = SceneFileWriter(
+            renderer,
+            "CachedReturnScene",
+            _VIDEO_OUTPUT,
+            _plan_for("CachedReturnScene", _VIDEO_OUTPUT),
+        )
         hash_invocation = "present_partial_hash"
         path = (
             writer.partial_movie_directory
@@ -1067,7 +1151,12 @@ def test_close_partial_movie_stream_without_open_stream_raises(config, tmp_path)
     with tempconfig({"media_dir": str(tmp_path)}):
         renderer = Mock()
         renderer.num_plays = 0
-        writer = SceneFileWriter(renderer, "GuardScene", _VIDEO_OUTPUT)
+        writer = SceneFileWriter(
+            renderer,
+            "GuardScene",
+            _VIDEO_OUTPUT,
+            _plan_for("GuardScene", _VIDEO_OUTPUT),
+        )
 
         with pytest.raises(RuntimeError, match="without an open partial"):
             writer.close_partial_movie_stream()
@@ -1079,7 +1168,12 @@ def test_open_partial_movie_stream_without_path_raises(config, tmp_path):
     with tempconfig({"media_dir": str(tmp_path)}):
         renderer = Mock()
         renderer.num_plays = 0
-        writer = SceneFileWriter(renderer, "GuardScene", _VIDEO_OUTPUT)
+        writer = SceneFileWriter(
+            renderer,
+            "GuardScene",
+            _VIDEO_OUTPUT,
+            _plan_for("GuardScene", _VIDEO_OUTPUT),
+        )
         writer.partial_movie_files = [None]
 
         with pytest.raises(RuntimeError, match="partial movie file path"):
@@ -1097,7 +1191,12 @@ def test_write_frame_without_open_stream_drops_frame(config, tmp_path):
     with tempconfig({"media_dir": str(tmp_path)}):
         renderer = Mock()
         renderer.num_plays = 0
-        writer = SceneFileWriter(renderer, "DropFrameScene", _VIDEO_OUTPUT)
+        writer = SceneFileWriter(
+            renderer,
+            "DropFrameScene",
+            _VIDEO_OUTPUT,
+            _plan_for("DropFrameScene", _VIDEO_OUTPUT),
+        )
         assert writer._current_encode_job is None
 
         # Must not raise and must not create a job.

--- a/tests/test_scene_rendering/test_parallel_encoding.py
+++ b/tests/test_scene_rendering/test_parallel_encoding.py
@@ -1140,6 +1140,7 @@ def test_is_already_cached_true_when_partial_exists(config, tmp_path):
             writer.partial_movie_directory
             / f"{hash_invocation}{writer.output_spec.segment_extension}"
         )
+        path.parent.mkdir(parents=True)
         path.write_bytes(b"cached partial")
 
         assert writer.is_already_cached(hash_invocation) is True


### PR DESCRIPTION
## Summary

This PR moves media-layout and output-path decisions out of
`SceneFileWriter`. Each scene now resolves an immutable `OutputPlan` before
renderer initialization and passes it explicitly to the writer alongside the
resolved `OutputSpec`.

The plan contains exact paths for the primary artifact, optional fallback PNG,
PNG sequence, silent segment cache, sections, subtitles, concat manifest, and
file log. Only directories required by the concrete output are resolved, and
their parents are created lazily when the corresponding operation writes.

This makes output placement deterministic and removes the writer's remaining
responsibility for interpreting global path configuration.

## Output behavior

- `-o` / `--output_file` is accepted only when rendering exactly one scene.
- The resolved format determines the final suffix. Existing suffixes are
  preserved: `-o movie.mp4 --format=mp4` produces `movie.mp4`, while
  `-o movie.mov --format=mp4` produces `movie.mov.mp4`.
- Nested or absolute output names relocate the primary artifact without moving
  section output or cached segments outside their configured directories.
- Explicit video and GIF output no longer resolves an unused `images_dir`.
  `images_dir` is required only for still output, PNG sequences, or automatic
  video fallback to a still image.
- Section filenames include a safe, human-readable form of the section name,
  while the original name remains in the JSON metadata.
- Media directories are no longer created merely by constructing a writer.
- File-log path resolution and setup no longer belong to `SceneFileWriter`.

## Breaking changes and migration

Most scenes using the default output layout require no changes.

### Removal of `custom_folders`

The following interfaces have been removed:

- `--custom_folders`
- `config.custom_folders`
- the `[custom_folders]` configuration section

Configure the ordinary directory settings directly under `[CLI]`. To reproduce
the former built-in preset, use:

```ini
[CLI]
media_dir = videos
video_dir = {media_dir}
sections_dir = {media_dir}
images_dir = {media_dir}
text_dir = {media_dir}/temp_files
tex_dir = {media_dir}/temp_files
log_dir = {media_dir}/temp_files
partial_movie_dir = {media_dir}/partial_movie_files/{scene_name}
```

Projects with customized values in `[custom_folders]` should move those values
to `[CLI]` and remove the flag from scripts and command invocations.

### Output names and sections

A single `--output_file` cannot represent several scene artifacts. Invocations
combining it with `--write_all` or several selected scene names must either
remove `--output_file` or render each scene separately.

Section videos are now named like:

```text
ElaborateSceneWithSections_0000_create-square.mp4
```

Consumers should read the exact relative filename from the section JSON
`video` field instead of constructing it from the ordinal alone.

### `SceneFileWriter` integrations

Custom renderers, writer subclasses, and direct writer users must pass the new
explicit plan:

```python
SceneFileWriter(renderer, scene_name, output_spec, output_plan)
```

The resolved plan is available as `scene.output_plan` and
`writer.output_plan`.

The following writer extension points have been removed:

- `SceneFileWriter.init_output_directories()`
- `SceneFileWriter.force_output_as_scene_name`
- `SceneFileWriter.get_resolution_directory()`

Custom writers should consume the paths in `output_plan` and create parent
directories only when writing. Code that needs the artifact directory should
use the parent of `output_plan.primary_artifact` rather than reconstructing it
from resolution settings.

The writer path attributes `output_name`, `image_file_path`,
`image_sequence_directory`, `movie_file_path`, `gif_file_path`,
`sections_output_dir`, and `partial_movie_directory` are now read-only views of
the immutable plan. Integrations that assigned these attributes must provide
the intended paths through the plan instead.

`SceneFileWriter.output_image()` now accepts only the image; frame paths and
zero-padding come from `output_plan.image_frame_path()`.

## Documentation

- [Output and configuration tutorial](https://manimce--4969.org.readthedocs.build/en/4969/tutorials/output_and_config.html)
- [Deep dive](https://manimce--4969.org.readthedocs.build/en/4969/guides/deep_dive.html)

## Scope

This PR does not change codecs, encoder settings, cache identity, audio
handling, or render scheduling. Those remain follow-up work after output-path
ownership has been removed from the writer.

AI assistance was used during implementation and review. The resulting design,
code, documentation, and tests were reviewed by the author.
