### PR TITLE
Derive the class name in CurvesAsSubmobjects error messages

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -2856,8 +2856,9 @@ class CurvesAsSubmobjects(VGroup):
     def _throw_error_if_no_submobjects(self):
         if len(self.submobjects) == 0:
             caller_name = sys._getframe(1).f_code.co_name
+            cls = type(self).__name__
             raise Exception(
-                f"Cannot call CurvesAsSubmobjects. {caller_name} for a CurvesAsSubmobject with no submobjects"
+                f"Cannot call {cls}.{caller_name} for a {cls} with no submobjects"
             )
 
     def _get_submobjects_with_points(self):
@@ -2866,8 +2867,9 @@ class CurvesAsSubmobjects(VGroup):
         )
         if len(submobjs_with_pts) == 0:
             caller_name = sys._getframe(1).f_code.co_name
+            cls = type(self).__name__
             raise Exception(
-                f"Cannot call CurvesAsSubmobjects. {caller_name} for a CurvesAsSubmobject whose submobjects have no points"
+                f"Cannot call {cls}.{caller_name} for a {cls} whose submobjects have no points"
             )
         return submobjs_with_pts
 

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -192,6 +192,28 @@ def test_curves_as_submobjects_point_from_proportion():
     np.testing.assert_array_equal(obj.point_from_proportion(0.5), np.array([3, 0, 0]))
 
 
+def test_curves_as_submobjects_error_messages_use_the_actual_class_name():
+    class DerivedCurves(CurvesAsSubmobjects):
+        pass
+
+    obj = DerivedCurves(VGroup())
+
+    with pytest.raises(
+        Exception,
+        match=r"Cannot call DerivedCurves\.point_from_proportion for a "
+        r"DerivedCurves with no submobjects",
+    ):
+        obj.point_from_proportion(0)
+
+    obj.add(VMobject())
+    with pytest.raises(
+        Exception,
+        match=r"Cannot call DerivedCurves\.point_from_proportion for a "
+        r"DerivedCurves whose submobjects have no points",
+    ):
+        obj.point_from_proportion(0)
+
+
 def test_vgroup_init():
     """Test the VGroup instantiation."""
     VGroup()


### PR DESCRIPTION
## Overview: What does this pull request change?

Closes #4983.

`CurvesAsSubmobjects._throw_error_if_no_submobjects` and
`_get_submobjects_with_points` both hardcoded the class name in the exception they
raise, so the messages are derived from `type(self).__name__` instead.

## Motivation and Explanation: Why and how do your changes improve the library?

A subclass of `CurvesAsSubmobjects` currently reports the base class name, which
points readers at the wrong class, and the strings would silently go stale if the
class were ever renamed. The two messages also disagreed with each other: one said
`CurvesAsSubmobjects`, the other `CurvesAsSubmobject` without the trailing "s".

Both now read `Cannot call {cls}.{caller_name} for a {cls} ...`, which matches the
convention already used by `Mobject.throw_error_if_no_points`:

```python
caller_name = sys._getframe(1).f_code.co_name
cls = type(self).__name__
message = f"Cannot call {cls}.{caller_name} because {self!r} has no points."
```

As a side effect this also removes the stray space that made the old message read
as `Cannot call CurvesAsSubmobjects. point_from_proportion ...`.

The added test defines a subclass and asserts that both error paths name it, so the
regression cannot come back unnoticed. The existing
`test_curves_as_submobjects_point_from_proportion` matches on the `with no submobjects`
and `have no points` fragments, which are unchanged, so it still passes.

## Links to added or changed documentation pages

None; the error strings are not quoted in the docs.

## Further Information and Comments

Verified locally on Windows with Python 3.13:
`pytest tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py`
gives 43 passed. The new test fails on `main` with

```
Expected regex: 'Cannot call DerivedCurves\.point_from_proportion for a DerivedCurves with no submobjects'
Actual message: 'Cannot call CurvesAsSubmobjects. point_from_proportion for a CurvesAsSubmobject with no submobjects'
```

`ruff check` and `ruff format --check` are clean on both changed files.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
