### PR TITLE
Use runtime class names in CurvesAsSubmobjects errors

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -2859,7 +2859,8 @@ class CurvesAsSubmobjects(VGroup):
         if len(self.submobjects) == 0:
             caller_name = sys._getframe(1).f_code.co_name
             raise Exception(
-                f"Cannot call CurvesAsSubmobjects. {caller_name} for a CurvesAsSubmobject with no submobjects"
+                f"Cannot call {type(self).__name__}.{caller_name} "
+                f"for a {type(self).__name__} with no submobjects"
             )
 
     def _get_submobjects_with_points(self):
@@ -2869,7 +2870,8 @@ class CurvesAsSubmobjects(VGroup):
         if len(submobjs_with_pts) == 0:
             caller_name = sys._getframe(1).f_code.co_name
             raise Exception(
-                f"Cannot call CurvesAsSubmobjects. {caller_name} for a CurvesAsSubmobject whose submobjects have no points"
+                f"Cannot call {type(self).__name__}.{caller_name} "
+                f"for a {type(self).__name__} whose submobjects have no points"
             )
         return submobjs_with_pts
 

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -774,3 +774,26 @@ def test_pointwise_become_partial_where_vmobject_is_self():
         ]
     )
     np.testing.assert_allclose(sq.points, expected_points)
+
+
+@pytest.mark.parametrize("use_subclass", [False, True])
+@pytest.mark.parametrize("empty_child", [False, True])
+def test_curves_as_submobjects_errors_use_actual_class(use_subclass, empty_child):
+    class CustomCurves(CurvesAsSubmobjects):
+        pass
+
+    curves_class = CustomCurves if use_subclass else CurvesAsSubmobjects
+    curves = curves_class(VGroup())
+    if empty_child:
+        curves.add(VMobject())
+
+    with pytest.raises(Exception) as error:
+        curves.point_from_proportion(0)
+
+    reason = (
+        "whose submobjects have no points" if empty_child else "with no submobjects"
+    )
+    class_name = curves_class.__name__
+    assert str(error.value) == (
+        f"Cannot call {class_name}.point_from_proportion for a {class_name} {reason}"
+    )


### PR DESCRIPTION
## Overview: What does this pull request change?

Use the runtime class name in both CurvesAsSubmobjects empty-geometry error messages. Subclasses now name themselves instead of reporting CurvesAsSubmobjects. The messages also use the correct class spelling and remove the stray space between the class and method names.

Fixes #4983.

## Motivation and Explanation: Why and how do your changes improve the library?

Adds four regression cases covering the base class and a subclass, each with no submobjects and with a point-less child. All four fail on the previous messages and pass with this change.

## Links to added or changed documentation pages

Not applicable — diagnostic messages only.

## Further Information and Comments

Validation on Python 3.12/macOS:

- `pytest tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py -o addopts='' -q` — 46 passed.
- Broader vectorized_mobject directory run — 59 passed, one failure because the local environment has no `latex` executable (`test_scale_stroke_preserves_zero_width_on_number_plane_coordinates`).
- Ruff checks and formatting passed for both changed files.

The full rendering suite was not run locally.

## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
