### PR TITLE
Add stack traces to warnings (#4981)

### DIFF
--- a/manim/mobject/graphing/probability.py
+++ b/manim/mobject/graphing/probability.py
@@ -292,7 +292,9 @@ class BarChart(Axes):
     ):
         if isinstance(bar_colors, str):
             logger.warning(
-                "Passing a string to `bar_colors` has been deprecated since v0.15.2 and will be removed after v0.17.0, the parameter must be a list.  "
+                "Passing a string to `bar_colors` has been deprecated since v0.15.2 and will be removed after v0.17.0, the parameter must be a list.  ",
+                stack_info=True,
+                stacklevel = 2
             )
             bar_colors = list(bar_colors)
 

--- a/manim/mobject/graphing/probability.py
+++ b/manim/mobject/graphing/probability.py
@@ -294,7 +294,7 @@ class BarChart(Axes):
             logger.warning(
                 "Passing a string to `bar_colors` has been deprecated since v0.15.2 and will be removed after v0.17.0, the parameter must be a list.  ",
                 stack_info=True,
-                stacklevel = 2
+                stacklevel=2,
             )
             bar_colors = list(bar_colors)
 

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -504,6 +504,8 @@ class Mobject:
             logger.warning(
                 "Attempted adding some Mobject as a child more than once, "
                 "this is not possible. Repetitions are ignored.",
+                stack_info=True,
+                stacklevel=3
             )
 
         if not self.submobjects:

--- a/manim/mobject/mobject.py
+++ b/manim/mobject/mobject.py
@@ -505,7 +505,7 @@ class Mobject:
                 "Attempted adding some Mobject as a child more than once, "
                 "this is not possible. Repetitions are ignored.",
                 stack_info=True,
-                stacklevel=3
+                stacklevel=3,
             )
 
         if not self.submobjects:

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -863,6 +863,8 @@ class OpenGLMobject:
             logger.warning(
                 "Attempted adding some Mobject as a child more than once, "
                 "this is not possible. Repetitions are ignored.",
+                stack_info=True,
+                stacklevel = 3
             )
 
         if not self._submobjects:

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -864,7 +864,7 @@ class OpenGLMobject:
                 "Attempted adding some Mobject as a child more than once, "
                 "this is not possible. Repetitions are ignored.",
                 stack_info=True,
-                stacklevel = 3
+                stacklevel=3,
             )
 
         if not self._submobjects:

--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -337,7 +337,11 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
         elif isinstance(shape, se.Text):
             mob = self.text_to_mobject(shape)
         else:
-            logger.warning(f"Unsupported element type: {type(shape)}")
+            logger.warning(
+                f"Unsupported element type: {type(shape)}",
+                stack_info=True,
+                stacklevel=3
+            )
             mob = None
         if mob is None or not mob.has_points():
             return None
@@ -486,7 +490,11 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
         text
             The parsed SVG text.
         """
-        logger.warning(f"Unsupported element type: {type(text)}")
+        logger.warning(
+            f"Unsupported element type: {type(text)}",
+            stack_info=True,
+            stacklevel=3
+        )
         return  # type: ignore[return-value]
 
     def move_into_position(self) -> Self:

--- a/manim/mobject/svg/svg_mobject.py
+++ b/manim/mobject/svg/svg_mobject.py
@@ -340,7 +340,7 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
             logger.warning(
                 f"Unsupported element type: {type(shape)}",
                 stack_info=True,
-                stacklevel=3
+                stacklevel=3,
             )
             mob = None
         if mob is None or not mob.has_points():
@@ -491,9 +491,7 @@ class SVGMobject(VMobject, metaclass=ConvertToOpenGL):
             The parsed SVG text.
         """
         logger.warning(
-            f"Unsupported element type: {type(text)}",
-            stack_info=True,
-            stacklevel=3
+            f"Unsupported element type: {type(text)}", stack_info=True, stacklevel=3
         )
         return  # type: ignore[return-value]
 

--- a/manim/mobject/text/text_mobject.py
+++ b/manim/mobject/text/text_mobject.py
@@ -1233,6 +1233,8 @@ class MarkupText(SVGMobject):
         if len(colormap) > 0:
             logger.warning(
                 'Using <color> tags in MarkupText is deprecated. Please use <span foreground="..."> instead.',
+                stack_info=True,
+                stacklevel=2
             )
         gradientmap = self._extract_gradient_tags()
         validate_error = MarkupUtils.validate(self.text)

--- a/manim/mobject/text/text_mobject.py
+++ b/manim/mobject/text/text_mobject.py
@@ -1234,7 +1234,7 @@ class MarkupText(SVGMobject):
             logger.warning(
                 'Using <color> tags in MarkupText is deprecated. Please use <span foreground="..."> instead.',
                 stack_info=True,
-                stacklevel=2
+                stacklevel=2,
             )
         gradientmap = self._extract_gradient_tags()
         validate_error = MarkupUtils.validate(self.text)

--- a/manim/mobject/three_d/three_dimensions.py
+++ b/manim/mobject/three_d/three_dimensions.py
@@ -297,7 +297,7 @@ class Surface(VGroup, metaclass=ConvertToOpenGL):
                 "The value passed to the colorscale keyword argument was None, "
                 "the surface fill color has not been changed",
                 stack_info=True,
-                stacklevel = 3
+                stacklevel=3,
             )
             return self
         colorscale_list = list(colorscale)

--- a/manim/mobject/three_d/three_dimensions.py
+++ b/manim/mobject/three_d/three_dimensions.py
@@ -295,7 +295,9 @@ class Surface(VGroup, metaclass=ConvertToOpenGL):
         if colorscale is None:
             logger.warning(
                 "The value passed to the colorscale keyword argument was None, "
-                "the surface fill color has not been changed"
+                "the surface fill color has not been changed",
+                stack_info=True,
+                stacklevel = 3
             )
             return self
         colorscale_list = list(colorscale)

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -1160,7 +1160,9 @@ class Scene:
                 f"The original {parameter_name} of {method_name}, "
                 f"{run_time:g} seconds, is too short for the current frame "
                 f"rate of {fps:g} FPS. Rendering with the shortest possible "
-                f"{parameter_name} of {seconds_per_frame:g} seconds instead."
+                f"{parameter_name} of {seconds_per_frame:g} seconds instead.",
+                stack_info=True,
+                stacklevel=3
             )
             run_time = seconds_per_frame
 
@@ -1602,10 +1604,18 @@ class Scene:
     def embed(self) -> None:
         assert isinstance(self.renderer, OpenGLRenderer)
         if not self.session_spec.presentation.live_preview:
-            logger.warning("Called embed() while no live preview window is available.")
+            logger.warning(
+                "Called embed() while no live preview window is available.", 
+                stack_info=True,
+                stacklevel=3
+            )
             return
         if self.renderer.file_writer.output_spec.enabled:
-            logger.warning("embed() is skipped while writing to a file.")
+            logger.warning(
+                "embed() is skipped while writing to a file.",
+                stack_info=True,
+                stacklevel=3
+            )
             return
 
         self.renderer.animation_start_time = 0

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -1162,7 +1162,7 @@ class Scene:
                 f"rate of {fps:g} FPS. Rendering with the shortest possible "
                 f"{parameter_name} of {seconds_per_frame:g} seconds instead.",
                 stack_info=True,
-                stacklevel=3
+                stacklevel=3,
             )
             run_time = seconds_per_frame
 
@@ -1605,16 +1605,16 @@ class Scene:
         assert isinstance(self.renderer, OpenGLRenderer)
         if not self.session_spec.presentation.live_preview:
             logger.warning(
-                "Called embed() while no live preview window is available.", 
+                "Called embed() while no live preview window is available.",
                 stack_info=True,
-                stacklevel=3
+                stacklevel=3,
             )
             return
         if self.renderer.file_writer.output_spec.enabled:
             logger.warning(
                 "embed() is skipped while writing to a file.",
                 stack_info=True,
-                stacklevel=3
+                stacklevel=3,
             )
             return
 


### PR DESCRIPTION
## Summary
- Add stack information to warnings so users can see where the warning originated.
- Set the stack level for user facing warnings.

Closes #4981

I am opening this as a draft to get feedback on this as it is my first contribution and would appreciate any help or advice.