### PR TITLE
Docs: Change formatter/linter mention to ruff

### DIFF
--- a/docs/source/contributing/development.md
+++ b/docs/source/contributing/development.md
@@ -196,13 +196,13 @@ that Manim still works as intended and that the code you added
 sticks to our coding conventions.
 
 - **Code style**: We use the code style imposed
-  by [Black](https://black.readthedocs.io/en/stable/), [isort](https://pycqa.github.io/isort/)
-  and [flake8](https://flake8.pycqa.org/en/latest/). The GitHub pipeline
-  makes sure that the (Python) files changed in your pull request
-  also adhere to this code style. If this step of the pipeline fails,
-  fix your code formatting automatically by running `black <file or directory>` and `isort <file or directory>`.
-  To fix code style problems, run `flake8 <file or directory>` for a style report, and then fix the problems
-  manually that were detected by `flake8`.
+  by [ruff](https://docs.astral.sh/ruff/). Every time you commit your changes
+  and when you create a PR based on your committed work, all new and modified
+  (Python) files will be checked for adherence to this code style. You can check
+  your changes and fix any problems yourself before committing by running
+  `ruff check --fix <file or directory>` and `ruff format <file or directory>`.
+  If you want to check your changes without auto-fixing anything, run
+  `ruff check <file or directory>` and `ruff format --check <file or directory>`.
 - **Tests**: The pipeline runs Manim's test suite on different operating systems
   (the latest versions of Ubuntu, macOS, and Windows) for different versions of Python.
   The test suite consists of two different kinds of tests: integration tests


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
The [Manim Development Process](https://docs.manim.community/en/stable/contributing/development.html) docs page mentions that we use Black, isort, and flake8. However, at present this is all handled by ruff. This PR updates the relevant paragraph to instead mention ruff and how to use it.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->
https://manimce--4978.org.readthedocs.build/en/4978/contributing/development.html#polishing-changes-and-submitting-a-pull-request

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
