### PR TITLE
Add optional Typst installation instructions

### DIFF
--- a/docs/source/guides/using_text.rst
+++ b/docs/source/guides/using_text.rst
@@ -309,7 +309,9 @@ Manim also supports rendering text and formulas with Typst via
 .. important::
 
     Typst support requires the optional ``typst`` dependency. Install it with
-    ``pip install manim[typst]``.
+    ``uv add "manim[typst]"`` or ``pip install "manim[typst]"``. The optional
+    dependency includes the Typst compiler; no separate system installation is
+    required.
 
 Typst mobjects compile Typst markup directly to SVG and import the result as
 vector graphics. This works both for general markup and for mathematical

--- a/docs/source/installation/uv.md
+++ b/docs/source/installation/uv.md
@@ -135,6 +135,27 @@ setspace standalone tipa wasy wasysym xcolor xetex xkeyval
 ```
 :::
 
+### Step 2 (optional): Installing Typst support
+
+Manim can render text and mathematical expressions with [Typst](https://typst.app/).
+The Typst compiler is provided by the optional `typst` Python dependency, so no
+separate system-level Typst installation is required.
+
+If you plan to use the `Typst` or `MathTypst` mobjects,
+include the optional dependency when adding Manim to your project:
+
+```bash
+uv add "manim[typst]"
+```
+
+If you installed Manim with `pip` instead, use:
+
+```bash
+pip install "manim[typst]"
+```
+
+See the :ref:`Typst text guide <rendering-with-typst>` for examples.
+
 ### Step 3: Installing Manim
 
 These steps again differ slightly between different operating systems. Make

--- a/docs/source/installation/uv.md
+++ b/docs/source/installation/uv.md
@@ -272,7 +272,7 @@ uv add "manim[typst]"
 ```
 
 This dependency includes the Typst compiler, so no separate system-level Typst
-installation is required. See the :ref:`Typst section in the text guide <rendering-with-typst>`
+installation is required. See the {ref}`Typst section in the text guide <rendering-with-typst>`
 for examples.
 :::
 

--- a/docs/source/installation/uv.md
+++ b/docs/source/installation/uv.md
@@ -154,7 +154,7 @@ If you installed Manim with `pip` instead, use:
 pip install "manim[typst]"
 ```
 
-See the :ref:`Typst text guide <rendering-with-typst>` for examples.
+See the :ref:`Typst section in the text guide <rendering-with-typst>` for examples.
 
 ### Step 3: Installing Manim
 

--- a/docs/source/installation/uv.md
+++ b/docs/source/installation/uv.md
@@ -135,27 +135,6 @@ setspace standalone tipa wasy wasysym xcolor xetex xkeyval
 ```
 :::
 
-### Step 2 (optional): Installing Typst support
-
-Manim can render text and mathematical expressions with [Typst](https://typst.app/).
-The Typst compiler is provided by the optional `typst` Python dependency, so no
-separate system-level Typst installation is required.
-
-If you plan to use the `Typst` or `MathTypst` mobjects,
-include the optional dependency when adding Manim to your project:
-
-```bash
-uv add "manim[typst]"
-```
-
-If you installed Manim with `pip` instead, use:
-
-```bash
-pip install "manim[typst]"
-```
-
-See the :ref:`Typst section in the text guide <rendering-with-typst>` for examples.
-
 ### Step 3: Installing Manim
 
 These steps again differ slightly between different operating systems. Make
@@ -282,6 +261,20 @@ uv add manim
 :::::
 
 ::::::
+
+:::{dropdown} Optional: Add Typst support
+
+To render text and mathematical expressions with [Typst](https://typst.app/),
+add Manim's optional `typst` dependency to your project:
+
+```bash
+uv add "manim[typst]"
+```
+
+This dependency includes the Typst compiler, so no separate system-level Typst
+installation is required. See the :ref:`Typst section in the text guide <rendering-with-typst>`
+for examples.
+:::
 
 To verify that your local Python project is setup correctly
 and that Manim is available, simply run


### PR DESCRIPTION
## Summary of Changes

- Document how to install Manim with the optional Typst dependency using `uv` or `pip`.
- Explain that the optional Python package includes the Typst compiler and link to the usage guide.

## Motivation and Explanation

The installation guide did not explain how to enable Typst support for a local Manim project. This adds the missing setup step and keeps the installation instructions aligned with the existing Typst examples.

Closes #4938

## Checklist
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)
- [x] I have written a descriptive PR title
- [x] My new documentation builds, looks correctly formatted, and adds no additional build warnings