### PR TITLE
Add an installation FAQ entry for the Windows C++ build tools error

### DIFF
--- a/docs/source/faq/installation.md
+++ b/docs/source/faq/installation.md
@@ -120,6 +120,35 @@ of [ManimPango's README](https://github.com/ManimCommunity/ManimPango).
 
 ---
 
+(msvc-build-tools)=
+## I am using Windows and the installation fails with `Microsoft Visual C++ 14.0 or greater is required`
+
+This error is raised by `pip`, not by Manim: it means that no pre-built wheel
+matched your platform for one of Manim's dependencies, so `pip` fell back to
+compiling that dependency from source -- and Windows ships no C compiler by
+default.
+
+Our dependencies do publish Windows wheels, so installing a compiler is usually
+not the fix you need. By far the most common cause is running a Python version
+that is newer than the wheels published for it; Manim supports Python 3.11 up to
+3.14, and the newest release of that range is the one most likely to still be
+missing wheels. Creating the environment with a slightly older supported Python
+version is normally enough:
+
+```powershell
+uv venv --python 3.13
+uv pip install manim
+```
+
+If you genuinely do need to build from source, install the
+[Build Tools for Visual Studio](https://visualstudio.microsoft.com/downloads/),
+tick the **Desktop development with C++** workload in the installer, then open a
+new terminal so that the compiler is on your `PATH` and retry the installation.
+Note that the full Visual Studio IDE is not required -- the standalone build
+tools are sufficient.
+
+---
+
 (not-on-path)=
 ## I am using Windows and get the error `X is not recognized as an internal or external command, operable program or batch file`
 


### PR DESCRIPTION
## Overview: What does this pull request change?

Addresses #4974 by adding an installation FAQ entry for the
`Microsoft Visual C++ 14.0 or greater is required` error that Windows users hit
when pip has to build a dependency from source.

## Motivation and Explanation: Why and how do your changes improve the library?

One note on the framing of the issue, which shaped how I wrote the entry. The issue
says the build tools are "often required to install manim". I could not reproduce
that: on a clean Windows 11 machine with **no** Visual Studio or Build Tools
installed at all (no `vswhere.exe`, no `cl.exe`, no install directory), Python 3.13
and `uv pip install -e .` installed Manim and every dependency from wheels without
touching a compiler.

So the compiler is not normally needed, and a FAQ entry that simply told people to
install it would send most readers to a multi-gigabyte download that does not fix
their problem. What actually triggers the error is pip failing to find a matching
wheel and falling back to a source build -- most commonly on a Python version newer
than the wheels published for it, which is a live concern since Manim supports up to
3.14.

The entry therefore explains the cause first, leads with the fix that applies most of
the time (use a supported Python version that already has wheels), and then gives the
build tools instructions for people who genuinely need to build from source, noting
that the standalone build tools are enough and the full IDE is not.

It is placed next to the other Windows and wheel-building entries, and gets a
`(msvc-build-tools)=` anchor so it can be linked from issues and Discord.

If you would rather have this in the {doc}`local installation guide </installation/uv>`
than the FAQ, or want the Python-version advice dropped in favour of just the build
tools instructions, I am happy to rework it.

## Links to added or changed documentation pages

`docs/source/faq/installation.md` -- rendered at
https://manimce--4996.org.readthedocs.build/en/4996/faq/installation.html

## Further Information and Comments

`codespell` (as configured in `.pre-commit-config.yaml`) is clean on the changed file.
I have not built the docs locally, so a look at the Read the Docs preview for the
admonition and anchor rendering would be welcome.

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
