### PR TITLE
Implement ManimColor.gradient() by delegating to color_gradient()

### DIFF
--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -957,12 +957,28 @@ class ManimColor:
     @staticmethod
     def gradient(
         colors: list[ManimColor], length: int
-    ) -> ManimColor | list[ManimColor]:
-        """This method is currently not implemented. Refer to :func:`color_gradient` for
-        a working implementation for now.
+    ) -> list[ManimColor]:
+        """Create a list of colors interpolated between the input colors.
+
+        Parameters
+        ----------
+        colors
+            The colors to be interpolated between or spread apart.
+        length
+            The number of colors that the output should have, ideally more than
+            the input.
+
+        Returns
+        -------
+        list[ManimColor]
+            A list of interpolated :class:`ManimColor`'s.
+
+        See Also
+        --------
+        :func:`color_gradient`
+            The module-level function this method delegates to.
         """
-        # TODO: implement proper gradient, research good implementation for this or look at 3b1b implementation
-        raise NotImplementedError
+        return color_gradient(colors, length)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}('{self.to_hex()}')"

--- a/manim/utils/color/core.py
+++ b/manim/utils/color/core.py
@@ -955,9 +955,7 @@ class ManimColor:
             return cls._from_internal(ManimColor(color, alpha)._internal_value)
 
     @staticmethod
-    def gradient(
-        colors: list[ManimColor], length: int
-    ) -> list[ManimColor]:
+    def gradient(colors: list[ManimColor], length: int) -> list[ManimColor]:
         """Create a list of colors interpolated between the input colors.
 
         Parameters

--- a/tests/module/utils/test_color_helpers.py
+++ b/tests/module/utils/test_color_helpers.py
@@ -236,6 +236,33 @@ def test_color_gradient_passes_through_each_of_four_reference_colors() -> None:
     assert gradient[3] == WHITE
 
 
+def test_manimcolor_gradient_zero_length_returns_empty_list() -> None:
+    assert ManimColor.gradient([RED], 0) == []
+
+
+def test_manimcolor_gradient_empty_reference_raises() -> None:
+    with pytest.raises(ValueError, match="Expected 1 or more reference colors"):
+        ManimColor.gradient([], 5)
+
+
+def test_manimcolor_gradient_single_reference_is_repeated() -> None:
+    gradient = ManimColor.gradient([RED], 5)
+    assert len(gradient) == 5
+    assert all(color == RED for color in gradient)
+
+
+def test_manimcolor_gradient_interpolates_endpoints() -> None:
+    gradient = ManimColor.gradient([BLACK, WHITE], 7)
+    assert len(gradient) == 7
+    assert gradient[0] == BLACK
+    assert gradient[-1] == WHITE
+
+
+def test_manimcolor_gradient_matches_module_function() -> None:
+    refs = [BLACK, RED, BLUE, WHITE]
+    assert ManimColor.gradient(refs, 7) == color_gradient(refs, 7)
+
+
 # ---------------------------------------------------------------------------
 # Random color machinery
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`ManimColor.gradient()` is a public static method with a documented signature and return type, but it raises `NotImplementedError`. Users discovering it via autocomplete or API docs get misled (the docstring redirected to the module-level `color_gradient`).

## Change

- Implement `ManimColor.gradient(colors, length)` by delegating to the existing `color_gradient()` logic (single source of truth).
- Correct the return annotation to `list[ManimColor]` (the old `ManimColor | list[ManimColor]` was inaccurate — it always returns a list).
- Rewrite the docstring to match the module function.

## Tests

Added in `tests/module/utils/test_color_helpers.py`:

- zero length returns empty list
- empty reference colors raises `ValueError`
- single reference color is repeated
- endpoints interpolated correctly
- parity with `color_gradient()`

All 10 gradient tests pass.

Closes #4802