### PR TITLE
fix(space_ops): flip the axis when angle_axis_from_quaternion folds the angle

### DIFF
--- a/manim/utils/space_ops.py
+++ b/manim/utils/space_ops.py
@@ -151,12 +151,16 @@ def angle_axis_from_quaternion(quaternion: Sequence[float]) -> Sequence[float]:
     Returns
     -------
     Sequence[float]
-        Gives the angle and axis
+        The angle, in the range ``[0, PI]``, and the axis it is measured about.
     """
     axis = normalize(quaternion[1:], fall_back=np.array([1, 0, 0]))
     angle = 2 * np.arccos(quaternion[0])
     if angle > TAU / 2:
+        # A rotation by ``angle`` about ``axis`` is a rotation by
+        # ``TAU - angle`` about ``-axis``, so the axis has to be flipped
+        # along with the angle.
         angle = TAU - angle
+        axis = -axis
     return angle, axis
 
 

--- a/tests/module/utils/test_space_ops.py
+++ b/tests/module/utils/test_space_ops.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from scipy.spatial.transform import Rotation
 
 from manim.utils.space_ops import *
 from manim.utils.space_ops import shoelace
@@ -51,6 +52,33 @@ def test_rotation_matrices():
                 [-0.22237, -0.5547, 0.80178],
             ]
         ),
+    )
+
+
+@pytest.mark.parametrize(
+    "angle",
+    # the first three are at or below PI, where no folding happens
+    [0.5, 2.0, np.pi, 3.5, 4.0, 5.5, 2 * np.pi - 0.01],
+)
+def test_angle_axis_from_quaternion(angle):
+    axis = normalize(np.array([1.0, -2.0, 3.0]))
+    quaternion = quaternion_from_angle_axis(angle, axis)
+    result_angle, result_axis = angle_axis_from_quaternion(quaternion)
+
+    # the returned pair must describe the same rotation as the input
+    np.testing.assert_allclose(
+        rotation_matrix(result_angle, result_axis),
+        rotation_matrix(angle, axis),
+        atol=1e-8,
+    )
+
+    # ... expressed the way scipy's Rotation.as_rotvec expresses it, i.e. with
+    # the angle in [0, PI] and the direction carried by the axis
+    rotation_vector = Rotation.from_quat([*quaternion[1:], quaternion[0]]).as_rotvec()
+    assert 0 <= result_angle <= np.pi
+    np.testing.assert_allclose(result_angle, np.linalg.norm(rotation_vector), atol=1e-8)
+    np.testing.assert_allclose(
+        result_axis, rotation_vector / np.linalg.norm(rotation_vector), atol=1e-8
     )
 
 


### PR DESCRIPTION
## Overview: What does this pull request change?

`angle_axis_from_quaternion` (`manim/utils/space_ops.py:143`) folds an angle above `PI` with

```python
if angle > TAU / 2:
    angle = TAU - angle
```

but leaves the axis untouched. A rotation by `angle` about `axis` is a rotation by `TAU - angle`
about **`-axis`**, so for every quaternion whose angle exceeds `PI` the returned pair describes the
inverse rotation. This adds `axis = -axis` to the fold, plus a test.

## Motivation and Explanation: Why and how do your changes improve the library?

On `main`, feeding `quaternion_from_angle_axis`'s own output back in does not round trip:

```python
axis = np.array([0.0, 0.0, 1.0])
q = quaternion_from_angle_axis(4.0, axis)
angle, ax = angle_axis_from_quaternion(q)      # -> 2.2832, [0. 0. 1.]
np.allclose(rotation_matrix(4.0, axis), rotation_matrix(angle, ax))   # False
```

5000 random (angle, axis) pairs, uniform angle over `[0, TAU)`: **2556 fail** the round trip on
`main`, **0 after**. The split is clean — all 2556 have `angle > PI`, none have `angle <= PI`. The
neighbouring `rotation_matrix_from_quaternion` and `rotation_matrix_transpose_from_quaternion` were
run over the same 5000 inputs as a control: 0 failures each, before and after.

Which of the two possible remedies to take was settled by scipy, already a hard dependency and what
`rotation_matrix` in this same module builds on: `Rotation.as_rotvec` returns exactly the
`angle in [0, PI]` + signed-axis form, and the patched function agrees with it on all 5000 cases.
Simply deleting the fold also repairs the round trip, but changes the returned angle range — happy
to go that way instead if you prefer it. No test caught this because the function has zero call
sites inside `manim/` and had no test.

Matched pair, same command and env both times (`uv run pytest tests/module -q -p no:randomly`):
**582 passed / 0 failed before → 589 passed / 0 failed after.** An earlier version of this description reported 90 failures; those were missing test dependencies in my checkout, not the suite
because this machine has no LaTeX (`FileNotFoundError: 'latex'`); they are identical on an
unmodified checkout. `pre-commit run --files ...` passes all hooks at the pinned versions
(ruff 0.16.2 lint + format, mypy, codespell).

Two mutants, both with the source marker asserted before measuring:

* revert the source, keep the test → the 4 cases above `PI` fail, the 3 at or below `PI` pass;
* drop the fold entirely instead → the rotation-matrix assertion passes and the `[0, PI]`
  assertion fails, which is what pins the remedy rather than just the round trip.

## Links to added or changed documentation pages

`angle_axis_from_quaternion` in the space_ops reference; its `Returns` text now names the angle
range.

## Further Information and Comments

Not tested: the LaTeX-dependent tests did not run here. I have not touched the `-> Sequence[float]`
return annotation, which does not describe the `(float, ndarray)` tuple, to keep the diff minimal.

Written with AI assistance (Claude); the measurements above were run locally on this branch.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested

