### PR TITLE
Add tests to verify that updaters affect their mobjects

### DIFF
--- a/tests/module/animation/test_updaters.py
+++ b/tests/module/animation/test_updaters.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from manim import UP, Circle, Dot, FadeIn
+from manim import UP, Circle, Dot, FadeIn, Square
 from manim.animation.updaters.mobject_update_utils import turn_animation_into_updater
 
 
@@ -65,3 +65,102 @@ def test_always():
     d2 = Dot()
     d.always.next_to(d2, UP).next_to(circ, UP)
     assert len(d.updaters) == 3
+
+
+def test_non_time_based_updater_modifies_mobject():
+    """Test that non-time-based updaters apply their changes every update step"""
+    square = Square(side_length=1, fill_opacity=0)
+    square.add_updater(lambda m: m.set(width=m.width + 1))
+    square.update(0)  # dt is ignored for non-time-based updaters
+    assert square.width == 2.0
+
+    # Multiple updaters should apply
+    square.add_updater(lambda m: m.shift(UP))
+    square.update(100)
+    assert square.width == 3.0
+    assert (square.get_center() == UP).all()
+
+    # When multiple updaters conflict, they should be applied in the order they were added
+    # Add a new updater that doubles the current displacement
+    square.add_updater(lambda m: m.shift(m.get_center()))
+    square.update(0)
+    assert square.width == 4.0
+    # Second shift must be based on the displacement after the first shift
+    assert (square.get_center() == 4 * UP).all()
+
+
+def test_time_based_updater_modifies_mobject():
+    """Test that time-based updaters apply their changes correctly based on dt"""
+    square = Square(side_length=1, fill_opacity=0)
+    square.add_updater(lambda m, dt: m.set(width=m.width + dt))
+    square.update(0.5)  # Simulate waiting 0.5 seconds
+    assert square.width == 1.5
+
+    # Multiple updaters should apply
+    square.add_updater(lambda m, dt: m.set_fill(opacity=dt))
+    square.update(0.5)
+    assert square.width == 2.0
+    assert square.get_fill_opacity() == 0.5
+
+    # When multiple updaters affect the same attribute, they should be applied in the
+    # order they were added
+    square.add_updater(lambda m, dt: m.set_fill(opacity=dt / 2))
+    square.update(0.5)
+    assert square.width == 2.5
+    assert square.get_fill_opacity() == 0.25  # last updater overrides previous
+
+    # Time-based updaters should handle dt=0 correctly
+    square.update(0)
+    assert square.width == 2.5  # width is linear in dt here, so no change
+    assert square.get_fill_opacity() == 0  # dt sets opacity directly
+
+
+def test_updater_remove():
+    """Test that updaters can be removed correctly"""
+    square = Square(side_length=1, fill_opacity=0)
+
+    def updater1(m):
+        return
+
+    def updater2(m, dt):
+        return
+
+    square.add_updater(updater1)
+    square.add_updater(updater2)
+
+    square.remove_updater(updater1)
+    assert updater1 not in square.updaters
+    assert updater2 in square.updaters
+
+    square.remove_updater(updater2)
+    assert updater2 not in square.updaters
+
+    # Removing an updater that is not present should not raise an error
+    square.remove_updater(updater1)
+
+    # Multiple instances of the same updater should be removed with one call
+    square.add_updater(updater1)
+    square.add_updater(updater1)
+    assert len(square.updaters) == 2
+    square.remove_updater(updater1)
+    assert len(square.updaters) == 0
+
+
+def test_updater_multiples():
+    """Test that the same updater can be added multiple times and removed correctly"""
+    square = Square(side_length=1, fill_opacity=0)
+
+    def updater(m):
+        m.shift(UP)
+
+    assert len(square.updaters) == 0
+    square.add_updater(updater)
+    assert len(square.updaters) == 1
+    square.update(0)
+    assert (square.get_center() == UP).all()
+
+    # Add the same updater again
+    square.add_updater(updater)
+    assert len(square.updaters) == 2
+    square.update(0)
+    assert (square.get_center() == 3 * UP).all()  # shifted twice


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
This PR adds unit tests which verify the following:
* Time-based updaters can use `dt` to modify their mobject
* Non-time-based updaters affect their mobject every update step
* The same updater can be applied multiple times with a corresponding increase in the change
* Updaters can be removed, and calling `mob.remove_updater(upd)` removes all instances of `upd` at once.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Previously, updater behavior was only verified through graphical tests, as well as a small set of tests to check a fairly narrow subset of updater-adding.

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
