### PR TITLE
fix: attribute user-triggered warnings to the caller via stacklevel

### DIFF
--- a/manim/mobject/graphing/probability.py
+++ b/manim/mobject/graphing/probability.py
@@ -292,7 +292,8 @@ class BarChart(Axes):
     ):
         if isinstance(bar_colors, str):
             logger.warning(
-                "Passing a string to `bar_colors` has been deprecated since v0.15.2 and will be removed after v0.17.0, the parameter must be a list.  "
+                "Passing a string to `bar_colors` has been deprecated since v0.15.2 and will be removed after v0.17.0, the parameter must be a list.  ",
+                stacklevel=2,
             )
             bar_colors = list(bar_colors)
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -504,6 +504,7 @@ class Mobject:
             logger.warning(
                 "Attempted adding some Mobject as a child more than once, "
                 "this is not possible. Repetitions are ignored.",
+                stacklevel=3,
             )
 
         if not self.submobjects:

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -863,6 +863,7 @@ class OpenGLMobject:
             logger.warning(
                 "Attempted adding some Mobject as a child more than once, "
                 "this is not possible. Repetitions are ignored.",
+                stacklevel=3,
             )
 
         if not self._submobjects:

--- a/manim/mobject/text/text_mobject.py
+++ b/manim/mobject/text/text_mobject.py
@@ -487,7 +487,7 @@ class Text(SVGMobject):
                 elif font.title() in fonts_list:
                     font = font.title()
                 else:
-                    logger.warning(f"Font {font} not in {fonts_list}.")
+                    logger.warning(f"Font {font} not in {fonts_list}.", stacklevel=2)
         self.font = font
         self._font_size = float(font_size)
         # needs to be a float or else size is inflated when font_size = 24
@@ -1214,7 +1214,7 @@ class MarkupText(SVGMobject):
                 elif font.title() in fonts_list:
                     font = font.title()
                 else:
-                    logger.warning(f"Font {font} not in {fonts_list}.")
+                    logger.warning(f"Font {font} not in {fonts_list}.", stacklevel=2)
         self.font = font
         self._font_size = float(font_size)
         self.slant = slant

--- a/manim/mobject/three_d/three_dimensions.py
+++ b/manim/mobject/three_d/three_dimensions.py
@@ -295,7 +295,8 @@ class Surface(VGroup, metaclass=ConvertToOpenGL):
         if colorscale is None:
             logger.warning(
                 "The value passed to the colorscale keyword argument was None, "
-                "the surface fill color has not been changed"
+                "the surface fill color has not been changed",
+                stacklevel=2,
             )
             return self
         colorscale_list = list(colorscale)

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -1160,7 +1160,8 @@ class Scene:
                 f"The original {parameter_name} of {method_name}, "
                 f"{run_time:g} seconds, is too short for the current frame "
                 f"rate of {fps:g} FPS. Rendering with the shortest possible "
-                f"{parameter_name} of {seconds_per_frame:g} seconds instead."
+                f"{parameter_name} of {seconds_per_frame:g} seconds instead.",
+                stacklevel=3,
             )
             run_time = seconds_per_frame
 
@@ -1602,10 +1603,13 @@ class Scene:
     def embed(self) -> None:
         assert isinstance(self.renderer, OpenGLRenderer)
         if not self.session_spec.presentation.live_preview:
-            logger.warning("Called embed() while no live preview window is available.")
+            logger.warning(
+                "Called embed() while no live preview window is available.",
+                stacklevel=2,
+            )
             return
         if self.renderer.file_writer.output_spec.enabled:
-            logger.warning("embed() is skipped while writing to a file.")
+            logger.warning("embed() is skipped while writing to a file.", stacklevel=2)
             return
 
         self.renderer.animation_start_time = 0

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -245,7 +245,7 @@ def deprecated(
             The return value of the given callable when being passed the given
             arguments.
         """
-        logger.warning(warning_msg())
+        logger.warning(warning_msg(), stacklevel=3)
         return func(*args, **kwargs)
 
     if type(func).__name__ != "function":
@@ -529,7 +529,7 @@ def deprecated_params(
         used = [param for param in params if param in kwargs]
 
         if len(used) > 0:
-            logger.warning(warning_msg(func, used))
+            logger.warning(warning_msg(func, used), stacklevel=3)
             redirect_params(kwargs, used)
         return func(*args, **kwargs)
 

--- a/tests/module/mobject/text/test_text_mobject.py
+++ b/tests/module/mobject/text/test_text_mobject.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from contextlib import redirect_stdout
-from io import StringIO
-
 import pytest
 
 from manim.mobject.text.text_mobject import MarkupText, Text
@@ -19,13 +16,13 @@ def test_font_size():
     assert round(markuptext_string.font_size, 5) == 14.4
 
 
-def test_font_warnings():
+def test_font_warnings(manim_caplog):
     def warning_printed(font: str, **kwargs) -> bool:
-        io = StringIO()
-        with redirect_stdout(io):
-            Text("hi!", font=font, **kwargs)
-        txt = io.getvalue()
-        return "Font" in txt and "not in" in txt
+        # Inspect the log records rather than rendered console output: the
+        # latter is wrapped to the terminal width, which can split the message.
+        manim_caplog.clear()
+        Text("hi!", font=font, **kwargs)
+        return any("not in" in record.getMessage() for record in manim_caplog.records)
 
     # check for normal fonts (no warning)
     assert not warning_printed("System-ui", warn_missing_font=True)

--- a/tests/module/utils/test_warning_stacklevel.py
+++ b/tests/module/utils/test_warning_stacklevel.py
@@ -1,0 +1,69 @@
+"""Warnings caused by user code should be attributed to the caller.
+
+Each ``logger.warning`` that a user's own call can trigger passes ``stacklevel``,
+so the emitted record points at the line the user wrote rather than at the line
+inside Manim where the warning happens to live.
+"""
+
+from __future__ import annotations
+
+import inspect
+import linecache
+from logging import LogRecord
+
+from manim import Mobject
+from manim.utils.deprecation import deprecated, deprecated_params
+
+
+@deprecated(since="v0.1.0", message="Use something else.")
+def _deprecated_function() -> int:
+    return 1
+
+
+@deprecated_params(params="old", since="v0.1.0", message="Use new instead.")
+def _function_with_deprecated_param(**kwargs: int) -> int:
+    return 1
+
+
+def _assert_blames_caller(record: LogRecord, source_fragment: str) -> None:
+    """Assert the record points at the caller's own statement.
+
+    Checked by source text rather than a line number so the test survives
+    reformatting.
+    """
+    caller = inspect.currentframe().f_back.f_code.co_name
+    assert record.pathname == __file__, (
+        f"warning was attributed to {record.pathname}, expected the calling module"
+    )
+    assert record.funcName == caller, (
+        f"warning was attributed to {record.funcName}(), expected {caller}()"
+    )
+    blamed_line = linecache.getline(record.pathname, record.lineno)
+    assert source_fragment in blamed_line, (
+        f"warning pointed at {blamed_line.strip()!r}, "
+        f"expected the line containing {source_fragment!r}"
+    )
+
+
+def test_deprecated_function_warning_points_at_caller(manim_caplog):
+    _deprecated_function()
+    _assert_blames_caller(manim_caplog.records[0], "_deprecated_function()")
+
+
+def test_deprecated_param_warning_points_at_caller(manim_caplog):
+    _function_with_deprecated_param(old=2)
+    _assert_blames_caller(
+        manim_caplog.records[0], "_function_with_deprecated_param(old=2)"
+    )
+
+
+def test_duplicate_add_warning_points_at_caller(manim_caplog):
+    parent, child = Mobject(), Mobject()
+    parent.add(child, child)
+    _assert_blames_caller(manim_caplog.records[0], "parent.add(child, child)")
+
+
+def test_duplicate_add_to_back_warning_points_at_caller(manim_caplog):
+    parent, child = Mobject(), Mobject()
+    parent.add_to_back(child, child)
+    _assert_blames_caller(manim_caplog.records[0], "parent.add_to_back(child, child)")


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?

Closes #4981.

Warnings that a user's own code triggers are now attributed to the user's line rather than to the line inside Manim where the `logger.warning` call lives.

Before:

```
WARNING  Attempted adding some Mobject as a child more than once...   mobject.py:504
```

After:

```
WARNING  Attempted adding some Mobject as a child more than once...   my_scene.py:12
```

## Motivation and Explanation: Why and how do your changes improve the library?

Per @nikolajmunk's point on the issue, this is applied only where the action originates in userland — pointing a traceback at Manim's own plumbing would just add noise.

`stacklevel` is **not** a constant. It is per-call-site, and I determined each value by inspecting the actual frame chain at warning time rather than assuming:

**`stacklevel=3`**

| Site | Why |
| --- | --- |
| `utils/deprecation.py` (×2) | the `decorator` library inserts a wrapper frame between the warning and user code — `stacklevel=2` here points at `decorator.py`, not the user |
| `mobject.py`, `opengl_mobject.py` | the warning lives in the private `_insert_submobjects`, reached from `add`, `insert` and `add_to_back` (verified all three entry points) |
| `scene.py` `validate_run_time` | called from `play` / `wait` / `pause` / `wait_until` |

**`stacklevel=2`** — warning sits directly in the public method the user calls: `Text` / `MarkupText`, `BarChart`, `Surface.set_fill_by_value`, `Scene.embed` (×2).

**Deliberately unchanged:**

- `Scene.replace_in_list` — it recurses over submobjects, so no fixed `stacklevel` is correct.
- Config/environment-driven warnings (`"Disabling interactive embed as dry_run is enabled"`, hashing, file ops, plugins, module loading). These aren't caused by a line of user code.

**On the feature freeze:** the contributing guide notes Manim is mid-refactor and that new-feature contributions generally aren't being accepted right now, and #4981 carries the `new feature` label. I've framed this as a `fix` because the existing warnings report a misleading source location rather than because it adds capability — but if maintainers read it as a feature, I'm happy to park it until the refactor settles.

I used `stacklevel` rather than `stack_info=True`; the latter dumps the whole stack into the log, which seemed far noisier than the issue needs. Happy to switch if you'd prefer the full trace.

## Further Information and Comments

**One existing test needed changing.** `test_font_warnings` asserted against rendered console output, which rich wraps to the terminal width. Because the source location is now the (longer) caller path, the wrap point shifted and split `"not in"` across two lines:

```
Font Manim!Manim!Manim! not      test_text_mobject.py:6
in ['.AppleSystemUIFont', ...
```

The warning itself is unchanged — only the rendered line breaks moved. The test now reads the log record's message via the existing `manim_caplog` fixture, which isn't width-dependent.

**Testing.** Added `tests/module/utils/test_warning_stacklevel.py`, covering both `stacklevel=3` shapes (decorator shim and private helper). It asserts the record's `pathname`, `funcName`, and the *source text* of the blamed line rather than a hardcoded line number, so it survives reformatting. Verified it fails on all four cases without the source change.

`tests/module/` and `tests/opengl/` show no new failures against master (108 pre-existing failures on both, all LaTeX/Typst tests that need a `latex` binary I don't have locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
