### PR TITLE
Fix: Make `normalize` properly check for a fallback when vector norm is 0

### DIFF
--- a/manim/utils/space_ops.py
+++ b/manim/utils/space_ops.py
@@ -361,15 +361,15 @@ def normalize(
     vect: np.ndarray | tuple[float], fall_back: np.ndarray | None = None
 ) -> np.ndarray:
     """Normalizes a vector to unit length while preserving its direction. If the vector
-    has length 0, a fallback vector is returned instead.
+    has norm 0, a fallback vector is returned instead.
 
     Parameters
     ----------
     vect
         The vector to be normalized.
     fall_back
-        The vector to be returned if ``vect`` has length 0. If ``None``, a zero vector
-        of the same length as ``vect`` is returned.
+        The vector to be returned if ``vect`` has norm 0. If ``None``, a zero vector of
+        the same length as ``vect`` is returned.
     """
     norm = np.linalg.norm(vect)
     if norm > 0:

--- a/manim/utils/space_ops.py
+++ b/manim/utils/space_ops.py
@@ -360,11 +360,22 @@ def angle_between_vectors(v1: np.ndarray, v2: np.ndarray) -> float:
 def normalize(
     vect: np.ndarray | tuple[float], fall_back: np.ndarray | None = None
 ) -> np.ndarray:
+    """Normalizes a vector to unit length while preserving its direction. If the vector
+    has length 0, a fallback vector is returned instead.
+
+    Parameters
+    ----------
+    vect
+        The vector to be normalized.
+    fall_back
+        The vector to be returned if ``vect`` has length 0. If ``None``, a zero vector
+        of the same length as ``vect`` is returned.
+    """
     norm = np.linalg.norm(vect)
     if norm > 0:
         return np.array(vect) / norm
     else:
-        return fall_back or np.zeros(len(vect))
+        return np.zeros(len(vect)) if fall_back is None else fall_back
 
 
 def normalize_along_axis(array: np.ndarray, axis: np.ndarray) -> np.ndarray:

--- a/tests/module/utils/test_space_ops.py
+++ b/tests/module/utils/test_space_ops.py
@@ -167,7 +167,7 @@ def test_normalize_nonzero_vector(vec, expected):
     normalized_vec = normalize(vec)
     assert np.allclose(normalized_vec, expected)
 
-    # check that fallback vector is returned when the input vector is non-zero
+    # check that fallback vector is ignored when the input vector is non-zero
     fallback_vec = np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
     normalized_vec_with_fallback = normalize(vec, fall_back=fallback_vec)
     assert np.all(normalized_vec_with_fallback == normalized_vec)

--- a/tests/module/utils/test_space_ops.py
+++ b/tests/module/utils/test_space_ops.py
@@ -148,3 +148,46 @@ def test_triangulation_ring_connection():
     assert len(triangulation) % 3 == 0
     assert min(triangulation) >= 0
     assert max(triangulation) < len(verts)
+
+
+@pytest.mark.parametrize(
+    ("vec", "expected"),
+    [
+        (np.array([1, 2, 3]), [0.26726124, 0.53452248, 0.80178373]),
+        ((-1, -2, -3), [-0.26726124, -0.53452248, -0.80178373]),
+        ((0.1, 0.1, 0), [0.70710678, 0.70710678, 0]),
+        (np.array([10]), [1]),
+        (
+            np.array([0, 1, 2, 3, 4, 5]),
+            [0, 0.13483997, 0.26967994, 0.40451992, 0.53935989, 0.67419986],
+        ),
+    ],
+)
+def test_normalize_nonzero_vector(vec, expected):
+    normalized_vec = normalize(vec)
+    assert np.allclose(normalized_vec, expected)
+
+    # check that fallback vector is returned when the input vector is non-zero
+    fallback_vec = np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    normalized_vec_with_fallback = normalize(vec, fall_back=fallback_vec)
+    assert np.all(normalized_vec_with_fallback == normalized_vec)
+
+
+@pytest.mark.parametrize(
+    "vec",
+    [
+        np.array([0, 0, 0]),
+        np.array([-0, -0, -0]),
+        (0, 0, 0),
+        np.array([0]),
+        np.array([0, 0, 0, 0, 0]),
+    ],
+)
+def test_normalize_zero_vector(vec):
+    normalized_zero_vec = normalize(vec)
+    assert np.allclose(normalized_zero_vec, np.zeros(len(vec)))
+
+    # check that fallback vector is returned when the input vector is zero
+    fallback_vec = np.array([1, 0, 0])
+    normalized_zero_vec_with_fallback = normalize(vec, fall_back=fallback_vec)
+    assert np.allclose(normalized_zero_vec_with_fallback, fallback_vec)


### PR DESCRIPTION
<!-- Thank you for contributing to Manim! Learn more about the process in our contributing guidelines: https://docs.manim.community/en/latest/contributing.html -->

## Overview: What does this pull request change?
This PR fixes a bug where calling `normalize` with a norm-0 vector and a fallback vector would raise the following exception:
```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
Instead, the function now checks that `fall_back` does not have its default value of `None` and returns the fallback if so. I added a docstring explaining the expected behavior.

This bug was likely not found because there did not exist any tests for `normalize` - running a proper test would have raised the above exception and caused a failure. I've written some tests for `normalize` so this hopefully doesn't happen again.

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

## Links to added or changed documentation pages
<!-- Please add links to the affected documentation pages (edit the description after opening the PR). The link to the documentation for your PR is https://manimce--####.org.readthedocs.build/en/####/, where #### represents the PR number. -->


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
- [ ] If applicable: newly added functions and classes are tested
