### PR TITLE
Refactor: move animation playback and timing into Manager

### DIFF
--- a/docs/source/guides/deep_dive.rst
+++ b/docs/source/guides/deep_dive.rst
@@ -356,9 +356,9 @@ first time a call is made which requires a manager, such as ``render()`` or
 **One renderer per scene.** A scene keeps the renderer selected at construction;
 ``scene.renderer`` is read-only. Successive plays reuse that renderer and its
 writer. For another scene, create a new renderer or let the scene create its
-default. The renderer stores the camera, animation clock, play count, and skip
-state; the manager has corresponding properties which are used to read and
-update those values.
+default. The renderer stores the camera and drawing resources. The manager stores
+the animation clock, play count, and skip state; the renderer's corresponding
+properties read and update those values.
 
 The CLI creates a fresh scene for each selected class and each interactive rerun,
 on both Cairo and OpenGL. It closes the previous run's resources before creating
@@ -811,27 +811,28 @@ walk through the code that is run when :meth:`.Scene.play` is called.
 
 As you will see when inspecting the method, :meth:`.Scene.play` first handles
 an OpenGL interactive-thread guard and then delegates to :meth:`.Manager.play`.
-The manager records the current renderer time and calls the renderer's ``play``
-method, in our case :meth:`.CairoRenderer.play`. Once the renderer returns, the
-manager uses the elapsed time to schedule an optional subcaption (see
+The manager records its current time and executes the animation request through
+its private backend-compatibility path. After playback, the manager uses elapsed
+time to schedule an optional subcaption (see
 :meth:`.Scene.play` and :meth:`.Scene.add_subcaption` for more information).
 
 .. warning::
 
-  The manager currently coordinates the call but deliberately preserves the
-  existing renderer implementation. Most compilation, caching, frame iteration,
-  and output behavior described in the following paragraphs still belongs to the
-  renderer and scene during this transitional stage.
+  Manager owns orchestration and state, but this transitional move preserves
+  the existing backend-specific timing conventions. It does not introduce a new
+  schedule or no-raster execution mode. Scene's compilation/mutation helpers
+  remain useful; its playback wrapper delegates the sample loop to Manager.
 
-Inside :meth:`.CairoRenderer.play`, the renderer first checks whether
+In the Cairo playback path, Manager first checks whether
 it may skip rendering of the current play call. This might happen, for example,
 when ``-s`` is passed to the CLI (i.e., only the last frame should be rendered),
 or when the ``-n`` flag is passed and the current play call is outside of the
 specified render bounds. The "skipping status" is updated in form of the
-call to :meth:`.CairoRenderer.update_skipping_status`.
+manager's selection check; :meth:`.CairoRenderer.update_skipping_status` remains
+a compatibility entrypoint.
 
-Next, the renderer asks the scene to process the animations in the play
-call so that renderer obtains all of the information it needs. To
+Next, Manager asks the scene to process the animations in the play
+call so that execution obtains all of the information it needs. To
 be more concrete, :meth:`.Scene.compile_animation_data` is called,
 which then takes care of several things:
 
@@ -843,7 +844,7 @@ which then takes care of several things:
   any animation-related keyword arguments (like ``run_time``,
   or ``rate_func``) passed to :class:`.Scene.play` to each individual
   animation. The processed animations are then stored in the ``animations``
-  attribute of the scene (which the renderer later reads...).
+  attribute of the scene (which Manager's execution path later reads).
 - It adds all mobjects to which the animations that are played are
   bound to to the scene (provided the animation is not an mobject-introducing
   animation -- for these, the addition to the scene happens later).
@@ -862,10 +863,10 @@ After the animation data has been compiled by the scene, the renderer
 continues to prepare for entering the render loop. It now checks the
 skipping status which has been determined before. If the renderer can
 skip this play call, it does so: it sets the current play call hash (which
-we will get back to in a moment) to ``None`` and increases the time of the
-renderer by the determined animation run time.
+we will get back to in a moment) to ``None`` and increases Manager's execution
+time by the determined animation run time.
 
-Otherwise, the renderer checks whether or not Manim's caching system should
+Otherwise, Manager checks whether or not Manim's caching system should
 be used. The idea of the caching system is simple: for every play call, a
 hash value is computed, which is then stored and upon re-rendering the scene,
 the hash is generated again and checked against the stored value. If it is the
@@ -875,14 +876,14 @@ to learn more, the :func:`.get_hash_from_play_call` function in the
 :mod:`.utils.hashing` module is essentially the entry point to the caching
 mechanism.
 
-In the event that the animation has to be rendered, the renderer gives its
+In the event that the animation has to be rendered, Manager gives its
 :class:`.SceneFileWriter` the current animation index and asks it to start a
 segment job. The writer creates a ``VideoSegmentEncoder`` from the resolved
 profile and wraps it in a ``_PartialMovieEncodeJob``. The synchronous segment
 encoder owns its container, video stream, sequential presentation timestamps,
 and target cleanup. The job owns only the frame queue and worker thread. During
 the render loop, concrete top-left-origin ``uint8`` RGBA arrays are added to the
-queue and encoded by the worker. With the writing process in place, the renderer
+queue and encoded by the worker. With the writing process in place, Manager
 then asks the scene to "begin" the animations.
 
 By default, Manim finishes encoding each partial movie file before rendering the
@@ -964,7 +965,7 @@ it partially renders a scene (to produce a background image), and then
 when iterating through the time progression of the animation only the
 "moving mobjects" are re-painted on top of the static background.
 
-The renderer calls :meth:`.CairoRenderer.save_static_frame_data`, which
+Manager calls :meth:`.CairoRenderer.save_static_frame_data`, which
 first checks whether there are currently any static mobjects, and if there
 are, it updates the frame (only with the static mobjects; more about how
 exactly this works in a moment) and then saves a NumPy array representing
@@ -972,7 +973,7 @@ the rendered frame in the ``static_image`` attribute. In our toy example,
 there are no static mobjects, and so the ``static_image`` attribute is
 simply set to ``None``.
 
-Next, the renderer asks the scene whether the current animation is
+Next, Manager asks the scene whether the current animation is
 a "frozen frame" animation, which would mean that the renderer actually
 does not have to repaint the moving mobjects in every frame of the time
 progression. It can then just take the latest static frame, and display it
@@ -986,13 +987,12 @@ throughout the animation.
   implementation of :meth:`.Scene.should_update_mobjects` for
   more details.
 
-If this is not the case (just as in our toy example), the renderer
-then calls the :meth:`.Scene.play_internal` method, which is the
-integral part of the render loop (in which the library steps through
-the time progression of the animation and renders the corresponding
-frames).
+If this is not the case (just as in our toy example), Manager calls
+:meth:`.Scene.play_internal`, preserving the Scene customization seam. Its default
+implementation delegates back to Manager's sample loop, which steps through the
+time progression and requests corresponding frames.
 
-Within :meth:`.Scene.play_internal`, the following steps are performed:
+Within that loop, the following steps are performed:
 
 - The scene determines the run time of the animations by calling
   :meth:`.Scene.get_run_time`. This method basically takes the maximum
@@ -1007,7 +1007,7 @@ Within :meth:`.Scene.play_internal`, the following steps are performed:
   current animations, so starting at 0 and ending at the total animation run time,
   with the step size determined by the render frame rate) of the timeline where
   a new animation frame should be rendered.
-- Then the scene iterates over the time progression: for each time stamp ``t``,
+- Then Manager iterates over the time progression: for each time stamp ``t``,
   :meth:`.Scene.update_to_time` is called, which ...
 
   - ... first computes the time passed since the last update (which might be 0,
@@ -1038,7 +1038,7 @@ then it is now time to *take a picture*!
   with skipped rendering), updater functions still run correctly, and the state
   of the first frame that *is* rendered is kept consistent.
 
-To render an image, the scene calls the corresponding method of its renderer,
+To render an image, Manager calls the corresponding method of its renderer,
 :meth:`.CairoRenderer.render` and passes just the list of *moving mobjects* (remember,
 the *static mobjects* are assumed to have already been painted statically to
 the background of the scene). All of the hard work then happens when the renderer
@@ -1066,8 +1066,9 @@ the implementation -- but the drawing process can be summarized as follows:
   primary view.
 
 After all batches have been processed, :meth:`.CairoRenderer.get_frame` copies the
-rendered image into a top-left-origin, C-contiguous ``uint8`` RGBA array. The renderer
-passes this array to :class:`.SceneFileWriter`. This concludes one iteration of the
+rendered image into a top-left-origin, C-contiguous ``uint8`` RGBA array. The manager
+advances its Cairo sample clock and delivers this array to :class:`.SceneFileWriter`.
+Drawing and readback do not advance time. This concludes one iteration of the
 render loop, and once the time progression has been processed completely, a final bit
 of cleanup is performed before the :meth:`.Scene.play_internal` call is completed.
 
@@ -1082,10 +1083,10 @@ A TL;DR for the render loop, in the context of our toy example, reads as follows
   state of the transformation animation to the desired time stamp (for example,
   at time stamp ``t = 45/30``, the animation is completed to a rate of
   ``alpha = 0.5``).
-- Then the scene asks the renderer to do its job. The only mobject that needs to
+- Then Manager asks the renderer to do its job. The only mobject that needs to
   be processed at this point is the main mobject attached to the transformation.
   The camera supplies its view transform, while Cairo drawing helpers draw the
-  transformed square into the renderer's image buffer. The renderer passes a copy
+  transformed square into the renderer's image buffer. The manager passes a copy
   of that buffer's RGBA pixels to the file writer.
 - At the end of the loop, 90 frames have been passed to the file writer.
 
@@ -1110,7 +1111,7 @@ and :meth:`.Animation.clean_up_from_scene` methods are called.
 
 In the end, the time progression is closed (which completes the displayed progress bar)
 in the terminal. With the closing of the time progression, the
-:meth:`.Scene.play_internal` call is completed, and we return to the renderer,
+:meth:`.Scene.play_internal` wrapper returns to Manager's orchestration,
 which now orders the :class:`.SceneFileWriter` to close the partial movie stream.
 This seals the corresponding encoding job so that it accepts no more frames. With
 the default ``max_inflight_encoders = 1``, the file writer immediately waits for

--- a/docs/source/guides/deep_dive.rst
+++ b/docs/source/guides/deep_dive.rst
@@ -812,7 +812,7 @@ walk through the code that is run when :meth:`.Scene.play` is called.
 As you will see when inspecting the method, :meth:`.Scene.play` first handles
 an OpenGL interactive-thread guard and then delegates to :meth:`.Manager.play`.
 The manager records its current time and executes the animation request through
-its private backend-compatibility path. After playback, the manager uses elapsed
+its shared execution path. After playback, the manager uses elapsed
 time to schedule an optional subcaption (see
 :meth:`.Scene.play` and :meth:`.Scene.add_subcaption` for more information).
 
@@ -820,8 +820,8 @@ time to schedule an optional subcaption (see
 
   Manager owns orchestration and state. Both backends now advance execution time
   once per evaluated sample, independently of output delivery. Scene's compilation
-  and mutation helpers remain useful; its playback wrapper delegates the sample
-  loop to Manager. This does not introduce a no-raster execution mode.
+  and mutation helpers remain useful; its public play method submits requests to
+  Manager. This does not introduce a no-raster execution mode.
 
 For normal playback, interpolation and updaters see the start of each sample interval;
 after drawing, the clock advances by ``1 / frame_rate`` before delivery and stop checks.
@@ -829,17 +829,32 @@ Finish and cleanup observe the consumed span, including when a stop condition en
 wait early. A fractional non-frozen duration uses the existing sample grid (so, at
 4 fps, 0.3 seconds consumes two samples and advances 0.5 seconds). Frozen waits retain
 the existing whole-frame repeat count (one frame and 0.25 seconds for that example).
-The clock uses the same current configuration rate as the sample progression, rather
-than a renderer's raster-target rate.
+The requested frame rate is captured with the scene's session settings. Changing it
+between construction and execution raises an error: construct the Scene inside the
+configuration context you intend to use. This prevents mixing a new sampling rate
+with an already-resolved encoder profile. Sample time is calculated from the event
+start and sample index, rather than accumulating floating-point additions.
 
-Skipped and cached plays retain their existing evaluation shortcuts and advance the
-nominal duration before animation begin. They are not equivalent to normal sampling,
-including for waits with stop conditions. OpenGL previously exposed event-start time
-throughout normal playback and advanced nominal duration at event end; it now uses the
-common clock. Its visual cache identity has changed so old time-dependent pixels are
-not reused.
+Explicitly skipped plays retain their evaluation shortcuts and advance nominal
+duration before animation begin. Cache hits instead advance the frame-rounded span
+of normal playback, so subsequent events retain the same clock positions. Cached
+Python state updates are still shortcuts, not a replay guarantee. Events with stop
+conditions are evaluated rather than reused, because cached pixels do not record
+when their stop condition fired.
 
-In the Cairo playback path, Manager first checks whether
+Cache identity includes execution time, play index and requested frame rate alongside
+visual inputs. Equal starting geometry at different timeline positions therefore no
+longer shares a segment. Repeated renders of the same timeline can still reuse their
+segments. This invalidates earlier cache identities on both backends; it does not
+claim to capture arbitrary external Python state.
+
+Both backends use one Manager playback path, compiling animations once. A private
+renderer protocol supplies cache drawing inputs, static preparation, drawing/readback
+and presentation; it does not compile, choose cache hits, or advance semantic time.
+OpenGL previously exposed event-start time throughout playback; it now uses the common
+sample clock.
+
+In that shared playback path, Manager first checks whether
 it may skip rendering of the current play call. This might happen, for example,
 when ``-s`` is passed to the CLI (i.e., only the last frame should be rendered),
 or when the ``-n`` flag is passed and the current play call is outside of the
@@ -1003,10 +1018,9 @@ throughout the animation.
   implementation of :meth:`.Scene.should_update_mobjects` for
   more details.
 
-If this is not the case (just as in our toy example), Manager calls
-:meth:`.Scene.play_internal`, preserving the Scene customization seam. Its default
-implementation delegates back to Manager's sample loop, which steps through the
-time progression and requests corresponding frames.
+If this is not the case (just as in our toy example), Manager enters its own private
+sample loop directly. It steps through the time progression and requests corresponding
+frames. Scene supplies compilation and graph-mutation helpers, not an execution loop.
 
 Within that loop, the following steps are performed:
 
@@ -1047,12 +1061,10 @@ then it is now time to *take a picture*!
 
 .. NOTE::
 
-  The update of the internal state (iteration over the time progression) happens
-  *always* once :meth:`.Scene.play_internal` is entered. This ensures that even
-  if frames do not need to be rendered (because, e.g., the ``-n`` CLI flag has
-  been passed, something has been cached, or because we might be in a *Section*
-  with skipped rendering), updater functions still run correctly, and the state
-  of the first frame that *is* rendered is kept consistent.
+  State updates still happen when Manager's sample loop is entered without
+  pixel delivery. However, legacy cache and skip policies may use endpoint-only
+  updates rather than the normal sample sequence. Stateful updaters are not
+  guaranteed to produce identical Python state under those shortcuts.
 
 To render an image, Manager calls the corresponding method of its renderer,
 :meth:`.CairoRenderer.render` and passes just the list of *moving mobjects* (remember,
@@ -1086,7 +1098,7 @@ rendered image into a top-left-origin, C-contiguous ``uint8`` RGBA array. The ma
 advances its sample clock and delivers this array to :class:`.SceneFileWriter`.
 Drawing and readback do not advance time. This concludes one iteration of the
 render loop, and once the time progression has been processed completely, a final bit
-of cleanup is performed before the :meth:`.Scene.play_internal` call is completed.
+of cleanup is performed before Manager's sample loop is completed.
 
 A TL;DR for the render loop, in the context of our toy example, reads as follows:
 
@@ -1109,7 +1121,7 @@ A TL;DR for the render loop, in the context of our toy example, reads as follows
 Completing the render loop
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The last few steps in the :meth:`.Scene.play_internal` call are not too
+The last few steps in Manager's sample loop are not too
 exciting: for every animation, the corresponding :meth:`.Animation.finish`
 and :meth:`.Animation.clean_up_from_scene` methods are called.
 
@@ -1127,7 +1139,7 @@ and :meth:`.Animation.clean_up_from_scene` methods are called.
 
 In the end, the time progression is closed (which completes the displayed progress bar)
 in the terminal. With the closing of the time progression, the
-:meth:`.Scene.play_internal` wrapper returns to Manager's orchestration,
+sample loop returns to Manager's event orchestration,
 which now orders the :class:`.SceneFileWriter` to close the partial movie stream.
 This seals the corresponding encoding job so that it accepts no more frames. With
 the default ``max_inflight_encoders = 1``, the file writer immediately waits for

--- a/docs/source/guides/deep_dive.rst
+++ b/docs/source/guides/deep_dive.rst
@@ -801,71 +801,35 @@ The ``play`` call: preparing to enter Manim's render loop
 We are finally there, the render loop is in our reach. Let us
 walk through the code that is run when :meth:`.Scene.play` is called.
 
-.. hint::
+Both Cairo and OpenGL use the same animation loop in :class:`.Manager`.
+The scene prepares animations and updates mobjects; the manager steps through the
+animation, decides whether to reuse cached frames, and sends new frames to the
+file writer. The renderer draws the scene and, for OpenGL, displays it in the
+preview window. We will follow Cairo's drawing operations below.
 
-  Recall that this article is specifically about the Cairo renderer.
-  Up to here, things were more or less the same for the OpenGL renderer
-  as well; while some base mobjects might be different, the control flow
-  and lifecycle of mobjects is still more or less the same. There are more
-  substantial differences when it comes to the rendering loop.
+:meth:`.Scene.play` passes the request to :meth:`.Manager.play`. During OpenGL
+interaction, calls from another thread are queued for the rendering thread first.
+The manager records the start time so that, after playback, it can place an
+optional subcaption using the elapsed animation time (see
+:meth:`.Scene.add_subcaption`).
 
-As you will see when inspecting the method, :meth:`.Scene.play` first handles
-an OpenGL interactive-thread guard and then delegates to :meth:`.Manager.play`.
-The manager records its current time and executes the animation request through
-its shared execution path. After playback, the manager uses elapsed
-time to schedule an optional subcaption (see
-:meth:`.Scene.play` and :meth:`.Scene.add_subcaption` for more information).
+The frame rate is saved when the scene is created. Create and render the scene
+under the same frame-rate configuration, for example::
 
-.. warning::
+    with tempconfig({"frame_rate": 30}):
+        scene = ToyExample()
+        scene.render()
 
-  Manager owns orchestration and state. Both backends now advance execution time
-  once per evaluated sample, independently of output delivery. Scene's compilation
-  and mutation helpers remain useful; its public play method submits requests to
-  Manager. This does not introduce a no-raster execution mode.
+Changing ``config.frame_rate`` between construction and playback raises an error:
+the animation steps must use the same rate as the saved video encoding settings.
 
-For normal playback, interpolation and updaters see the start of each sample interval;
-after drawing, the clock advances by ``1 / frame_rate`` before delivery and stop checks.
-Finish and cleanup observe the consumed span, including when a stop condition ends a
-wait early. A fractional non-frozen duration uses the existing sample grid (so, at
-4 fps, 0.3 seconds consumes two samples and advances 0.5 seconds). Frozen waits retain
-the existing whole-frame repeat count (one frame and 0.25 seconds for that example).
-The requested frame rate is captured with the scene's session settings. Changing it
-between construction and execution raises an error: construct the Scene inside the
-configuration context you intend to use. This prevents mixing a new sampling rate
-with an already-resolved encoder profile. Sample time is calculated from the event
-start and sample index, rather than accumulating floating-point additions.
+The manager first checks whether to skip rendering this play call. For example,
+``-s`` requests only the final image, and ``-n`` selects a range of play calls.
+Section settings can also request skipped rendering. This sets
+``manager.skip_animations``; the renderer's property reads the same value.
 
-Explicitly skipped plays retain their evaluation shortcuts and advance nominal
-duration before animation begin. Cache hits instead advance the frame-rounded span
-of normal playback, so subsequent events retain the same clock positions. Cached
-Python state updates are still shortcuts, not a replay guarantee. Events with stop
-conditions are evaluated rather than reused, because cached pixels do not record
-when their stop condition fired.
-
-Cache identity includes execution time, play index and requested frame rate alongside
-visual inputs. Equal starting geometry at different timeline positions therefore no
-longer shares a segment. Repeated renders of the same timeline can still reuse their
-segments. This invalidates earlier cache identities on both backends; it does not
-claim to capture arbitrary external Python state.
-
-Both backends use one Manager playback path, compiling animations once. A private
-renderer protocol supplies cache drawing inputs, static preparation, drawing/readback
-and presentation; it does not compile, choose cache hits, or advance semantic time.
-OpenGL previously exposed event-start time throughout playback; it now uses the common
-sample clock.
-
-In that shared playback path, Manager first checks whether
-it may skip rendering of the current play call. This might happen, for example,
-when ``-s`` is passed to the CLI (i.e., only the last frame should be rendered),
-or when the ``-n`` flag is passed and the current play call is outside of the
-specified render bounds. The "skipping status" is updated in form of the
-manager's selection check; :meth:`.CairoRenderer.update_skipping_status` remains
-a compatibility entrypoint.
-
-Next, Manager asks the scene to process the animations in the play
-call so that execution obtains all of the information it needs. To
-be more concrete, :meth:`.Scene.compile_animation_data` is called,
-which then takes care of several things:
+Next, the manager calls :meth:`.Scene.compile_animation_data` to prepare the
+animations. This happens once per play call and includes the following steps:
 
 - The method processes all animations and the keyword arguments passed
   to the initial :meth:`.Scene.play` call. In particular, this means
@@ -875,7 +839,7 @@ which then takes care of several things:
   any animation-related keyword arguments (like ``run_time``,
   or ``rate_func``) passed to :class:`.Scene.play` to each individual
   animation. The processed animations are then stored in the ``animations``
-  attribute of the scene (which Manager's execution path later reads).
+  attribute of the scene for the manager to use during playback.
 - It adds all mobjects to which the animations that are played are
   bound to to the scene (provided the animation is not an mobject-introducing
   animation -- for these, the addition to the scene happens later).
@@ -890,22 +854,31 @@ which then takes care of several things:
   animations). This is stored in the ``duration`` attribute of the scene.
 
 
-After the animation data has been compiled by the scene, the renderer
-continues to prepare for entering the render loop. It now checks the
-skipping status which has been determined before. If the renderer can
-skip this play call, it does so: it sets the current play call hash (which
-we will get back to in a moment) to ``None`` and increases Manager's execution
-time by the determined animation run time.
+**Skipping and caching.** If rendering is explicitly skipped, the manager records
+``None`` as the play call's cache key and advances the clock by the requested
+animation run time before beginning the animations.
 
-Otherwise, Manager checks whether or not Manim's caching system should
-be used. The idea of the caching system is simple: for every play call, a
-hash value is computed, which is then stored and upon re-rendering the scene,
-the hash is generated again and checked against the stored value. If it is the
-same, the cached output is reused, otherwise it is fully rerendered again.
-We will not go into details of the caching system here; if you would like
-to learn more, the :func:`.get_hash_from_play_call` function in the
-:mod:`.utils.hashing` module is essentially the entry point to the caching
-mechanism.
+Otherwise, if caching is enabled, the manager computes a key with
+:func:`.get_hash_from_play_call` and asks the file writer whether a matching
+partial movie file exists. A match lets Manim reuse that file instead of drawing
+and encoding the frames again. The clock advances before the animations begin,
+just as for an explicitly skipped play, but by the duration of the frames that
+normal playback would produce. This includes rounding to whole frames, as
+explained below, so later animations start at the same time on a cache hit or miss.
+
+The key includes the play call's start time, index, and frame rate as well as its
+visual inputs. Identical geometry at different points in a scene can therefore
+produce different keys; another render of the same scene can still reuse those
+segments. Waits with stop conditions do not reuse cached movies: a cached movie
+does not record when the condition became true.
+
+.. note::
+
+   Skipped and cached plays fast-forward state updates rather than replaying every
+   animation step. Stateful updaters can therefore leave different Python state
+   than a full render, and cache keys do not track arbitrary external state. Use
+   ``--disable_caching`` to render without reusing partial movies. This does not
+   override explicit skip settings such as ``-n``.
 
 In the event that the animation has to be rendered, Manager gives its
 :class:`.SceneFileWriter` the current animation index and asks it to start a
@@ -931,13 +904,11 @@ animation suspends updater functions being called on its mobject, and
 it sets its mobject to the state that corresponds to the first frame
 of the animation.
 
-After this has happened for all animations in the current ``play`` call,
-the Cairo renderer determines which of the scene's mobjects can be
-painted statically to the background, and which ones have to be
-redrawn every frame. It does so by calling
-:meth:`.Scene.get_moving_and_static_mobjects`, and the resulting
-partition of mobjects is stored in the corresponding ``moving_mobjects``
-and ``static_mobjects`` attributes.
+After starting the animations, :meth:`.Scene.begin_animations` also prepares
+Cairo's lists of moving and static mobjects. It calls
+:meth:`.Scene.get_moving_and_static_mobjects` and stores the result in
+``moving_mobjects`` and ``static_mobjects``. The renderer uses these lists to
+reuse the background image while redrawing the moving mobjects.
 
 .. NOTE::
 
@@ -956,20 +927,14 @@ Before we enter the render loop, let us briefly revisit our toy
 example and discuss how the generic :meth:`.Scene.play` call
 setup looks like there.
 
-For the call that plays the :class:`.ReplacementTransform`, there
-is no subcaption for the manager to schedule. The manager forwards the call,
-and the renderer then asks the scene to compile the animation data: the passed
-argument already is an animation (no additional preparations needed),
-there is no need for processing any keyword arguments (as
-we did not specify any additional ones to ``play``). The
-mobject bound to the animation, ``orange_square``, is already
-part of the scene (so again, no action taken). Finally, the run
-time is extracted (3 seconds long) and stored in
-``Scene.duration``. The renderer then checks whether it should
-skip (it should not), then whether the animation is already
-cached (it is not). The corresponding animation hash value is
-determined and passed to the file writer. The writer resolves the segment target
-from that key and starts its queued encoder, which waits for rendered frames.
+For the :class:`.ReplacementTransform` call, the manager has no subcaption to
+schedule and no request to skip rendering. It asks the scene to prepare the
+animation: the argument is already an animation, no extra keyword arguments were
+passed to ``play``, and ``orange_square`` is already in the scene. The scene saves
+the animation's run time, 3 seconds, in ``duration``. Assuming this is the first
+render, there is no cached movie to reuse. The manager passes the computed cache
+key to the file writer, which opens an encoding job for the partial movie and
+waits for frames.
 
 The scene then ``begin``\ s the animation: for the
 :class:`.ReplacementTransform` this means that the animation populates
@@ -1004,11 +969,12 @@ the rendered frame in the ``static_image`` attribute. In our toy example,
 there are no static mobjects, and so the ``static_image`` attribute is
 simply set to ``None``.
 
-Next, Manager asks the scene whether the current animation is
-a "frozen frame" animation, which would mean that the renderer actually
-does not have to repaint the moving mobjects in every frame of the time
-progression. It can then just take the latest static frame, and display it
-throughout the animation.
+Next, the manager checks whether this is a frozen wait. If so, it asks the
+renderer to draw one frame, then sends it to the writer with a repeat count
+of ``int(duration * frame_rate)``. Repeating this frame advances the animation
+clock by ``repeat_count / frame_rate`` seconds without updating the mobjects
+again. OpenGL also holds the frame in its preview window for the requested wait
+duration.
 
 .. NOTE::
 
@@ -1018,13 +984,10 @@ throughout the animation.
   implementation of :meth:`.Scene.should_update_mobjects` for
   more details.
 
-If this is not the case (just as in our toy example), Manager enters its own private
-sample loop directly. It steps through the time progression and requests corresponding
-frames. Scene supplies compilation and graph-mutation helpers, not an execution loop.
+For a non-frozen animation, such as our transformation, the manager steps through
+the animation and requests a frame at each time stamp. Here is how it does that:
 
-Within that loop, the following steps are performed:
-
-- The scene determines the run time of the animations by calling
+- The manager determines the run time of the animations by calling
   :meth:`.Scene.get_run_time`. This method basically takes the maximum
   ``run_time`` attribute of all of the animations passed to the
   :meth:`.Scene.play` call.
@@ -1034,9 +997,8 @@ Within that loop, the following steps are performed:
   progression is a ``tqdm`` `progress bar object <https://tqdm.github.io>`__
   for an iterator over ``np.arange(0, run_time, 1 / config.frame_rate)``. In
   other words, the time progression holds the time stamps (relative to the
-  current animations, so starting at 0 and ending at the total animation run time,
-  with the step size determined by the render frame rate) of the timeline where
-  a new animation frame should be rendered.
+  current animations, starting at 0 and stopping before the total run time, with
+  the step size determined by the frame rate) at which a new frame is drawn.
 - Then Manager iterates over the time progression: for each time stamp ``t``,
   :meth:`.Scene.update_to_time` is called, which ...
 
@@ -1058,13 +1020,6 @@ Within that loop, the following steps are performed:
 At this point, the internal (Python) state of all mobjects has been updated
 to match the currently processed timestamp. If rendering should not be skipped,
 then it is now time to *take a picture*!
-
-.. NOTE::
-
-  State updates still happen when Manager's sample loop is entered without
-  pixel delivery. However, legacy cache and skip policies may use endpoint-only
-  updates rather than the normal sample sequence. Stateful updaters are not
-  guaranteed to produce identical Python state under those shortcuts.
 
 To render an image, Manager calls the corresponding method of its renderer,
 :meth:`.CairoRenderer.render` and passes just the list of *moving mobjects* (remember,
@@ -1093,12 +1048,40 @@ the implementation -- but the drawing process can be summarized as follows:
   the resulting image in the corresponding :class:`.ImageMobjectFromCamera` in the
   primary view.
 
-After all batches have been processed, :meth:`.CairoRenderer.get_frame` copies the
-rendered image into a top-left-origin, C-contiguous ``uint8`` RGBA array. The manager
-advances its sample clock and delivers this array to :class:`.SceneFileWriter`.
-Drawing and readback do not advance time. This concludes one iteration of the
-render loop, and once the time progression has been processed completely, a final bit
-of cleanup is performed before Manager's sample loop is completed.
+After drawing, :meth:`.CairoRenderer.get_frame` copies the rendered image into a
+top-left-origin, C-contiguous ``uint8`` RGBA array. The manager advances the animation
+clock by one frame interval, then passes the array to the :class:`.SceneFileWriter`.
+If the animation has a stop condition, the manager checks it at this point,
+before starting the next iteration. Drawing and reading pixels alone do not
+advance the clock.
+
+**Which time does user code see?** Within each normal animation step,
+interpolation and updaters see the time at the start of that step. The writer
+and stop condition see the time after its frame interval. For example, a
+non-frozen 0.3-second animation starting at time 0, at 4 fps, takes two steps:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Animation offset
+     - ``Scene.time`` during interpolation and updaters
+     - ``Scene.time`` when checking the stop condition
+   * - 0 seconds
+     - 0 seconds
+     - 0.25 seconds
+   * - 0.25 seconds
+     - 0.25 seconds
+     - 0.5 seconds
+
+The two frames occupy 0.5 seconds, so the next play starts at time 0.5. A frozen
+wait of the same requested duration instead repeats one frame and advances by
+0.25 seconds. These rounding rules apply to both backends. The manager calculates
+each step's time from the play's start time and step index rather than repeatedly
+adding floating-point intervals.
+
+After the last step, ``finish()`` and ``clean_up_from_scene()`` see the time at
+the end of the frames processed so far. This also applies when a stop condition
+ends a non-frozen wait early. We will return to those methods below.
 
 A TL;DR for the render loop, in the context of our toy example, reads as follows:
 
@@ -1114,8 +1097,8 @@ A TL;DR for the render loop, in the context of our toy example, reads as follows
 - Then Manager asks the renderer to do its job. The only mobject that needs to
   be processed at this point is the main mobject attached to the transformation.
   The camera supplies its view transform, while Cairo drawing helpers draw the
-  transformed square into the renderer's image buffer. The manager passes a copy
-  of that buffer's RGBA pixels to the file writer.
+  transformed square into the renderer's image buffer. The manager advances the
+  clock and passes a copy of that buffer's RGBA pixels to the file writer.
 - At the end of the loop, 90 frames have been passed to the file writer.
 
 Completing the render loop
@@ -1130,17 +1113,15 @@ and :meth:`.Animation.clean_up_from_scene` methods are called.
   Note that as part of :meth:`.Animation.finish`, the :meth:`.Animation.interpolate`
   method is called with an argument of 1.0 -- you might have noticed already that
   the last frame of an animation can sometimes be a bit off or incomplete.
-  This is by current design! The last frame rendered in the render loop (and displayed
-  for a duration of ``1 / frame_rate`` seconds in the rendered video) corresponds to
-  the state of the animation ``1 / frame_rate`` seconds before it ends. To display
-  the final frame as well in the video, we would need to append another ``1 / frame_rate``
-  seconds to the video -- which would then mean that a 1 second rendered Manim video
-  would be slightly longer than 1 second. We decided against this at some point.
+  The render loop samples times strictly before the requested run time. When that
+  run time is a whole number of frame intervals, the last image shows the animation
+  one interval before its end. Appending the final state as another frame would
+  lengthen the video by ``1 / frame_rate`` seconds. The final interpolation updates
+  the mobject for the next animation without adding that extra frame.
 
-In the end, the time progression is closed (which completes the displayed progress bar)
-in the terminal. With the closing of the time progression, the
-sample loop returns to Manager's event orchestration,
-which now orders the :class:`.SceneFileWriter` to close the partial movie stream.
+Finally, the manager closes the time progression, completing the terminal's
+progress bar, and asks the :class:`.SceneFileWriter` to close the partial movie
+stream.
 This seals the corresponding encoding job so that it accepts no more frames. With
 the default ``max_inflight_encoders = 1``, the file writer immediately waits for
 the job and the partial movie file has been written when the call returns. With a

--- a/docs/source/guides/deep_dive.rst
+++ b/docs/source/guides/deep_dive.rst
@@ -818,10 +818,26 @@ time to schedule an optional subcaption (see
 
 .. warning::
 
-  Manager owns orchestration and state, but this transitional move preserves
-  the existing backend-specific timing conventions. It does not introduce a new
-  schedule or no-raster execution mode. Scene's compilation/mutation helpers
-  remain useful; its playback wrapper delegates the sample loop to Manager.
+  Manager owns orchestration and state. Both backends now advance execution time
+  once per evaluated sample, independently of output delivery. Scene's compilation
+  and mutation helpers remain useful; its playback wrapper delegates the sample
+  loop to Manager. This does not introduce a no-raster execution mode.
+
+For normal playback, interpolation and updaters see the start of each sample interval;
+after drawing, the clock advances by ``1 / frame_rate`` before delivery and stop checks.
+Finish and cleanup observe the consumed span, including when a stop condition ends a
+wait early. A fractional non-frozen duration uses the existing sample grid (so, at
+4 fps, 0.3 seconds consumes two samples and advances 0.5 seconds). Frozen waits retain
+the existing whole-frame repeat count (one frame and 0.25 seconds for that example).
+The clock uses the same current configuration rate as the sample progression, rather
+than a renderer's raster-target rate.
+
+Skipped and cached plays retain their existing evaluation shortcuts and advance the
+nominal duration before animation begin. They are not equivalent to normal sampling,
+including for waits with stop conditions. OpenGL previously exposed event-start time
+throughout normal playback and advanced nominal duration at event end; it now uses the
+common clock. Its visual cache identity has changed so old time-dependent pixels are
+not reused.
 
 In the Cairo playback path, Manager first checks whether
 it may skip rendering of the current play call. This might happen, for example,
@@ -1067,7 +1083,7 @@ the implementation -- but the drawing process can be summarized as follows:
 
 After all batches have been processed, :meth:`.CairoRenderer.get_frame` copies the
 rendered image into a top-left-origin, C-contiguous ``uint8`` RGBA array. The manager
-advances its Cairo sample clock and delivers this array to :class:`.SceneFileWriter`.
+advances its sample clock and delivers this array to :class:`.SceneFileWriter`.
 Drawing and readback do not advance time. This concludes one iteration of the
 render loop, and once the time progression has been processed completely, a final bit
 of cleanup is performed before the :meth:`.Scene.play_internal` call is completed.

--- a/manim/_config/render_session.py
+++ b/manim/_config/render_session.py
@@ -33,6 +33,7 @@ class RenderSessionSpec:
     output: OutputSpec
     presentation: PresentationSpec
     dry_run: bool
+    frame_rate: float
     video_encoder: VideoEncoderSpec | None
 
 
@@ -122,5 +123,6 @@ def resolve_render_session(
         output=output,
         presentation=presentation,
         dry_run=dry_run,
+        frame_rate=float(config.frame_rate),
         video_encoder=video_encoder,
     )

--- a/manim/manager.py
+++ b/manim/manager.py
@@ -655,6 +655,11 @@ class Manager(Generic[SceneT]):
         if isinstance(self.renderer, OpenGLRenderer):
             self.renderer._present_frame(self.scene, frame_offset)
 
+    def _render_preview_frame(self, frame_offset: float) -> None:
+        """Preserve interactive redraw/delivery without advancing execution time."""
+        frame = self._draw_animation_frame(frame_offset)
+        self._deliver_animation_frame(frame, frame_offset)
+
     def _legacy_add_frame(self, frame: RGBAPixelArray, num_frames: int = 1) -> None:
         """Compatibility for explicit Cairo add_frame calls, not evaluation."""
         renderer = cast("CairoRenderer", self.renderer)

--- a/manim/manager.py
+++ b/manim/manager.py
@@ -66,6 +66,9 @@ class Manager(Generic[SceneT]):
     the file writer when first requested and makes it available before
     :meth:`~manim.scene.scene.Scene.setup` runs.
 
+    Both backends use the same animation clock and sampling rules. Cached and
+    skipped animations follow a separate fast-forward path.
+
     Rendering normally closes the renderer before returning. Use a
     ``with manager:`` block to keep its resources available after a successful
     render, for example to read the last-rendered frame. The block closes them
@@ -498,9 +501,10 @@ class Manager(Generic[SceneT]):
         if scene.is_current_animation_frozen_frame():
             renderer.update_frame(scene, mobjects=scene.moving_mobjects)
             frame = renderer.get_frame()
-            repeats = int(scene.duration * renderer._frame_rate)
+            frame_rate = float(config.frame_rate)
+            repeats = int(scene.duration * frame_rate)
             if not self.skip_animations:
-                self.time += repeats / renderer._frame_rate
+                self.time += repeats / frame_rate
                 self.file_writer.write_frame(frame, repeat=repeats)
         else:
             scene.play_internal()
@@ -535,6 +539,9 @@ class Manager(Generic[SceneT]):
                         "meshes": scene.meshes,
                         "background_color": renderer.background_color,
                         "anti_alias_width": renderer.anti_alias_width,
+                        # Time-dependent user code now sees sample time instead
+                        # of the old event-start time: old pixels are not reusable.
+                        "execution_clock": "sample-v1",
                     },
                 )
                 if self.file_writer.is_already_cached(hash_play):
@@ -558,17 +565,24 @@ class Manager(Generic[SceneT]):
             not self.skip_animations, animation_index=self.num_plays
         )
         scene.compile_animation_data(*args, **kwargs)
+        if self.skip_animations:
+            self.time += scene.duration
         scene.begin_animations()
         if scene.is_current_animation_frozen_frame():
             renderer.update_frame(scene)
             output = self.file_writer.output_spec
-            if not self.skip_animations and (
-                output.is_video or output.is_image_sequence
-            ):
-                self.file_writer.write_frame(
-                    renderer.get_frame(),
-                    repeat=int(config.frame_rate * scene.duration),
-                )
+            frame_rate = float(config.frame_rate)
+            repeats = int(scene.duration * frame_rate)
+            frame = (
+                renderer.get_frame()
+                if not self.skip_animations
+                and (output.is_video or output.is_image_sequence)
+                else None
+            )
+            if not self.skip_animations:
+                self.time += repeats / frame_rate
+                if frame is not None:
+                    self.file_writer.write_frame(frame, repeat=repeats)
             if renderer.window is not None:
                 renderer.window.swap_buffers()
                 while time.time() - renderer.animation_start_time < scene.duration:
@@ -577,17 +591,17 @@ class Manager(Generic[SceneT]):
         else:
             scene.play_internal()
         self.file_writer.end_animation(not self.skip_animations)
-        self.time += scene.duration
         self.num_plays += 1
         if skipped_at_entry:
             renderer.animations_hashes.append(None)
             self.file_writer.add_partial_movie_file(None)
 
     def _play_internal(self, skip_rendering: bool = False) -> None:
-        """Own the existing sample loop without changing its callback order."""
-        from .renderer.cairo.renderer import CairoRenderer
-
+        """Evaluate samples on the common clock, independently of pixel delivery."""
         scene = self.scene
+        # Use the same rate as Scene.get_time_progression, not a backend's
+        # raster-target settings. Resolution timing and sample rounding stay put.
+        sample_step = 1 / config.frame_rate
         assert scene.animations is not None
         scene.duration = scene.get_run_time(scene.animations)
         scene.time_progression = scene._get_animation_time_progression(
@@ -598,11 +612,10 @@ class Manager(Generic[SceneT]):
             scene.update_to_time(t)
             draw = not skip_rendering and not scene.skip_animation_preview
             frame = self._draw_animation_frame(t) if draw else None
-            # Preserve the characterized backend timing in this ownership move.
-            # Cairo advances per sample; OpenGL's legacy event-end advance is in
-            # _play_opengl. Neither advance is owned by pixel delivery anymore.
-            if isinstance(self.renderer, CairoRenderer) and not self.skip_animations:
-                self.time += 1 / self.renderer._frame_rate
+            # The sample represents one interval, including the initial t=0
+            # sample. Stop conditions and finish observe the consumed span.
+            if not self.skip_animations:
+                self.time += sample_step
             if draw:
                 self._deliver_animation_frame(frame, t)
             if scene.stop_condition is not None and scene.stop_condition():

--- a/manim/manager.py
+++ b/manim/manager.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import datetime
-import time
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+import math
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import srt
 
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from .renderer.cairo.camera import Camera
     from .renderer.opengl.camera import OpenGLCamera
     from .renderer.opengl.renderer import OpenGLRenderer
+    from .renderer.protocol import _AnimationRenderer
     from .scene.scene import Scene
     from .scene.scene_file_writer import SceneFileWriter
     from .typing import RGBAPixelArray
@@ -240,6 +241,17 @@ class Manager(Generic[SceneT]):
     def skip_animations(self, value: bool) -> None:
         self._execution.skip_animations = value
 
+    def _validate_execution(self) -> None:
+        if self._closed or self._closing:
+            raise RuntimeError("The Manager is closed or closing.")
+        if self.renderer._closed or getattr(self.renderer, "_retiring", False):
+            raise RuntimeError("Cannot execute a closed or retiring renderer.")
+        if float(config.frame_rate) != self.session_spec.frame_rate:
+            raise ValueError(
+                "frame_rate changed after Scene construction. Construct a new Scene "
+                "under the desired configuration before executing it."
+            )
+
     def render(self, preview: bool = False) -> bool:
         """Run the complete render lifecycle for the managed scene.
 
@@ -268,8 +280,7 @@ class Manager(Generic[SceneT]):
         """
         from .renderer.opengl.renderer import OpenGLRenderer
 
-        if self._closed or self._closing:
-            raise RuntimeError("The Manager is closed or closing.")
+        self._validate_execution()
         started = False
         try:
             presentation = self.session_spec.presentation
@@ -394,8 +405,7 @@ class Manager(Generic[SceneT]):
         kwargs
             Additional animation arguments passed to Scene's compilation helpers.
         """
-        if self._closed or self._closing:
-            raise RuntimeError("The Manager is closed or closing.")
+        self._validate_execution()
         try:
             self._open_log_handler()
             start_time = self.time
@@ -420,16 +430,6 @@ class Manager(Generic[SceneT]):
             self._cleanup_after_failure()
             raise
 
-    def _play(
-        self, *args: Animation | Mobject | _AnimationBuilder, **kwargs: Any
-    ) -> None:
-        from .renderer.opengl.renderer import OpenGLRenderer
-
-        if isinstance(self.renderer, OpenGLRenderer):
-            self._play_opengl(*args, **kwargs)
-        else:
-            self._play_cairo(*args, **kwargs)
-
     def _update_skipping_status(self) -> None:
         if (
             self.file_writer.sections[-1].skip_animations
@@ -448,14 +448,14 @@ class Manager(Generic[SceneT]):
             self.skip_animations = True
             raise EndSceneEarlyException()
 
-    def _play_cairo(
+    def _play(
         self, *args: Animation | Mobject | _AnimationBuilder, **kwargs: Any
     ) -> None:
-        """Preserve Cairo's existing order while moving its orchestration owner."""
+        """Compile, select and execute one event through shared backend operations."""
+        self._validate_execution()
         scene = self.scene
-        renderer = cast("CairoRenderer", self.renderer)
-        renderer._ensure_open()
-        self.skip_animations = renderer._original_skipping_status
+        renderer: _AnimationRenderer = self.renderer
+        self.skip_animations = self._execution.original_skipping_status
         self._update_skipping_status()
         scene.compile_animation_data(*args, **kwargs)
 
@@ -469,153 +469,97 @@ class Manager(Generic[SceneT]):
                 hash_current_animation = f"uncached_{self.num_plays:05}"
             else:
                 assert scene.animations is not None
+                backend, drawing_state = renderer._animation_cache_identity(scene)
                 hash_current_animation = get_hash_from_play_call(
                     scene,
                     self.camera,
                     scene.animations,
                     scene.mobjects,
-                    backend="cairo",
+                    backend=backend,
                     encoder_fingerprint=video_encoder_fingerprint(
                         self.session_spec.video_encoder
                     ),
-                    renderer_state=(),
+                    renderer_state={
+                        "drawing": drawing_state,
+                        "execution": {
+                            "clock": "sample-v2",
+                            "time": self.time,
+                            "play_index": self.num_plays,
+                            "frame_rate": self.session_spec.frame_rate,
+                        },
+                    },
                 )
-                if self.file_writer.is_already_cached(hash_current_animation):
+                # Cached pixels cannot tell us when an arbitrary stop condition
+                # fired. Evaluate these events rather than inventing their span.
+                if scene.stop_condition is None and self.file_writer.is_already_cached(
+                    hash_current_animation
+                ):
                     logger.info(
                         f"Animation {self.num_plays} : Using cached data (hash : %(hash_current_animation)s)",
                         {"hash_current_animation": hash_current_animation},
                     )
                     self.skip_animations = True
-                    self.time += scene.duration
+                    self.time += self._sampled_duration(
+                        scene.duration, scene.is_current_animation_frozen_frame()
+                    )
         self.file_writer.add_partial_movie_file(hash_current_animation)
-        renderer.animations_hashes.append(hash_current_animation)
+        self._execution.animations_hashes.append(hash_current_animation)
         logger.debug(
             "List of the first few animation hashes of the scene: %(h)s",
-            {"h": str(renderer.animations_hashes[:5])},
+            {"h": str(self._execution.animations_hashes[:5])},
         )
+        renderer._start_animation()
         self.file_writer.begin_animation(
             not self.skip_animations, animation_index=self.num_plays
         )
         scene.begin_animations()
-        renderer.save_static_frame_data(scene, scene.static_mobjects)
+        renderer._prepare_animation(scene)
         if scene.is_current_animation_frozen_frame():
-            renderer.update_frame(scene, mobjects=scene.moving_mobjects)
-            frame = renderer.get_frame()
-            frame_rate = float(config.frame_rate)
+            frame = self._draw_animation_frame(0)
+            frame_rate = self.session_spec.frame_rate
             repeats = int(scene.duration * frame_rate)
-            if not self.skip_animations:
-                self.time += repeats / frame_rate
-                self.file_writer.write_frame(frame, repeat=repeats)
-        else:
-            scene.play_internal()
-        self.file_writer.end_animation(not self.skip_animations)
-        self.num_plays += 1
-
-    def _play_opengl(
-        self, *args: Animation | Mobject | _AnimationBuilder, **kwargs: Any
-    ) -> None:
-        """Keep the former decorator/body ordering, including double compilation."""
-        scene = self.scene
-        renderer = cast("OpenGLRenderer", self.renderer)
-        self.skip_animations = renderer._original_skipping_status
-        self._update_skipping_status()
-        animations = scene.compile_animations(*args, **kwargs)
-        scene.add_mobjects_from_animations(animations)
-        skipped_at_entry = self.skip_animations
-        if skipped_at_entry:
-            logger.debug(f"Skipping animation {self.num_plays}")
-        else:
-            if not config["disable_caching"]:
-                hash_play = get_hash_from_play_call(
-                    scene,
-                    self.camera,
-                    animations,
-                    scene.mobjects,
-                    backend="opengl",
-                    encoder_fingerprint=video_encoder_fingerprint(
-                        self.session_spec.video_encoder
-                    ),
-                    renderer_state={
-                        "meshes": scene.meshes,
-                        "background_color": renderer.background_color,
-                        "anti_alias_width": renderer.anti_alias_width,
-                        # Time-dependent user code now sees sample time instead
-                        # of the old event-start time: old pixels are not reusable.
-                        "execution_clock": "sample-v1",
-                    },
-                )
-                if self.file_writer.is_already_cached(hash_play):
-                    logger.info(
-                        f"Animation {self.num_plays} : Using cached data (hash : %(hash_play)s)",
-                        {"hash_play": hash_play},
-                    )
-                    self.skip_animations = True
-            else:
-                hash_play = f"uncached_{self.num_plays:05}"
-            renderer.animations_hashes.append(hash_play)
-            self.file_writer.add_partial_movie_file(hash_play)
-            logger.debug(
-                "List of the first few animation hashes of the scene: %(h)s",
-                {"h": str(renderer.animations_hashes[:5])},
-            )
-
-        renderer.open()
-        renderer.animation_start_time = time.time()
-        self.file_writer.begin_animation(
-            not self.skip_animations, animation_index=self.num_plays
-        )
-        scene.compile_animation_data(*args, **kwargs)
-        if self.skip_animations:
-            self.time += scene.duration
-        scene.begin_animations()
-        if scene.is_current_animation_frozen_frame():
-            renderer.update_frame(scene)
-            output = self.file_writer.output_spec
-            frame_rate = float(config.frame_rate)
-            repeats = int(scene.duration * frame_rate)
-            frame = (
-                renderer.get_frame()
-                if not self.skip_animations
-                and (output.is_video or output.is_image_sequence)
-                else None
-            )
             if not self.skip_animations:
                 self.time += repeats / frame_rate
                 if frame is not None:
                     self.file_writer.write_frame(frame, repeat=repeats)
-            if renderer.window is not None:
-                renderer.window.swap_buffers()
-                while time.time() - renderer.animation_start_time < scene.duration:
-                    pass
-            renderer.animation_elapsed_time = scene.duration
+            renderer._present_frozen_frame(scene, scene.duration)
         else:
-            scene.play_internal()
+            self._play_internal()
         self.file_writer.end_animation(not self.skip_animations)
         self.num_plays += 1
-        if skipped_at_entry:
-            renderer.animations_hashes.append(None)
-            self.file_writer.add_partial_movie_file(None)
+
+    def _sampled_duration(self, duration: float, frozen: bool) -> float:
+        """The ordinary event span, also used on a visual cache hit."""
+        frame_rate = self.session_spec.frame_rate
+        count = (
+            int(duration * frame_rate)
+            if frozen
+            else math.ceil(duration / (1 / frame_rate))
+        )
+        return count / frame_rate
 
     def _play_internal(self, skip_rendering: bool = False) -> None:
         """Evaluate samples on the common clock, independently of pixel delivery."""
+        self._validate_execution()
         scene = self.scene
         # Use the same rate as Scene.get_time_progression, not a backend's
         # raster-target settings. Resolution timing and sample rounding stay put.
-        sample_step = 1 / config.frame_rate
+        frame_rate = self.session_spec.frame_rate
+        event_start = self.time
         assert scene.animations is not None
         scene.duration = scene.get_run_time(scene.animations)
         scene.time_progression = scene._get_animation_time_progression(
             scene.animations,
             scene.duration,
         )
-        for t in scene.time_progression:
+        for sample_index, t in enumerate(scene.time_progression):
             scene.update_to_time(t)
             draw = not skip_rendering and not scene.skip_animation_preview
             frame = self._draw_animation_frame(t) if draw else None
             # The sample represents one interval, including the initial t=0
             # sample. Stop conditions and finish observe the consumed span.
             if not self.skip_animations:
-                self.time += sample_step
+                self.time = event_start + (sample_index + 1) / frame_rate
             if draw:
                 self._deliver_animation_frame(frame, t)
             if scene.stop_condition is not None and scene.stop_condition():
@@ -646,26 +590,23 @@ class Manager(Generic[SceneT]):
     def _deliver_animation_frame(
         self, frame: RGBAPixelArray | None, frame_offset: float
     ) -> None:
-        from .renderer.opengl.renderer import OpenGLRenderer
-
         if self.skip_animations:
             return
         if frame is not None:
             self.file_writer.write_frame(frame)
-        if isinstance(self.renderer, OpenGLRenderer):
-            self.renderer._present_frame(self.scene, frame_offset)
+        self.renderer._present_frame(self.scene, frame_offset)
 
     def _render_preview_frame(self, frame_offset: float) -> None:
         """Preserve interactive redraw/delivery without advancing execution time."""
+        self._validate_execution()
         frame = self._draw_animation_frame(frame_offset)
         self._deliver_animation_frame(frame, frame_offset)
 
     def _legacy_add_frame(self, frame: RGBAPixelArray, num_frames: int = 1) -> None:
         """Compatibility for explicit Cairo add_frame calls, not evaluation."""
-        renderer = cast("CairoRenderer", self.renderer)
-        renderer._ensure_open()
+        self._validate_execution()
         if not self.skip_animations:
-            self.time += num_frames / renderer._frame_rate
+            self.time += num_frames / self.session_spec.frame_rate
             self.file_writer.write_frame(frame, repeat=num_frames)
 
     def next_section(

--- a/manim/manager.py
+++ b/manim/manager.py
@@ -216,7 +216,7 @@ class Manager(Generic[SceneT]):
 
     @property
     def time(self) -> float:
-        """Return the managed execution time."""
+        """Return elapsed animation time in seconds."""
         return self._execution.time
 
     @time.setter
@@ -225,7 +225,7 @@ class Manager(Generic[SceneT]):
 
     @property
     def num_plays(self) -> int:
-        """Return the managed execution's play count."""
+        """Return the number of completed play or wait calls."""
         return self._execution.num_plays
 
     @num_plays.setter
@@ -234,7 +234,7 @@ class Manager(Generic[SceneT]):
 
     @property
     def skip_animations(self) -> bool:
-        """Return the managed execution's animation skip state."""
+        """Return whether the current play is being fast-forwarded."""
         return self._execution.skip_animations
 
     @skip_animations.setter
@@ -388,7 +388,7 @@ class Manager(Generic[SceneT]):
         subcaption_offset: float = 0,
         **kwargs: Any,
     ) -> None:
-        """Coordinate an animation request and its optional subcaption.
+        """Play animations and add an optional subcaption.
 
         Parameters
         ----------
@@ -403,7 +403,8 @@ class Manager(Generic[SceneT]):
         subcaption_offset
             Offset in seconds from the beginning of the play call.
         kwargs
-            Additional animation arguments passed to Scene's compilation helpers.
+            Animation options such as ``run_time`` and ``rate_func``, applied
+            by :meth:`.Scene.compile_animations`.
         """
         self._validate_execution()
         try:
@@ -451,7 +452,7 @@ class Manager(Generic[SceneT]):
     def _play(
         self, *args: Animation | Mobject | _AnimationBuilder, **kwargs: Any
     ) -> None:
-        """Compile, select and execute one event through shared backend operations."""
+        """Prepare and play animations, reusing cached frames when available."""
         self._validate_execution()
         scene = self.scene
         renderer: _AnimationRenderer = self.renderer
@@ -489,8 +490,8 @@ class Manager(Generic[SceneT]):
                         },
                     },
                 )
-                # Cached pixels cannot tell us when an arbitrary stop condition
-                # fired. Evaluate these events rather than inventing their span.
+                # Cached movies do not record when a stop condition became true.
+                # Run these waits again to determine when they end.
                 if scene.stop_condition is None and self.file_writer.is_already_cached(
                     hash_current_animation
                 ):
@@ -529,7 +530,7 @@ class Manager(Generic[SceneT]):
         self.num_plays += 1
 
     def _sampled_duration(self, duration: float, frozen: bool) -> float:
-        """The ordinary event span, also used on a visual cache hit."""
+        """Return the duration of the frames a normal render would produce."""
         frame_rate = self.session_spec.frame_rate
         count = (
             int(duration * frame_rate)
@@ -539,11 +540,10 @@ class Manager(Generic[SceneT]):
         return count / frame_rate
 
     def _play_internal(self, skip_rendering: bool = False) -> None:
-        """Evaluate samples on the common clock, independently of pixel delivery."""
+        """Step through animations, advancing time even when frames are not written."""
         self._validate_execution()
         scene = self.scene
-        # Use the same rate as Scene.get_time_progression, not a backend's
-        # raster-target settings. Resolution timing and sample rounding stay put.
+        # Match Scene.get_time_progression and the scene's saved encoder settings.
         frame_rate = self.session_spec.frame_rate
         event_start = self.time
         assert scene.animations is not None
@@ -556,8 +556,8 @@ class Manager(Generic[SceneT]):
             scene.update_to_time(t)
             draw = not skip_rendering and not scene.skip_animation_preview
             frame = self._draw_animation_frame(t) if draw else None
-            # The sample represents one interval, including the initial t=0
-            # sample. Stop conditions and finish observe the consumed span.
+            # Count the interval displayed by this frame, including the t=0 frame.
+            # Stop conditions and finish() see the time at the end of that interval.
             if not self.skip_animations:
                 self.time = event_start + (sample_index + 1) / frame_rate
             if draw:
@@ -597,13 +597,13 @@ class Manager(Generic[SceneT]):
         self.renderer._present_frame(self.scene, frame_offset)
 
     def _render_preview_frame(self, frame_offset: float) -> None:
-        """Preserve interactive redraw/delivery without advancing execution time."""
+        """Redraw and display an interactive frame without advancing animation time."""
         self._validate_execution()
         frame = self._draw_animation_frame(frame_offset)
         self._deliver_animation_frame(frame, frame_offset)
 
     def _legacy_add_frame(self, frame: RGBAPixelArray, num_frames: int = 1) -> None:
-        """Compatibility for explicit Cairo add_frame calls, not evaluation."""
+        """Write frames and advance time for callers of CairoRenderer.add_frame."""
         self._validate_execution()
         if not self.skip_animations:
             self.time += num_frames / self.session_spec.frame_rate

--- a/manim/manager.py
+++ b/manim/manager.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+import time
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 import srt
 
-from . import logger
+from . import config, logger
 from ._config.logger_utils import set_file_logger
+from ._config.video_encoder import video_encoder_fingerprint
 from .scene.section import DefaultSectionType
 from .utils.exceptions import EndSceneEarlyException, RerunSceneException
 from .utils.file_ops import open_media_file
+from .utils.hashing import get_hash_from_play_call
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -30,6 +33,7 @@ if TYPE_CHECKING:
     from .renderer.opengl.renderer import OpenGLRenderer
     from .scene.scene import Scene
     from .scene.scene_file_writer import SceneFileWriter
+    from .typing import RGBAPixelArray
 
 __all__ = ["Manager"]
 
@@ -40,10 +44,10 @@ class Manager(Generic[SceneT]):
     """Run a scene's rendering steps and clean up its resources.
 
     Each manager works with one :class:`~manim.scene.scene.Scene`. It calls the
-    scene's setup, construct, and tear-down hooks, delegates animation playback to
-    the renderer, and uses a file writer for sections, subcaptions, and audio.
-    Calling :meth:`~manim.scene.scene.Scene.render` creates a manager if needed
-    and stores it in ``scene.manager``.
+    scene's setup, construct, and tear-down hooks, runs animation playback, and
+    uses the renderer for drawing. A file writer handles sections, subcaptions,
+    and audio. Calling :meth:`~manim.scene.scene.Scene.render` creates a manager
+    if needed and stores it in ``scene.manager``.
 
     Parameters
     ----------
@@ -81,6 +85,7 @@ class Manager(Generic[SceneT]):
         if scene.manager is not None:
             raise ValueError("A manager is already attached to this scene.")
         self.scene = scene
+        self._execution = scene.renderer._claim_execution(self)
         self._file_writer: SceneFileWriter | None = None
         self._creating_file_writer = False
         self._log_handler: FileHandler | None = None
@@ -207,30 +212,30 @@ class Manager(Generic[SceneT]):
 
     @property
     def time(self) -> float:
-        """Return the current renderer time."""
-        return self.renderer.time
+        """Return the managed execution time."""
+        return self._execution.time
 
     @time.setter
     def time(self, value: float) -> None:
-        self.renderer.time = value
+        self._execution.time = value
 
     @property
     def num_plays(self) -> int:
-        """Return the current renderer's play count."""
-        return self.renderer.num_plays
+        """Return the managed execution's play count."""
+        return self._execution.num_plays
 
     @num_plays.setter
     def num_plays(self, value: int) -> None:
-        self.renderer.num_plays = value
+        self._execution.num_plays = value
 
     @property
     def skip_animations(self) -> bool:
-        """Return the current renderer's animation skip state."""
-        return self.renderer.skip_animations
+        """Return the managed execution's animation skip state."""
+        return self._execution.skip_animations
 
     @skip_animations.setter
     def skip_animations(self, value: bool) -> None:
-        self.renderer.skip_animations = value
+        self._execution.skip_animations = value
 
     def render(self, preview: bool = False) -> bool:
         """Run the complete render lifecycle for the managed scene.
@@ -384,14 +389,14 @@ class Manager(Generic[SceneT]):
         subcaption_offset
             Offset in seconds from the beginning of the play call.
         kwargs
-            Additional animation arguments forwarded to the renderer.
+            Additional animation arguments passed to Scene's compilation helpers.
         """
         if self._closed or self._closing:
             raise RuntimeError("The Manager is closed or closing.")
         try:
             self._open_log_handler()
             start_time = self.time
-            self.renderer.play(self.scene, *args, **kwargs)
+            self._play(*args, **kwargs)
             run_time = self.time - start_time
 
             if subcaption:
@@ -411,6 +416,239 @@ class Manager(Generic[SceneT]):
             # A direct play() can fail outside render(), so it needs cleanup here too.
             self._cleanup_after_failure()
             raise
+
+    def _play(
+        self, *args: Animation | Mobject | _AnimationBuilder, **kwargs: Any
+    ) -> None:
+        from .renderer.opengl.renderer import OpenGLRenderer
+
+        if isinstance(self.renderer, OpenGLRenderer):
+            self._play_opengl(*args, **kwargs)
+        else:
+            self._play_cairo(*args, **kwargs)
+
+    def _update_skipping_status(self) -> None:
+        if (
+            self.file_writer.sections[-1].skip_animations
+            or self.file_writer.output_spec.is_still
+        ):
+            self.skip_animations = True
+        if (
+            config.from_animation_number > 0
+            and self.num_plays < config.from_animation_number
+        ):
+            self.skip_animations = True
+        if (
+            config.upto_animation_number >= 0
+            and self.num_plays > config.upto_animation_number
+        ):
+            self.skip_animations = True
+            raise EndSceneEarlyException()
+
+    def _play_cairo(
+        self, *args: Animation | Mobject | _AnimationBuilder, **kwargs: Any
+    ) -> None:
+        """Preserve Cairo's existing order while moving its orchestration owner."""
+        scene = self.scene
+        renderer = cast("CairoRenderer", self.renderer)
+        renderer._ensure_open()
+        self.skip_animations = renderer._original_skipping_status
+        self._update_skipping_status()
+        scene.compile_animation_data(*args, **kwargs)
+
+        if self.skip_animations:
+            logger.debug(f"Skipping animation {self.num_plays}")
+            hash_current_animation = None
+            self.time += scene.duration
+        else:
+            if config["disable_caching"]:
+                logger.info("Caching disabled.")
+                hash_current_animation = f"uncached_{self.num_plays:05}"
+            else:
+                assert scene.animations is not None
+                hash_current_animation = get_hash_from_play_call(
+                    scene,
+                    self.camera,
+                    scene.animations,
+                    scene.mobjects,
+                    backend="cairo",
+                    encoder_fingerprint=video_encoder_fingerprint(
+                        self.session_spec.video_encoder
+                    ),
+                    renderer_state=(),
+                )
+                if self.file_writer.is_already_cached(hash_current_animation):
+                    logger.info(
+                        f"Animation {self.num_plays} : Using cached data (hash : %(hash_current_animation)s)",
+                        {"hash_current_animation": hash_current_animation},
+                    )
+                    self.skip_animations = True
+                    self.time += scene.duration
+        self.file_writer.add_partial_movie_file(hash_current_animation)
+        renderer.animations_hashes.append(hash_current_animation)
+        logger.debug(
+            "List of the first few animation hashes of the scene: %(h)s",
+            {"h": str(renderer.animations_hashes[:5])},
+        )
+        self.file_writer.begin_animation(
+            not self.skip_animations, animation_index=self.num_plays
+        )
+        scene.begin_animations()
+        renderer.save_static_frame_data(scene, scene.static_mobjects)
+        if scene.is_current_animation_frozen_frame():
+            renderer.update_frame(scene, mobjects=scene.moving_mobjects)
+            frame = renderer.get_frame()
+            repeats = int(scene.duration * renderer._frame_rate)
+            if not self.skip_animations:
+                self.time += repeats / renderer._frame_rate
+                self.file_writer.write_frame(frame, repeat=repeats)
+        else:
+            scene.play_internal()
+        self.file_writer.end_animation(not self.skip_animations)
+        self.num_plays += 1
+
+    def _play_opengl(
+        self, *args: Animation | Mobject | _AnimationBuilder, **kwargs: Any
+    ) -> None:
+        """Keep the former decorator/body ordering, including double compilation."""
+        scene = self.scene
+        renderer = cast("OpenGLRenderer", self.renderer)
+        self.skip_animations = renderer._original_skipping_status
+        self._update_skipping_status()
+        animations = scene.compile_animations(*args, **kwargs)
+        scene.add_mobjects_from_animations(animations)
+        skipped_at_entry = self.skip_animations
+        if skipped_at_entry:
+            logger.debug(f"Skipping animation {self.num_plays}")
+        else:
+            if not config["disable_caching"]:
+                hash_play = get_hash_from_play_call(
+                    scene,
+                    self.camera,
+                    animations,
+                    scene.mobjects,
+                    backend="opengl",
+                    encoder_fingerprint=video_encoder_fingerprint(
+                        self.session_spec.video_encoder
+                    ),
+                    renderer_state={
+                        "meshes": scene.meshes,
+                        "background_color": renderer.background_color,
+                        "anti_alias_width": renderer.anti_alias_width,
+                    },
+                )
+                if self.file_writer.is_already_cached(hash_play):
+                    logger.info(
+                        f"Animation {self.num_plays} : Using cached data (hash : %(hash_play)s)",
+                        {"hash_play": hash_play},
+                    )
+                    self.skip_animations = True
+            else:
+                hash_play = f"uncached_{self.num_plays:05}"
+            renderer.animations_hashes.append(hash_play)
+            self.file_writer.add_partial_movie_file(hash_play)
+            logger.debug(
+                "List of the first few animation hashes of the scene: %(h)s",
+                {"h": str(renderer.animations_hashes[:5])},
+            )
+
+        renderer.open()
+        renderer.animation_start_time = time.time()
+        self.file_writer.begin_animation(
+            not self.skip_animations, animation_index=self.num_plays
+        )
+        scene.compile_animation_data(*args, **kwargs)
+        scene.begin_animations()
+        if scene.is_current_animation_frozen_frame():
+            renderer.update_frame(scene)
+            output = self.file_writer.output_spec
+            if not self.skip_animations and (
+                output.is_video or output.is_image_sequence
+            ):
+                self.file_writer.write_frame(
+                    renderer.get_frame(),
+                    repeat=int(config.frame_rate * scene.duration),
+                )
+            if renderer.window is not None:
+                renderer.window.swap_buffers()
+                while time.time() - renderer.animation_start_time < scene.duration:
+                    pass
+            renderer.animation_elapsed_time = scene.duration
+        else:
+            scene.play_internal()
+        self.file_writer.end_animation(not self.skip_animations)
+        self.time += scene.duration
+        self.num_plays += 1
+        if skipped_at_entry:
+            renderer.animations_hashes.append(None)
+            self.file_writer.add_partial_movie_file(None)
+
+    def _play_internal(self, skip_rendering: bool = False) -> None:
+        """Own the existing sample loop without changing its callback order."""
+        from .renderer.cairo.renderer import CairoRenderer
+
+        scene = self.scene
+        assert scene.animations is not None
+        scene.duration = scene.get_run_time(scene.animations)
+        scene.time_progression = scene._get_animation_time_progression(
+            scene.animations,
+            scene.duration,
+        )
+        for t in scene.time_progression:
+            scene.update_to_time(t)
+            draw = not skip_rendering and not scene.skip_animation_preview
+            frame = self._draw_animation_frame(t) if draw else None
+            # Preserve the characterized backend timing in this ownership move.
+            # Cairo advances per sample; OpenGL's legacy event-end advance is in
+            # _play_opengl. Neither advance is owned by pixel delivery anymore.
+            if isinstance(self.renderer, CairoRenderer) and not self.skip_animations:
+                self.time += 1 / self.renderer._frame_rate
+            if draw:
+                self._deliver_animation_frame(frame, t)
+            if scene.stop_condition is not None and scene.stop_condition():
+                scene.time_progression.close()
+                break
+        for animation in scene.animations:
+            animation.finish()
+            animation.clean_up_from_scene(scene)
+        if not self.skip_animations:
+            scene.update_mobjects(0)
+        self.renderer.static_image = None  # type: ignore[union-attr]
+        scene.time_progression.close()
+
+    def _draw_animation_frame(self, frame_offset: float) -> RGBAPixelArray | None:
+        from .renderer.cairo.renderer import CairoRenderer
+
+        self.renderer.render(self.scene, frame_offset, self.scene.moving_mobjects)
+        if isinstance(self.renderer, CairoRenderer) or (
+            not self.skip_animations
+            and (
+                self.file_writer.output_spec.is_video
+                or self.file_writer.output_spec.is_image_sequence
+            )
+        ):
+            return self.renderer.get_frame()
+        return None
+
+    def _deliver_animation_frame(
+        self, frame: RGBAPixelArray | None, frame_offset: float
+    ) -> None:
+        from .renderer.opengl.renderer import OpenGLRenderer
+
+        if self.skip_animations:
+            return
+        if frame is not None:
+            self.file_writer.write_frame(frame)
+        if isinstance(self.renderer, OpenGLRenderer):
+            self.renderer._present_frame(self.scene, frame_offset)
+
+    def _legacy_add_frame(self, frame: RGBAPixelArray, num_frames: int = 1) -> None:
+        """Compatibility for explicit Cairo add_frame calls, not evaluation."""
+        renderer = cast("CairoRenderer", self.renderer)
+        renderer._ensure_open()
+        if not self.skip_animations:
+            self.time += num_frames / renderer._frame_rate
+            self.file_writer.write_frame(frame, repeat=num_frames)
 
     def next_section(
         self,

--- a/manim/renderer/_execution.py
+++ b/manim/renderer/_execution.py
@@ -1,0 +1,87 @@
+"""Legacy renderer views of Manager-owned execution state.
+
+An unclaimed renderer retains bootstrap values for constructor compatibility. Once a
+Manager claims them, only that Manager stores the live state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from manim.manager import Manager
+
+
+@dataclass
+class _ExecutionState:
+    time: float = 0.0
+    num_plays: int = 0
+    skip_animations: bool = False
+    original_skipping_status: bool = False
+    animations_hashes: list[str | None] = field(default_factory=list)
+
+
+class _RendererExecutionView:
+    """Compatibility properties, not a second execution owner or scheduler."""
+
+    def _initialize_execution(self, skip_animations: bool) -> None:
+        self._execution_owner: Manager | None = None
+        self._pending_execution: _ExecutionState | None = _ExecutionState(
+            skip_animations=skip_animations,
+            original_skipping_status=skip_animations,
+        )
+
+    @property
+    def _execution_state(self) -> _ExecutionState:
+        if self._execution_owner is not None:
+            return self._execution_owner._execution
+        assert self._pending_execution is not None
+        return self._pending_execution
+
+    def _claim_execution(self, manager: Manager) -> _ExecutionState:
+        assert self._execution_owner is None
+        state = self._execution_state
+        self._execution_owner = manager
+        self._pending_execution = None
+        return state
+
+    @property
+    def time(self) -> float:
+        return self._execution_state.time
+
+    @time.setter
+    def time(self, value: float) -> None:
+        self._execution_state.time = value
+
+    @property
+    def num_plays(self) -> int:
+        return self._execution_state.num_plays
+
+    @num_plays.setter
+    def num_plays(self, value: int) -> None:
+        self._execution_state.num_plays = value
+
+    @property
+    def skip_animations(self) -> bool:
+        return self._execution_state.skip_animations
+
+    @skip_animations.setter
+    def skip_animations(self, value: bool) -> None:
+        self._execution_state.skip_animations = value
+
+    @property
+    def _original_skipping_status(self) -> bool:
+        return self._execution_state.original_skipping_status
+
+    @_original_skipping_status.setter
+    def _original_skipping_status(self, value: bool) -> None:
+        self._execution_state.original_skipping_status = value
+
+    @property
+    def animations_hashes(self) -> list[str | None]:
+        return self._execution_state.animations_hashes
+
+    @animations_hashes.setter
+    def animations_hashes(self, value: list[str | None]) -> None:
+        self._execution_state.animations_hashes = value

--- a/manim/renderer/_execution.py
+++ b/manim/renderer/_execution.py
@@ -1,7 +1,8 @@
-"""Legacy renderer views of Manager-owned execution state.
+"""Renderer accessors for the animation clock and play state.
 
-An unclaimed renderer retains bootstrap values for constructor compatibility. Once a
-Manager claims them, only that Manager stores the live state.
+Before a manager is attached, the renderer stores the initial values. The manager
+takes over that state object; renderer properties then read and update it through
+the manager.
 """
 
 from __future__ import annotations
@@ -15,6 +16,8 @@ if TYPE_CHECKING:
 
 @dataclass
 class _ExecutionState:
+    """Animation clock, counters, and cache/skip state for one scene."""
+
     time: float = 0.0
     num_plays: int = 0
     skip_animations: bool = False
@@ -23,7 +26,7 @@ class _ExecutionState:
 
 
 class _RendererExecutionView:
-    """Compatibility properties, not a second execution owner or scheduler."""
+    """Keep renderer properties working with the manager's playback state."""
 
     def _initialize_execution(self, skip_animations: bool) -> None:
         self._execution_owner: Manager | None = None

--- a/manim/renderer/cairo/renderer.py
+++ b/manim/renderer/cairo/renderer.py
@@ -96,7 +96,7 @@ class CairoRenderer(_RendererExecutionView):
         *args: Animation | Mobject | _AnimationBuilder,
         **kwargs: Any,
     ) -> None:
-        """Compatibility entrypoint; Manager owns animation orchestration."""
+        """Delegate playback to the scene's manager; prefer Scene.play for new code."""
         scene._get_manager()._play(*args, **kwargs)
 
     def _animation_cache_identity(self, scene: Scene) -> tuple[str, Any]:
@@ -281,7 +281,7 @@ class CairoRenderer(_RendererExecutionView):
     ) -> None:
         if self._render_all_mobjects:
             moving_mobjects = None
-        # Drawing is separate from Manager-owned time advancement and delivery.
+        # Manager advances animation time and sends the pixels to the writer.
         self.update_frame(scene, moving_mobjects)
 
     def get_frame(self) -> RGBAPixelArray:

--- a/manim/renderer/cairo/renderer.py
+++ b/manim/renderer/cairo/renderer.py
@@ -292,6 +292,7 @@ class CairoRenderer(_RendererExecutionView):
         return Image.fromarray(self.get_frame())
 
     def add_frame(self, frame: RGBAPixelArray, num_frames: int = 1) -> None:
+        self._ensure_open()
         self._scene._get_manager()._legacy_add_frame(frame, num_frames)
 
     def freeze_current_frame(self, duration: float) -> None:

--- a/manim/renderer/cairo/renderer.py
+++ b/manim/renderer/cairo/renderer.py
@@ -52,7 +52,6 @@ class CairoRenderer(_RendererExecutionView):
         camera_cls = camera_class if camera_class is not None else Camera
         self.camera = camera if camera is not None else camera_cls()
         self._initialize_execution(skip_animations)
-        self._frame_rate = float(config["frame_rate"])
         self._raster_settings = _raster_settings or _CairoRasterSettings(
             pixel_width=int(config["pixel_width"]),
             pixel_height=int(config["pixel_height"]),
@@ -98,7 +97,22 @@ class CairoRenderer(_RendererExecutionView):
         **kwargs: Any,
     ) -> None:
         """Compatibility entrypoint; Manager owns animation orchestration."""
-        scene._get_manager()._play_cairo(*args, **kwargs)
+        scene._get_manager()._play(*args, **kwargs)
+
+    def _animation_cache_identity(self, scene: Scene) -> tuple[str, Any]:
+        return "cairo", ()
+
+    def _start_animation(self) -> None:
+        self._ensure_open()
+
+    def _prepare_animation(self, scene: Scene) -> None:
+        self.save_static_frame_data(scene, scene.static_mobjects)
+
+    def _present_frame(self, scene: Scene, frame_offset: float) -> None:
+        pass
+
+    def _present_frozen_frame(self, scene: Scene, duration: float) -> None:
+        pass
 
     def _sub_target_for(
         self,
@@ -298,7 +312,7 @@ class CairoRenderer(_RendererExecutionView):
     def freeze_current_frame(self, duration: float) -> None:
         self.add_frame(
             self.get_frame(),
-            num_frames=int(duration * self._frame_rate),
+            num_frames=int(duration * self._scene.session_spec.frame_rate),
         )
 
     def show_frame(self, scene: Scene) -> None:

--- a/manim/renderer/cairo/renderer.py
+++ b/manim/renderer/cairo/renderer.py
@@ -5,15 +5,12 @@ from typing import TYPE_CHECKING, Any
 
 from PIL import Image
 
-from manim.utils.hashing import get_hash_from_play_call
-
-from ... import config, logger
-from ..._config.video_encoder import video_encoder_fingerprint
+from ... import config
 from ...mobject.mobject import Mobject, _AnimationBuilder
 from ...mobject.types.image_mobject import ImageMobjectFromCamera
 from ...scene.scene_file_writer import SceneFileWriter
-from ...utils.exceptions import EndSceneEarlyException
 from ...utils.iterables import list_update
+from .._execution import _RendererExecutionView
 from ..protocol import RendererCapabilities
 from .camera import Camera, MultiCamera
 from .rendering import _CairoDrawingContext
@@ -29,7 +26,7 @@ if TYPE_CHECKING:
 __all__ = ["CairoRenderer"]
 
 
-class CairoRenderer:
+class CairoRenderer(_RendererExecutionView):
     """A renderer using Cairo.
 
     The renderer draws the camera's view, including inset views, into image
@@ -54,11 +51,7 @@ class CairoRenderer:
         self._file_writer_class = file_writer_class
         camera_cls = camera_class if camera_class is not None else Camera
         self.camera = camera if camera is not None else camera_cls()
-        self._original_skipping_status = skip_animations
-        self.skip_animations = skip_animations
-        self.animations_hashes: list[str | None] = []
-        self.num_plays = 0
-        self.time = 0.0
+        self._initialize_execution(skip_animations)
         self._frame_rate = float(config["frame_rate"])
         self._raster_settings = _raster_settings or _CairoRasterSettings(
             pixel_width=int(config["pixel_width"]),
@@ -104,60 +97,8 @@ class CairoRenderer:
         *args: Animation | Mobject | _AnimationBuilder,
         **kwargs: Any,
     ) -> None:
-        self._ensure_open()
-        self.skip_animations = self._original_skipping_status
-        self.update_skipping_status()
-        scene.compile_animation_data(*args, **kwargs)
-
-        if self.skip_animations:
-            logger.debug(f"Skipping animation {self.num_plays}")
-            hash_current_animation = None
-            self.time += scene.duration
-        else:
-            if config["disable_caching"]:
-                logger.info("Caching disabled.")
-                hash_current_animation = f"uncached_{self.num_plays:05}"
-            else:
-                assert scene.animations is not None
-                hash_current_animation = get_hash_from_play_call(
-                    scene,
-                    self.camera,
-                    scene.animations,
-                    scene.mobjects,
-                    backend="cairo",
-                    encoder_fingerprint=video_encoder_fingerprint(
-                        scene.session_spec.video_encoder,
-                    ),
-                    renderer_state=(),
-                )
-                if self.file_writer.is_already_cached(hash_current_animation):
-                    logger.info(
-                        f"Animation {self.num_plays} : Using cached data (hash : %(hash_current_animation)s)",
-                        {"hash_current_animation": hash_current_animation},
-                    )
-                    self.skip_animations = True
-                    self.time += scene.duration
-        self.file_writer.add_partial_movie_file(hash_current_animation)
-        self.animations_hashes.append(hash_current_animation)
-        logger.debug(
-            "List of the first few animation hashes of the scene: %(h)s",
-            {"h": str(self.animations_hashes[:5])},
-        )
-
-        self.file_writer.begin_animation(
-            not self.skip_animations,
-            animation_index=self.num_plays,
-        )
-        scene.begin_animations()
-        self.save_static_frame_data(scene, scene.static_mobjects)
-
-        if scene.is_current_animation_frozen_frame():
-            self.update_frame(scene, mobjects=scene.moving_mobjects)
-            self.freeze_current_frame(scene.duration)
-        else:
-            scene.play_internal()
-        self.file_writer.end_animation(not self.skip_animations)
-        self.num_plays += 1
+        """Compatibility entrypoint; Manager owns animation orchestration."""
+        scene._get_manager()._play_cairo(*args, **kwargs)
 
     def _sub_target_for(
         self,
@@ -326,8 +267,8 @@ class CairoRenderer:
     ) -> None:
         if self._render_all_mobjects:
             moving_mobjects = None
+        # Drawing is separate from Manager-owned time advancement and delivery.
         self.update_frame(scene, moving_mobjects)
-        self.add_frame(self.get_frame())
 
     def get_frame(self) -> RGBAPixelArray:
         """Copy the current image to an RGBA array, with row zero at the top."""
@@ -351,11 +292,7 @@ class CairoRenderer:
         return Image.fromarray(self.get_frame())
 
     def add_frame(self, frame: RGBAPixelArray, num_frames: int = 1) -> None:
-        self._ensure_open()
-        if self.skip_animations:
-            return
-        self.time += num_frames / self._frame_rate
-        self.file_writer.write_frame(frame, repeat=num_frames)
+        self._scene._get_manager()._legacy_add_frame(frame, num_frames)
 
     def freeze_current_frame(self, duration: float) -> None:
         self.add_frame(
@@ -387,21 +324,7 @@ class CairoRenderer:
         return self.static_image
 
     def update_skipping_status(self) -> None:
-        if self.file_writer.sections[-1].skip_animations:
-            self.skip_animations = True
-        if self.file_writer.output_spec.is_still:
-            self.skip_animations = True
-        if (
-            config.from_animation_number > 0
-            and self.num_plays < config.from_animation_number
-        ):
-            self.skip_animations = True
-        if (
-            config.upto_animation_number >= 0
-            and self.num_plays > config.upto_animation_number
-        ):
-            self.skip_animations = True
-            raise EndSceneEarlyException()
+        self._scene._get_manager()._update_skipping_status()
 
     def scene_finished(self, scene: Scene) -> None:
         self._ensure_open()

--- a/manim/renderer/opengl/renderer.py
+++ b/manim/renderer/opengl/renderer.py
@@ -609,7 +609,28 @@ class OpenGLRenderer(_RendererExecutionView):
         **kwargs Any
             Additional keyword arguments to pass to the animation compilation.
         """
-        scene._get_manager()._play_opengl(*animations, **kwargs)
+        scene._get_manager()._play(*animations, **kwargs)
+
+    def _animation_cache_identity(self, scene: Scene) -> tuple[str, Any]:
+        return "opengl", {
+            "meshes": scene.meshes,
+            "background_color": self.background_color,
+            "anti_alias_width": self.anti_alias_width,
+        }
+
+    def _start_animation(self) -> None:
+        self.open()
+        self.animation_start_time = time.time()
+
+    def _prepare_animation(self, scene: Scene) -> None:
+        pass
+
+    def _present_frozen_frame(self, scene: Scene, duration: float) -> None:
+        if self.window is not None:
+            self.window.swap_buffers()
+            while time.time() - self.animation_start_time < duration:
+                pass
+        self.animation_elapsed_time = duration
 
     def clear_screen(self) -> None:
         """

--- a/manim/renderer/opengl/renderer.py
+++ b/manim/renderer/opengl/renderer.py
@@ -573,13 +573,7 @@ class OpenGLRenderer(_RendererExecutionView):
         return tid
 
     def update_skipping_status(self) -> None:
-        """
-        Check and update the skipping status for the current animation
-        (self.skip_animations flag) based on the configuration settings.
-
-        Parameters
-        ----------
-        None
+        """Ask the scene's manager whether this play should be fast-forwarded.
 
         Raises
         ------
@@ -594,20 +588,19 @@ class OpenGLRenderer(_RendererExecutionView):
         *animations: Animation | Mobject | _AnimationBuilder,
         **kwargs: Any,
     ) -> None:
-        """
-        Compatibility entrypoint for Manager-owned OpenGL playback.
+        """Delegate animation playback to the scene's manager.
 
-        Compilation, selection, state advancement and output orchestration now
-        belong to Manager; this method delegates to its legacy-compatible path.
+        Prefer :meth:`.Scene.play` for new code; it also handles subcaptions and
+        calls made from another thread during OpenGL interaction.
 
         Parameters
         ----------
-        scene Scene
+        scene
             The scene in which to play the animations.
-        *animations Animation | Mobject | _AnimationBuilder
+        animations
             The animations, mobjects, or animation builders to play.
-        **kwargs Any
-            Additional keyword arguments to pass to the animation compilation.
+        kwargs
+            Animation options such as ``run_time`` and ``rate_func``.
         """
         scene._get_manager()._play(*animations, **kwargs)
 
@@ -648,31 +641,29 @@ class OpenGLRenderer(_RendererExecutionView):
     def render(
         self, scene: Scene, frame_offset: float, moving_mobjects: list[Mobject]
     ) -> None:
-        """
-        Renders a single frame of the given scene using OpenGL.
+        """Draw a single frame of the scene's current state using OpenGL.
 
         Parameters
         ----------
-        scene : Scene
-            The scene to render.
-        frame_offset : float
-            The time offset for the current frame in seconds. If no window is present,
-            this parameter is ignored, and a frame is a true snapshot of
-            the scene at the current time.
-        moving_mobjects : list[Mobject]
-            List of mobjects that are currently moving and need to be updated.
-            Not used at all, kept for compatibility with other renderers.
+        scene
+            The scene to draw.
+        frame_offset
+            Animation-relative time in seconds. Accepted for the common renderer
+            interface; drawing itself does not use this value.
+        moving_mobjects
+            Accepted for the common renderer interface. OpenGL draws the full
+            scene rather than using Cairo's moving/static split.
 
         Notes
         -----
-        Draws the current scene. Manager owns output delivery and invokes legacy
-        native presentation separately after securing any requested frame pixels.
-        Drawing does not advance the semantic clock.
+        This method draws into the framebuffer. The manager reads any pixels
+        needed for output and displays the preview window separately. Drawing
+        alone neither writes frames nor advances ``Scene.time``.
         """
         self.update_frame(scene)
 
     def _present_frame(self, scene: Scene, frame_offset: float) -> None:
-        """Legacy native pacing, invoked after Manager has secured output pixels."""
+        """Refresh the preview window until wall-clock time reaches the frame offset."""
         if self.window is not None:
             self.window.swap_buffers()
             while self.animation_elapsed_time < frame_offset:
@@ -688,7 +679,7 @@ class OpenGLRenderer(_RendererExecutionView):
         2. Refresh camera perspective uniforms for rendering.
         3. Iterate through all mobjects in the scene, rendering those marked for display.
         4. Iterate through all mesh objects in the scene, setting their uniforms and rendering them.
-        5. Update the elapsed animation time.
+        5. Update the wall-clock time used to pace the preview window.
 
         Parameters
         ----------

--- a/manim/renderer/opengl/renderer.py
+++ b/manim/renderer/opengl/renderer.py
@@ -19,12 +19,11 @@ from manim.mobject.opengl.opengl_mobject import (
 )
 from manim.mobject.opengl.opengl_vectorized_mobject import OpenGLVMobject
 from manim.typing import Point3D
-from manim.utils.caching import handle_caching_play
 from manim.utils.color import color_to_rgba
-from manim.utils.exceptions import EndSceneEarlyException
 
 from ...constants import *
 from ...scene.scene_file_writer import SceneFileWriter
+from .._execution import _RendererExecutionView
 from ..protocol import RendererCapabilities
 from .shader import Mesh, Shader, shader_program_cache
 from .vectorized_mobject_rendering import (
@@ -56,7 +55,7 @@ __all__ = ["OpenGLRenderer"]
 _active_context = threading.local()
 
 
-class OpenGLRenderer:
+class OpenGLRenderer(_RendererExecutionView):
     """
     An OpenGL-based renderer.
 
@@ -108,13 +107,9 @@ class OpenGLRenderer:
         self.anti_alias_width = 1.5
         self._file_writer_class = file_writer_class
 
-        self._original_skipping_status = skip_animations
-        self.skip_animations = skip_animations
+        self._initialize_execution(skip_animations)
         self.animation_start_time = 0.0
         self.animation_elapsed_time = 0.0
-        self.time = 0.0
-        self.animations_hashes: list[str | None] = []
-        self.num_plays = 0
 
         self.camera = OpenGLCamera()
         self.pressed_keys: set[int] = set()
@@ -591,24 +586,8 @@ class OpenGLRenderer:
         EndSceneEarlyException
             If the number of played animations exceeds the configured upper bound.
         """
-        # there is always at least one section -> no out of bounds here
-        if self.file_writer.sections[-1].skip_animations:
-            self.skip_animations = True
-        if self.file_writer.output_spec.is_still:
-            self.skip_animations = True
-        if (
-            config.from_animation_number > 0
-            and self.num_plays < config.from_animation_number
-        ):
-            self.skip_animations = True
-        if (
-            config.upto_animation_number >= 0
-            and self.num_plays > config.upto_animation_number
-        ):
-            self.skip_animations = True
-            raise EndSceneEarlyException()
+        self.scene._get_manager()._update_skipping_status()
 
-    @handle_caching_play
     def play(
         self,
         scene: Scene,
@@ -616,11 +595,10 @@ class OpenGLRenderer:
         **kwargs: Any,
     ) -> None:
         """
-        Plays the given animations or mobjects in the specified scene.
+        Compatibility entrypoint for Manager-owned OpenGL playback.
 
-        "Playing" here refers to the process of compiling animation data,
-        beginning the animations, updating frames, and finalizing the animation
-        in the context of the renderer.
+        Compilation, selection, state advancement and output orchestration now
+        belong to Manager; this method delegates to its legacy-compatible path.
 
         Parameters
         ----------
@@ -631,40 +609,7 @@ class OpenGLRenderer:
         **kwargs Any
             Additional keyword arguments to pass to the animation compilation.
         """
-        self.open()
-        # TODO: Handle data locking / unlocking.
-        self.animation_start_time = time.time()
-        self.file_writer.begin_animation(
-            not self.skip_animations,
-            animation_index=self.num_plays,
-        )
-
-        scene.compile_animation_data(*animations, **kwargs)
-        scene.begin_animations()
-        if scene.is_current_animation_frozen_frame():
-            self.update_frame(scene)
-
-            output = self.file_writer.output_spec
-            if not self.skip_animations and (
-                output.is_video or output.is_image_sequence
-            ):
-                self.file_writer.write_frame(
-                    self.get_frame(),
-                    repeat=int(config.frame_rate * scene.duration),
-                )
-
-            if self.window is not None:
-                self.window.swap_buffers()
-                while time.time() - self.animation_start_time < scene.duration:
-                    pass
-            self.animation_elapsed_time = scene.duration
-
-        else:
-            scene.play_internal()
-
-        self.file_writer.end_animation(not self.skip_animations)
-        self.time += scene.duration
-        self.num_plays += 1
+        scene._get_manager()._play_opengl(*animations, **kwargs)
 
     def clear_screen(self) -> None:
         """
@@ -699,21 +644,14 @@ class OpenGLRenderer:
 
         Notes
         -----
-        - Updates the frame for the scene.
-        - If animations are skipped, the method returns early.
-        - Writes the current frame using the file writer.
-        - If a window is present, swaps buffers and continues
-          updating frames until the animation elapsed time reaches the frame offset.
+        Draws the current scene. Manager owns output delivery and invokes legacy
+        native presentation separately after securing any requested frame pixels.
+        Drawing does not advance the semantic clock.
         """
         self.update_frame(scene)
 
-        if self.skip_animations:
-            return
-
-        output = self.file_writer.output_spec
-        if output.is_video or output.is_image_sequence:
-            self.file_writer.write_frame(self.get_frame())
-
+    def _present_frame(self, scene: Scene, frame_offset: float) -> None:
+        """Legacy native pacing, invoked after Manager has secured output pixels."""
         if self.window is not None:
             self.window.swap_buffers()
             while self.animation_elapsed_time < frame_offset:

--- a/manim/renderer/protocol.py
+++ b/manim/renderer/protocol.py
@@ -1,10 +1,16 @@
-"""Shared renderer feature declarations."""
+"""Shared renderer features and the narrow animation drawing boundary."""
 
 from __future__ import annotations
 
-__all__ = ["RendererCapabilities"]
-
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from manim.mobject.mobject import Mobject
+    from manim.scene.scene import Scene
+    from manim.typing import RGBAPixelArray
+
+__all__ = ["RendererCapabilities"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -12,3 +18,27 @@ class RendererCapabilities:
     """Optional session features implemented by a renderer."""
 
     live_preview: bool = False
+
+
+class _AnimationRenderer(Protocol):
+    """Drawing/presentation operations, never compilation, selection or clock ticks.
+
+    Kept private during the render-flow migration. The native backend owns wall
+    pacing; Manager owns when these operations are requested and any output delivery.
+    """
+
+    def _animation_cache_identity(self, scene: Scene) -> tuple[str, Any]: ...
+
+    def _start_animation(self) -> None: ...
+
+    def _prepare_animation(self, scene: Scene) -> None: ...
+
+    def render(
+        self, scene: Scene, frame_offset: float, moving_mobjects: list[Mobject], /
+    ) -> None: ...
+
+    def get_frame(self) -> RGBAPixelArray: ...
+
+    def _present_frame(self, scene: Scene, frame_offset: float) -> None: ...
+
+    def _present_frozen_frame(self, scene: Scene, duration: float) -> None: ...

--- a/manim/renderer/protocol.py
+++ b/manim/renderer/protocol.py
@@ -1,4 +1,4 @@
-"""Shared renderer features and the narrow animation drawing boundary."""
+"""Renderer capabilities and drawing methods used by Manager."""
 
 from __future__ import annotations
 
@@ -21,10 +21,11 @@ class RendererCapabilities:
 
 
 class _AnimationRenderer(Protocol):
-    """Drawing/presentation operations, never compilation, selection or clock ticks.
+    """Draw frames and display them in a preview window at Manager's request.
 
-    Kept private during the render-flow migration. The native backend owns wall
-    pacing; Manager owns when these operations are requested and any output delivery.
+    Manager prepares animations, checks the cache, advances animation time, and
+    sends frames to the writer. The renderer prepares its drawing resources and
+    uses wall-clock time to pace its live preview.
     """
 
     def _animation_cache_identity(self, scene: Scene) -> tuple[str, Any]: ...

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -30,6 +30,7 @@ except ImportError:
     dearpygui_imported = False
 
 from collections.abc import Callable, Iterable, Sequence
+from types import FrameType
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -68,7 +69,6 @@ from ..utils.iterables import list_difference_update, list_update
 from ..utils.module_ops import scene_classes_from_file
 
 if TYPE_CHECKING:
-    from types import FrameType
     from typing import Self, TypeAlias
 
     from PIL.Image import Image
@@ -1607,7 +1607,7 @@ class Scene:
                 self.renderer.animation_start_time = 0
                 dt = time.time() - last_time
                 last_time = time.time()
-                self.renderer.render(self, dt, self.moving_mobjects)
+                self._get_manager()._render_preview_frame(dt)
                 self.update_mobjects(dt)
                 self.update_meshes(dt)
                 self.update_self(dt)
@@ -1639,7 +1639,7 @@ class Scene:
             return
 
         self.renderer.animation_start_time = 0
-        self.renderer.render(self, -1, self.moving_mobjects)
+        self._get_manager()._render_preview_frame(-1)
 
         # Configure IPython shell.
         from IPython.terminal.embed import InteractiveShellEmbed
@@ -1649,7 +1649,7 @@ class Scene:
         # Have the frame update after each command
         shell.events.register(
             "post_run_cell",
-            lambda *a, **kw: self.renderer.render(self, -1, self.moving_mobjects),
+            lambda *a, **kw: self._get_manager()._render_preview_frame(-1),
         )
 
         # Use the locals of the caller as the local namespace

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -291,7 +291,7 @@ class Scene:
 
     @property
     def time(self) -> float:
-        """The time since the start of the managed execution."""
+        """Elapsed animation time in seconds, as reported by the scene's manager."""
         if self.manager is not None:
             return self.manager.time
         return self.renderer.time
@@ -1304,10 +1304,11 @@ class Scene:
         duration
             The run time of the animation.
         stop_condition
-            A function without positional arguments that is evaluated every time
-            a frame is rendered. The animation only stops when the return value
-            of the function is truthy, or when the time specified in ``duration``
-            passes.
+            A function without positional arguments, evaluated after each animation
+            step. During normal playback, ``self.time`` then includes that step's
+            frame interval.
+            The wait ends when the function returns a truthy value or the requested
+            duration is reached.
         frozen_frame
             If True, updater functions are not evaluated, and the animation outputs
             a frozen frame. If False, updater functions are called and frames
@@ -1316,7 +1317,7 @@ class Scene:
 
         See also
         --------
-        :class:`.Wait`, :meth:`.should_mobjects_update`
+        :class:`.Wait`, :meth:`.should_update_mobjects`
         """
         duration = self.validate_run_time(duration, self.wait, "duration")
         self.play(
@@ -1366,10 +1367,10 @@ class Scene:
         *animations: Animation | Mobject | _AnimationBuilder,
         **play_kwargs: Any,
     ) -> Self | None:
-        """Given a list of animations, compile the corresponding
-        static and moving mobjects, and gather the animation durations.
+        """Prepare animations, their run time, and frozen-wait status for a play call.
 
-        This also begins the animations.
+        The manager starts the prepared animations afterward via
+        :meth:`begin_animations`.
 
         Parameters
         ----------
@@ -1382,10 +1383,8 @@ class Scene:
         Returns
         -------
         self, None
-            None if there is nothing to play, or self otherwise.
+            This scene, or ``None`` for a frozen wait.
         """
-        # NOTE TODO : returns statement of this method are wrong. It should return nothing, as it makes a little sense to get any information from this method.
-        # The return are kept to keep webgl renderer from breaking.
         if len(animations) == 0:
             raise ValueError("Called Scene.play with no animations")
 
@@ -1403,7 +1402,7 @@ class Scene:
                 self.update_mobjects(dt=0)  # Any problems with this?
                 self.stop_condition = self.animations[0].stop_condition
             else:
-                # Static image logic when the wait is static is done by the renderer, not here.
+                # Manager will draw one frame and repeat it for this wait.
                 self.animations[0].is_static_wait = True
                 return None
 
@@ -1417,8 +1416,7 @@ class Scene:
             animation.begin()
 
         if config.renderer == RendererType.CAIRO:
-            # Paint all non-moving objects onto the screen, so they don't
-            # have to be rendered every frame
+            # Identify mobjects whose pixels can be reused between frames.
             (
                 self.moving_mobjects,
                 self.static_mobjects,

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -1433,19 +1433,6 @@ class Scene:
             and self.animations[0].is_static_wait
         )
 
-    def play_internal(self, skip_rendering: bool = False) -> None:
-        """
-        This method is used to prep the animations for rendering,
-        apply the arguments and parameters required to them,
-        render them, and write them to the video file.
-
-        Parameters
-        ----------
-        skip_rendering
-            Whether the rendering should be skipped, by default False
-        """
-        self._get_manager()._play_internal(skip_rendering=skip_rendering)
-
     def check_interactive_embed_is_valid(self) -> bool:
         assert isinstance(self.renderer, OpenGLRenderer)
         if self.skip_animation_preview:

--- a/manim/scene/scene.py
+++ b/manim/scene/scene.py
@@ -291,7 +291,9 @@ class Scene:
 
     @property
     def time(self) -> float:
-        """The time since the start of the scene."""
+        """The time since the start of the managed execution."""
+        if self.manager is not None:
+            return self.manager.time
         return self.renderer.time
 
     def __deepcopy__(self, clone_from_id: dict[int, Any]) -> Scene:
@@ -1442,29 +1444,7 @@ class Scene:
         skip_rendering
             Whether the rendering should be skipped, by default False
         """
-        assert self.animations is not None
-        self.duration = self.get_run_time(self.animations)
-        self.time_progression = self._get_animation_time_progression(
-            self.animations,
-            self.duration,
-        )
-        for t in self.time_progression:
-            self.update_to_time(t)
-            if not skip_rendering and not self.skip_animation_preview:
-                self.renderer.render(self, t, self.moving_mobjects)
-            if self.stop_condition is not None and self.stop_condition():
-                self.time_progression.close()
-                break
-
-        for animation in self.animations:
-            animation.finish()
-            animation.clean_up_from_scene(self)
-        if not self.renderer.skip_animations:
-            self.update_mobjects(0)
-        # TODO: The OpenGLRenderer does not have the property static.image.
-        self.renderer.static_image = None  # type: ignore[union-attr]
-        # Closing the progress bar at the end of the play.
-        self.time_progression.close()
+        self._get_manager()._play_internal(skip_rendering=skip_rendering)
 
     def check_interactive_embed_is_valid(self) -> bool:
         assert isinstance(self.renderer, OpenGLRenderer)

--- a/manim/utils/caching.py
+++ b/manim/utils/caching.py
@@ -1,16 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
 
-from .. import config, logger
-from .._config.video_encoder import video_encoder_fingerprint
-from ..utils.hashing import get_hash_from_play_call
+from .. import logger
 
 __all__ = [
     "clear_segment_cache",
-    "handle_caching_play",
     "prune_segment_cache",
 ]
 
@@ -76,77 +71,3 @@ def clear_segment_cache(directory: Path) -> int:
             continue
         removed += 1
     return removed
-
-
-if TYPE_CHECKING:
-    from manim.renderer.opengl import OpenGLRenderer
-    from manim.scene.scene import Scene
-
-
-def handle_caching_play(func: Callable[..., None]) -> Callable[..., None]:
-    """Decorator that returns a wrapped version of func that will compute
-    the hash of the play invocation.
-
-    The returned function will act according to the computed hash: either skip
-    the animation because it's already cached, or let the invoked function
-    play normally.
-
-    Parameters
-    ----------
-    func
-        The play like function that has to be written to the video file stream.
-        Take the same parameters as `scene.play`.
-    """
-    # NOTE : This is only kept for OpenGL renderer.
-    # The play logic of the cairo renderer as been refactored and does not need this function anymore.
-    # When OpenGL renderer will have a proper testing system,
-    # the play logic of the latter has to be refactored in the same way the cairo renderer has been, and thus this
-    # method has to be deleted.
-
-    def wrapper(self: OpenGLRenderer, scene: Scene, *args: Any, **kwargs: Any) -> None:
-        self.skip_animations = self._original_skipping_status
-        self.update_skipping_status()
-        animations = scene.compile_animations(*args, **kwargs)
-        scene.add_mobjects_from_animations(animations)
-        if self.skip_animations:
-            logger.debug(f"Skipping animation {self.num_plays}")
-            func(self, scene, *args, **kwargs)
-            # If the animation is skipped, we mark its hash as None.
-            # When sceneFileWriter will start combining partial movie files, it won't take into account None hashes.
-            self.animations_hashes.append(None)
-            self.file_writer.add_partial_movie_file(None)
-            return
-        if not config["disable_caching"]:
-            mobjects_on_scene = scene.mobjects
-            hash_play = get_hash_from_play_call(
-                scene,
-                self.camera,
-                animations,
-                mobjects_on_scene,
-                backend="opengl",
-                encoder_fingerprint=video_encoder_fingerprint(
-                    scene.session_spec.video_encoder,
-                ),
-                renderer_state={
-                    "meshes": scene.meshes,
-                    "background_color": self.background_color,
-                    "anti_alias_width": self.anti_alias_width,
-                },
-            )
-            if self.file_writer.is_already_cached(hash_play):
-                logger.info(
-                    f"Animation {self.num_plays} : Using cached data (hash : %(hash_play)s)",
-                    {"hash_play": hash_play},
-                )
-                self.skip_animations = True
-        else:
-            hash_play = f"uncached_{self.num_plays:05}"
-        self.animations_hashes.append(hash_play)
-        self.file_writer.add_partial_movie_file(hash_play)
-        logger.debug(
-            "List of the first few animation hashes of the scene: %(h)s",
-            {"h": str(self.animations_hashes[:5])},
-        )
-        func(self, scene, *args, **kwargs)
-
-    return wrapper

--- a/manim/utils/testing/_test_class_makers.py
+++ b/manim/utils/testing/_test_class_makers.py
@@ -28,7 +28,9 @@ def _make_test_scene_class(
             # Manim hack to render the very last frame (normally the last frame is not the very end of the animation)
             if self.animations is not None:
                 self.update_to_time(self.get_run_time(self.animations))
-                self.renderer.render(self, 1, self.moving_mobjects)
+                manager = self._get_manager()
+                frame = manager._draw_animation_frame(1)
+                manager._deliver_animation_frame(frame, 1)
 
     return _TestedScene
 

--- a/tests/control_data/logs_data/BasicSceneLoggingTest.txt
+++ b/tests/control_data/logs_data/BasicSceneLoggingTest.txt
@@ -2,7 +2,7 @@
 {"levelname": "DEBUG", "module": "hashing", "message": "Hashing ..."}
 {"levelname": "DEBUG", "module": "hashing", "message": "Hashing done in <> s."}
 {"levelname": "DEBUG", "module": "hashing", "message": "Hash generated :  <>"}
-{"levelname": "DEBUG", "module": "renderer", "message": "List of the first few animation hashes of the scene: <>"}
+{"levelname": "DEBUG", "module": "manager", "message": "List of the first few animation hashes of the scene: <>"}
 {"levelname": "INFO", "module": "scene_file_writer", "message": "Animation 0 : Partial movie file written in <>"}
 {"levelname": "INFO", "module": "scene_file_writer", "message": "Combining to Movie file."}
 {"levelname": "DEBUG", "module": "scene_file_writer", "message": "Partial movie files to combine (1 files): <>"}

--- a/tests/module/mobject/test_graph.py
+++ b/tests/module/mobject/test_graph.py
@@ -137,10 +137,10 @@ def test_graph_accepts_labeledline_as_edge_type():
 
 def test_custom_animation_mobject_list():
     G = Graph([1, 2, 3], [(1, 2), (2, 3)])
-    scene = Scene()
-    scene.add(G)
-    assert scene.mobjects == [G]
     with tempconfig({"dry_run": True, "quality": "low_quality"}):
+        scene = Scene()
+        scene.add(G)
+        assert scene.mobjects == [G]
         scene.play(G.animate.add_vertices(4))
         assert str(G) == "Undirected graph on 4 vertices and 2 edges"
         assert scene.mobjects == [G]

--- a/tests/module/test_cairo_renderer_lifecycle.py
+++ b/tests/module/test_cairo_renderer_lifecycle.py
@@ -48,6 +48,8 @@ def test_skipped_drawing_and_close_do_not_allocate(target_factory):
         renderer.get_frame()
     with pytest.raises(RuntimeError, match="closed"):
         renderer.render_mobjects([])
+    with pytest.raises(RuntimeError, match="closed"):
+        renderer.add_frame(np.zeros((1, 1, 4), dtype=np.uint8))
     target_factory.assert_not_called()
 
 

--- a/tests/module/test_execution_ownership.py
+++ b/tests/module/test_execution_ownership.py
@@ -1,4 +1,4 @@
-"""Execution state and orchestration have one owner, independent of pixel delivery."""
+"""Manager controls playback and advances animation time independently of drawing."""
 
 from unittest.mock import Mock
 

--- a/tests/module/test_execution_ownership.py
+++ b/tests/module/test_execution_ownership.py
@@ -51,9 +51,41 @@ def test_manager_does_not_delegate_play_or_selection_to_backend(scene, monkeypat
     rejected = Mock(side_effect=AssertionError("backend executed policy"))
     monkeypatch.setattr(scene.renderer, "play", rejected)
     monkeypatch.setattr(scene.renderer, "update_skipping_status", rejected)
+    # Even an old subclass method with this name is no longer the execution seam.
+    monkeypatch.setattr(scene, "play_internal", rejected, raising=False)
     scene.play(Wait(1, frozen_frame=False))
     assert scene.manager.num_plays == 1
     rejected.assert_not_called()
+
+
+def test_late_manager_cannot_claim_a_rebound_renderers_state(scene):
+    old = Scene()
+    current = Scene(renderer=old.renderer)
+    try:
+        with pytest.raises(RuntimeError, match="renderer was rebound"):
+            Manager(old)
+        assert old.manager is None
+        with current._get_manager() as manager:
+            assert manager.time == 0
+    finally:
+        current.renderer.close()
+
+
+def test_closed_backend_rejected_before_output_startup(scene):
+    manager = scene._get_manager()
+    scene.renderer.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        scene.play(Wait(1, frozen_frame=False))
+    assert manager._file_writer is None
+
+
+def test_shared_play_compiles_once(scene, monkeypatch):
+    compile_data = Mock(wraps=scene.compile_animation_data)
+    compile_animations = Mock(wraps=scene.compile_animations)
+    monkeypatch.setattr(scene, "compile_animation_data", compile_data)
+    monkeypatch.setattr(scene, "compile_animations", compile_animations)
+    scene.play(Wait(1, frozen_frame=False))
+    assert compile_data.call_count == compile_animations.call_count == 1
 
 
 def test_clock_advances_when_drawing_and_delivery_are_stubbed(scene, monkeypatch):
@@ -114,8 +146,8 @@ def test_cached_play_advances_once_before_begin(scene, monkeypatch):
     monkeypatch.setattr(manager.file_writer, "is_already_cached", lambda _: True)
     with tempconfig({"disable_caching": False}):
         scene.play(Probe(Square(), run_time=0.3))
-    assert observed == [("begin", 2.3), ("finish", 2.3)]
-    assert manager.time == 2.3
+    assert observed == [("begin", 2.5), ("finish", 2.5)]
+    assert manager.time == 2.5
 
 
 def test_frozen_clock_does_not_depend_on_output_delivery(scene, monkeypatch):
@@ -128,12 +160,14 @@ def test_frozen_clock_does_not_depend_on_output_delivery(scene, monkeypatch):
     assert manager.time == 0.5
 
 
-def test_sample_clock_uses_progression_rate_not_raster_rate(scene):
-    # Progression already resolves the current config at play time. A stale
-    # Cairo raster rate must not make a 1s/8-sample play consume 2 semantic seconds.
+def test_changed_rate_is_rejected_before_execution(scene):
     with tempconfig({"frame_rate": 8}):
-        scene.wait(1, frozen_frame=False)
-    assert scene.time == 1
+        with pytest.raises(ValueError, match="frame_rate changed"):
+            scene.wait(1, frozen_frame=False)
+        with pytest.raises(ValueError, match="frame_rate changed"):
+            scene.render()
+    assert scene.time == 0
+    assert scene.manager._file_writer is None
 
 
 def test_skipped_stop_wait_keeps_legacy_nominal_span(scene):

--- a/tests/module/test_execution_ownership.py
+++ b/tests/module/test_execution_ownership.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from manim import Manager, Scene, Square, Wait, tempconfig
+from manim import Animation, Manager, Scene, Square, Wait, tempconfig
 
 
 @pytest.fixture(params=["cairo", "opengl"])
@@ -58,8 +58,10 @@ def test_manager_does_not_delegate_play_or_selection_to_backend(scene, monkeypat
 
 def test_clock_advances_when_drawing_and_delivery_are_stubbed(scene, monkeypatch):
     manager = scene._get_manager()
-    draw = Mock(return_value=None)
-    deliver = Mock()
+    draw_times = []
+    delivery_times = []
+    draw = Mock(side_effect=lambda _: draw_times.append(manager.time))
+    deliver = Mock(side_effect=lambda *_: delivery_times.append(manager.time))
     monkeypatch.setattr(manager, "_draw_animation_frame", draw)
     monkeypatch.setattr(manager, "_deliver_animation_frame", deliver)
     scene.play(Wait(1, frozen_frame=False))
@@ -67,6 +69,8 @@ def test_clock_advances_when_drawing_and_delivery_are_stubbed(scene, monkeypatch
     assert manager.num_plays == 1
     assert draw.call_count == 4
     assert deliver.call_count == 4
+    assert draw_times == [0, 0.25, 0.5, 0.75]
+    assert delivery_times == [0.25, 0.5, 0.75, 1]
 
 
 def test_raw_backend_drawing_does_not_advance_clock_or_write(scene, monkeypatch):
@@ -78,3 +82,70 @@ def test_raw_backend_drawing_does_not_advance_clock_or_write(scene, monkeypatch)
     scene.renderer.render(scene, 0, scene.mobjects)
     assert manager.time == 2
     write.assert_not_called()
+
+
+def test_stopped_clock_and_next_play_without_frame_delivery(scene, monkeypatch):
+    manager = scene._get_manager()
+    manager.time = 2
+    monkeypatch.setattr(manager, "_draw_animation_frame", Mock(return_value=None))
+    monkeypatch.setattr(manager, "_deliver_animation_frame", Mock())
+    scene.wait(1, stop_condition=lambda: scene.time >= 2.5)
+    assert manager.time == 2.5
+    scene.wait(0.3, frozen_frame=False)
+    assert manager.time == 3
+    assert manager.num_plays == 2
+
+
+def test_cached_play_advances_once_before_begin(scene, monkeypatch):
+    manager = scene._get_manager()
+    manager.time = 2
+    observed = []
+
+    class Probe(Animation):
+        def begin(self):
+            observed.append(("begin", scene.time))
+            super().begin()
+
+        def finish(self):
+            observed.append(("finish", scene.time))
+            super().finish()
+
+    monkeypatch.setattr("manim.manager.get_hash_from_play_call", lambda *a, **k: "hit")
+    monkeypatch.setattr(manager.file_writer, "is_already_cached", lambda _: True)
+    with tempconfig({"disable_caching": False}):
+        scene.play(Probe(Square(), run_time=0.3))
+    assert observed == [("begin", 2.3), ("finish", 2.3)]
+    assert manager.time == 2.3
+
+
+def test_frozen_clock_does_not_depend_on_output_delivery(scene, monkeypatch):
+    manager = scene._get_manager()
+    write = Mock()
+    monkeypatch.setattr(manager.file_writer, "write_frame", write)
+    with tempconfig({"format": "none"}):
+        scene.wait(0.3, frozen_frame=True)
+        scene.wait(0.3, frozen_frame=True)
+    assert manager.time == 0.5
+
+
+def test_sample_clock_uses_progression_rate_not_raster_rate(scene):
+    # Progression already resolves the current config at play time. A stale
+    # Cairo raster rate must not make a 1s/8-sample play consume 2 semantic seconds.
+    with tempconfig({"frame_rate": 8}):
+        scene.wait(1, frozen_frame=False)
+    assert scene.time == 1
+
+
+def test_skipped_stop_wait_keeps_legacy_nominal_span(scene):
+    manager = scene._get_manager()
+    manager.time = 2
+    scene.renderer._original_skipping_status = True
+    stops = []
+
+    def stop():
+        stops.append(scene.time)
+        return scene.time >= 3
+
+    scene.wait(1, stop_condition=stop)
+    assert stops == [3]
+    assert scene.time == 3

--- a/tests/module/test_execution_ownership.py
+++ b/tests/module/test_execution_ownership.py
@@ -28,47 +28,24 @@ def scene(request):
             scene._get_manager().close()
 
 
-def test_renderer_bootstrap_is_transferred_not_mirrored(scene):
+def test_renderer_compatibility_preserves_bootstrap_and_manager_updates(scene):
     renderer = scene.renderer
     assert scene.manager is None
-    initial = renderer._pending_execution
     renderer.time = 2
     manager = Manager(scene)
-    assert manager._execution is initial
-    assert renderer._pending_execution is None
     assert manager.time == 2
     manager.time = 3
     assert renderer.time == 3
+    renderer.time = 4
+    assert manager.time == 4
     renderer.num_plays = 4
     assert manager.num_plays == 4
+    manager.num_plays = 5
+    assert renderer.num_plays == 5
     renderer.skip_animations = True
     assert manager.skip_animations
-    assert "time" not in renderer.__dict__
-    assert "num_plays" not in renderer.__dict__
-
-
-def test_manager_does_not_delegate_play_or_selection_to_backend(scene, monkeypatch):
-    rejected = Mock(side_effect=AssertionError("backend executed policy"))
-    monkeypatch.setattr(scene.renderer, "play", rejected)
-    monkeypatch.setattr(scene.renderer, "update_skipping_status", rejected)
-    # Even an old subclass method with this name is no longer the execution seam.
-    monkeypatch.setattr(scene, "play_internal", rejected, raising=False)
-    scene.play(Wait(1, frozen_frame=False))
-    assert scene.manager.num_plays == 1
-    rejected.assert_not_called()
-
-
-def test_late_manager_cannot_claim_a_rebound_renderers_state(scene):
-    old = Scene()
-    current = Scene(renderer=old.renderer)
-    try:
-        with pytest.raises(RuntimeError, match="renderer was rebound"):
-            Manager(old)
-        assert old.manager is None
-        with current._get_manager() as manager:
-            assert manager.time == 0
-    finally:
-        current.renderer.close()
+    manager.skip_animations = False
+    assert not renderer.skip_animations
 
 
 def test_closed_backend_rejected_before_output_startup(scene):
@@ -150,13 +127,10 @@ def test_cached_play_advances_once_before_begin(scene, monkeypatch):
     assert manager.time == 2.5
 
 
-def test_frozen_clock_does_not_depend_on_output_delivery(scene, monkeypatch):
+def test_frozen_clock_does_not_depend_on_output_delivery(scene):
     manager = scene._get_manager()
-    write = Mock()
-    monkeypatch.setattr(manager.file_writer, "write_frame", write)
-    with tempconfig({"format": "none"}):
-        scene.wait(0.3, frozen_frame=True)
-        scene.wait(0.3, frozen_frame=True)
+    scene.wait(0.3, frozen_frame=True)
+    scene.wait(0.3, frozen_frame=True)
     assert manager.time == 0.5
 
 

--- a/tests/module/test_execution_ownership.py
+++ b/tests/module/test_execution_ownership.py
@@ -1,0 +1,80 @@
+"""Execution state and orchestration have one owner, independent of pixel delivery."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from manim import Manager, Scene, Square, Wait, tempconfig
+
+
+@pytest.fixture(params=["cairo", "opengl"])
+def scene(request):
+    with tempconfig(
+        {
+            "renderer": request.param,
+            "format": "none",
+            "live_preview": False,
+            "pixel_width": 32,
+            "pixel_height": 16,
+            "frame_rate": 4,
+            "disable_caching": True,
+            "progress_bar": "none",
+        }
+    ):
+        scene = Scene()
+        try:
+            yield scene
+        finally:
+            scene._get_manager().close()
+
+
+def test_renderer_bootstrap_is_transferred_not_mirrored(scene):
+    renderer = scene.renderer
+    assert scene.manager is None
+    initial = renderer._pending_execution
+    renderer.time = 2
+    manager = Manager(scene)
+    assert manager._execution is initial
+    assert renderer._pending_execution is None
+    assert manager.time == 2
+    manager.time = 3
+    assert renderer.time == 3
+    renderer.num_plays = 4
+    assert manager.num_plays == 4
+    renderer.skip_animations = True
+    assert manager.skip_animations
+    assert "time" not in renderer.__dict__
+    assert "num_plays" not in renderer.__dict__
+
+
+def test_manager_does_not_delegate_play_or_selection_to_backend(scene, monkeypatch):
+    rejected = Mock(side_effect=AssertionError("backend executed policy"))
+    monkeypatch.setattr(scene.renderer, "play", rejected)
+    monkeypatch.setattr(scene.renderer, "update_skipping_status", rejected)
+    scene.play(Wait(1, frozen_frame=False))
+    assert scene.manager.num_plays == 1
+    rejected.assert_not_called()
+
+
+def test_clock_advances_when_drawing_and_delivery_are_stubbed(scene, monkeypatch):
+    manager = scene._get_manager()
+    draw = Mock(return_value=None)
+    deliver = Mock()
+    monkeypatch.setattr(manager, "_draw_animation_frame", draw)
+    monkeypatch.setattr(manager, "_deliver_animation_frame", deliver)
+    scene.play(Wait(1, frozen_frame=False))
+    assert manager.time == 1
+    assert manager.num_plays == 1
+    assert draw.call_count == 4
+    assert deliver.call_count == 4
+
+
+def test_raw_backend_drawing_does_not_advance_clock_or_write(scene, monkeypatch):
+    scene.add(Square())
+    manager = scene._get_manager()
+    manager.time = 2
+    write = Mock(side_effect=AssertionError("drawing delivered output"))
+    monkeypatch.setattr(manager.file_writer, "write_frame", write)
+    scene.renderer.render(scene, 0, scene.mobjects)
+    assert manager.time == 2
+    write.assert_not_called()

--- a/tests/module/test_execution_traces.py
+++ b/tests/module/test_execution_traces.py
@@ -1,0 +1,121 @@
+"""Characterize legacy execution before moving its owner (not a new schedule)."""
+
+import pytest
+
+from manim import Animation, Scene, Square, tempconfig
+
+
+@pytest.mark.parametrize("backend", ["cairo", "opengl"])
+@pytest.mark.parametrize("duration", [1, 0.3])
+@pytest.mark.parametrize("skip", [False, True])
+def test_legacy_animation_clock_trace(backend, duration, skip):
+    trace = []
+    with tempconfig(
+        {
+            "renderer": backend,
+            "format": "none",
+            "live_preview": False,
+            "pixel_width": 32,
+            "pixel_height": 16,
+            "frame_rate": 4,
+            "disable_caching": True,
+            "progress_bar": "none",
+        }
+    ):
+        scene = Scene(skip_animations=skip)
+        # OpenGL historically ignores Scene's skip_animations constructor argument.
+        scene.renderer._original_skipping_status = skip
+        scene.add(Square())
+
+        class Probe(Animation):
+            def begin(self):
+                trace.append(("begin", scene.time))
+                super().begin()
+
+            def interpolate_mobject(self, alpha):
+                trace.append(("interpolate", scene.time, float(alpha)))
+
+            def finish(self):
+                trace.append(("finish", scene.time))
+                super().finish()
+
+            def clean_up_from_scene(self, scene):
+                trace.append(("cleanup", scene.time))
+                super().clean_up_from_scene(scene)
+
+        scene.add_updater(lambda dt: trace.append(("update", scene.time, float(dt))))
+        with scene._get_manager():
+            scene.play(Probe(scene.mobjects[0], run_time=duration))
+            final_time = scene.time
+            plays = scene.renderer.num_plays
+
+    count = 4 if duration == 1 else 2
+    start = duration if skip and backend == "cairo" else 0
+    assert trace[:2] == [("begin", start), ("interpolate", start, 0)]
+    updates = [item for item in trace if item[0] == "update"]
+    if skip:
+        assert updates == [("update", start, duration)]
+    else:
+        expected = [
+            ("update", i / 4 if backend == "cairo" else 0, 0 if i == 0 else 0.25)
+            for i in range(count)
+        ]
+        assert updates == expected
+    finish_time = (duration if skip else count / 4) if backend == "cairo" else 0
+    assert ("finish", finish_time) in trace
+    assert ("cleanup", finish_time) in trace
+    assert final_time == (count / 4 if backend == "cairo" and not skip else duration)
+    assert plays == 1
+
+
+@pytest.mark.parametrize("backend", ["cairo", "opengl"])
+def test_legacy_frozen_wait_clock_trace(backend):
+    with tempconfig(
+        {
+            "renderer": backend,
+            "format": "none",
+            "live_preview": False,
+            "pixel_width": 32,
+            "pixel_height": 16,
+            "frame_rate": 4,
+            "disable_caching": True,
+            "progress_bar": "none",
+        }
+    ):
+        scene = Scene()
+        with scene._get_manager():
+            scene.wait(0.3, frozen_frame=True)
+            assert scene.time == (0.25 if backend == "cairo" else 0.3)
+            assert scene.renderer.num_plays == 1
+
+
+@pytest.mark.parametrize("backend", ["cairo", "opengl"])
+def test_legacy_stop_condition_observes_backend_time(backend):
+    stops = []
+    updates = []
+    with tempconfig(
+        {
+            "renderer": backend,
+            "format": "none",
+            "live_preview": False,
+            "pixel_width": 32,
+            "pixel_height": 16,
+            "frame_rate": 4,
+            "disable_caching": True,
+            "progress_bar": "none",
+        }
+    ):
+        scene = Scene()
+        scene.add_updater(lambda dt: updates.append((scene.time, float(dt))))
+
+        def stop():
+            stops.append(scene.time)
+            return len(stops) == 2
+
+        with scene._get_manager():
+            scene.wait(1, stop_condition=stop)
+            assert scene.time == (0.5 if backend == "cairo" else 1)
+    assert stops == ([0.25, 0.5] if backend == "cairo" else [0, 0])
+    assert updates == (
+        [(0, 0), (0.25, 0.25)] if backend == "cairo" else [(0, 0), (0, 0.25)]
+    )

--- a/tests/module/test_execution_traces.py
+++ b/tests/module/test_execution_traces.py
@@ -1,4 +1,4 @@
-"""Characterize legacy execution before moving its owner (not a new schedule)."""
+"""Common Manager clock contract; legacy traces are preserved in 30a72b67."""
 
 import pytest
 
@@ -8,7 +8,7 @@ from manim import Animation, Scene, Square, tempconfig
 @pytest.mark.parametrize("backend", ["cairo", "opengl"])
 @pytest.mark.parametrize("duration", [1, 0.3])
 @pytest.mark.parametrize("skip", [False, True])
-def test_legacy_animation_clock_trace(backend, duration, skip):
+def test_animation_clock_trace(backend, duration, skip):
     trace = []
     with tempconfig(
         {
@@ -50,26 +50,23 @@ def test_legacy_animation_clock_trace(backend, duration, skip):
             plays = scene.renderer.num_plays
 
     count = 4 if duration == 1 else 2
-    start = duration if skip and backend == "cairo" else 0
+    start = duration if skip else 0
     assert trace[:2] == [("begin", start), ("interpolate", start, 0)]
     updates = [item for item in trace if item[0] == "update"]
     if skip:
         assert updates == [("update", start, duration)]
     else:
-        expected = [
-            ("update", i / 4 if backend == "cairo" else 0, 0 if i == 0 else 0.25)
-            for i in range(count)
-        ]
+        expected = [("update", i / 4, 0 if i == 0 else 0.25) for i in range(count)]
         assert updates == expected
-    finish_time = (duration if skip else count / 4) if backend == "cairo" else 0
+    finish_time = duration if skip else count / 4
     assert ("finish", finish_time) in trace
     assert ("cleanup", finish_time) in trace
-    assert final_time == (count / 4 if backend == "cairo" and not skip else duration)
+    assert final_time == (duration if skip else count / 4)
     assert plays == 1
 
 
 @pytest.mark.parametrize("backend", ["cairo", "opengl"])
-def test_legacy_frozen_wait_clock_trace(backend):
+def test_frozen_wait_clock_trace(backend):
     with tempconfig(
         {
             "renderer": backend,
@@ -85,12 +82,12 @@ def test_legacy_frozen_wait_clock_trace(backend):
         scene = Scene()
         with scene._get_manager():
             scene.wait(0.3, frozen_frame=True)
-            assert scene.time == (0.25 if backend == "cairo" else 0.3)
+            assert scene.time == 0.25
             assert scene.renderer.num_plays == 1
 
 
 @pytest.mark.parametrize("backend", ["cairo", "opengl"])
-def test_legacy_stop_condition_observes_backend_time(backend):
+def test_stop_condition_observes_consumed_time(backend):
     stops = []
     updates = []
     with tempconfig(
@@ -114,8 +111,6 @@ def test_legacy_stop_condition_observes_backend_time(backend):
 
         with scene._get_manager():
             scene.wait(1, stop_condition=stop)
-            assert scene.time == (0.5 if backend == "cairo" else 1)
-    assert stops == ([0.25, 0.5] if backend == "cairo" else [0, 0])
-    assert updates == (
-        [(0, 0), (0.25, 0.25)] if backend == "cairo" else [(0, 0), (0, 0.25)]
-    )
+            assert scene.time == 0.5
+    assert stops == [0.25, 0.5]
+    assert updates == [(0, 0), (0.25, 0.25)]

--- a/tests/module/test_execution_traces.py
+++ b/tests/module/test_execution_traces.py
@@ -1,4 +1,4 @@
-"""Common Manager clock contract; legacy traces are preserved in 30a72b67."""
+"""Cairo and OpenGL expose the same animation times to user code."""
 
 import pytest
 

--- a/tests/module/test_manager.py
+++ b/tests/module/test_manager.py
@@ -12,6 +12,7 @@ from manim import Manager, Scene, tempconfig
 from manim._config.output import OutputFormat
 from manim.animation.animation import Wait
 from manim.constants import RendererType
+from manim.renderer._execution import _ExecutionState
 from manim.renderer.protocol import RendererCapabilities
 from manim.scene.scene import SceneInteractRerun
 from manim.utils.exceptions import EndSceneEarlyException, RerunSceneException
@@ -69,6 +70,7 @@ def test_manager_rejects_explicit_video_for_scene_without_play_calls(
 ):
     config.format = output_format
     renderer = Mock()
+    renderer._claim_execution.return_value = _ExecutionState()
     renderer.capabilities = RendererCapabilities()
     renderer.num_plays = 0
     scene = Scene(renderer)
@@ -86,6 +88,7 @@ def test_manager_rejects_explicit_video_for_scene_without_play_calls(
 def test_manager_warns_when_automatic_video_falls_back_to_still(config):
     config.format = "auto"
     renderer = Mock()
+    renderer._claim_execution.return_value = _ExecutionState()
     renderer.capabilities = RendererCapabilities()
     renderer.num_plays = 0
     scene = Scene(renderer)
@@ -259,7 +262,7 @@ def test_scene_play_adds_subcaption_with_explicit_duration(dry_run, monkeypatch)
     renderer_play = Mock(
         side_effect=lambda *args, **kwargs: setattr(scene.renderer, "time", 4.5)
     )
-    monkeypatch.setattr(scene.renderer, "play", renderer_play)
+    monkeypatch.setattr(scene._get_manager(), "_play", renderer_play)
     animation = Wait()
 
     scene.play(
@@ -294,7 +297,7 @@ def test_scene_play_preserves_scene_add_subcaption_override(dry_run, monkeypatch
     renderer_play = Mock(
         side_effect=lambda *args, **kwargs: setattr(scene.renderer, "time", 4.5)
     )
-    monkeypatch.setattr(scene.renderer, "play", renderer_play)
+    monkeypatch.setattr(scene._get_manager(), "_play", renderer_play)
 
     scene.play(
         Wait(),
@@ -316,7 +319,7 @@ def test_scene_play_uses_animation_duration_for_default_subcaption_after_skip(
     renderer_play = Mock(
         side_effect=lambda *args, **kwargs: setattr(scene.renderer, "time", 3.5)
     )
-    monkeypatch.setattr(scene.renderer, "play", renderer_play)
+    monkeypatch.setattr(scene._get_manager(), "_play", renderer_play)
 
     scene.play(Wait(), subcaption="Hello")
 

--- a/tests/module/test_manager.py
+++ b/tests/module/test_manager.py
@@ -234,7 +234,7 @@ def test_manager_render_retires_rerun_without_finishing_scene(dry_run, monkeypat
 
 def test_manager_render_finalizes_after_early_scene_end(dry_run):
     lifecycle: list[str] = []
-    renderer = Mock()
+    renderer = Mock(_closed=False, _retiring=False)
     renderer.num_plays = 0
     renderer.scene_finished.side_effect = lambda scene: lifecycle.append(
         "post_construct"

--- a/tests/module/test_manager_preview.py
+++ b/tests/module/test_manager_preview.py
@@ -1,0 +1,56 @@
+"""Interactive redraws still deliver/present, but never consume semantic time."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from manim import Scene, tempconfig
+
+
+@pytest.fixture
+def scene():
+    with tempconfig({"renderer": "opengl", "format": "none", "live_preview": True}):
+        scene = Scene()
+        with scene._get_manager():
+            yield scene
+
+
+def test_preview_presents_without_advancing_time(scene, monkeypatch):
+    manager = scene.manager
+    manager.time = 2
+    draw = Mock(return_value=None)
+    monkeypatch.setattr(manager, "_draw_animation_frame", draw)
+    window = Mock()
+    monkeypatch.setattr(scene.renderer, "window", window)
+    manager._render_preview_frame(-1)
+    draw.assert_called_once_with(-1)
+    window.swap_buffers.assert_called_once_with()
+    assert scene.time == 2
+
+
+def test_embed_redraws_through_manager_before_and_after_commands(scene, monkeypatch):
+    redraw = Mock()
+    monkeypatch.setattr(scene.manager, "_render_preview_frame", redraw)
+    shell = Mock()
+    monkeypatch.setattr("IPython.terminal.embed.InteractiveShellEmbed", lambda: shell)
+    with pytest.raises(Exception, match="Exiting scene"):
+        scene.embed()
+    redraw.assert_called_once_with(-1)
+    event, callback = shell.events.register.call_args.args
+    assert event == "post_run_cell"
+    callback()
+    assert redraw.call_count == 2
+    assert scene.time == 0
+
+
+def test_interactive_idle_redraw_uses_manager(scene, monkeypatch):
+    monkeypatch.setattr("manim.scene.scene.Observer", Mock())
+
+    def redraw(_):
+        scene.quit_interaction = True
+
+    redraw = Mock(side_effect=redraw)
+    monkeypatch.setattr(scene.manager, "_render_preview_frame", redraw)
+    scene.interact(Mock(pt_app=None), Mock())
+    redraw.assert_called_once()
+    assert scene.time == 0

--- a/tests/module/test_manager_preview.py
+++ b/tests/module/test_manager_preview.py
@@ -1,4 +1,4 @@
-"""Interactive redraws still deliver/present, but never consume semantic time."""
+"""Interactive redraws display frames without advancing animation time."""
 
 from unittest.mock import Mock
 

--- a/tests/module/utils/test_caching.py
+++ b/tests/module/utils/test_caching.py
@@ -123,12 +123,15 @@ def test_opengl_cache_inputs_and_per_play_policy(monkeypatch):
         def __init__(self):
             self.mobjects = [object()]
             self.meshes = [object()]
-            self.session_spec = Mock(video_encoder=encoder, output=Mock(is_still=False))
+            self.session_spec = Mock(
+                video_encoder=encoder, output=Mock(is_still=False), frame_rate=60.0
+            )
+            self.stop_condition = None
+            self.animations = []
             self.manager = None
             self.duration = 1
             self.compile_animation_data = Mock()
             self.begin_animations = Mock()
-            self.play_internal = Mock()
             self.is_current_animation_frozen_frame = Mock(return_value=False)
 
         def compile_animations(self, *args, **kwargs):
@@ -147,7 +150,17 @@ def test_opengl_cache_inputs_and_per_play_policy(monkeypatch):
         file_writer = Mock(
             sections=[Mock(skip_animations=False)], output_spec=Mock(is_still=False)
         )
-        open = Mock()
+        _closed = False
+        _start_animation = Mock()
+        _prepare_animation = Mock()
+        _is_bound_to = Mock(return_value=True)
+
+        def _animation_cache_identity(self, scene):
+            return "opengl", {
+                "meshes": scene.meshes,
+                "background_color": self.background_color,
+                "anti_alias_width": self.anti_alias_width,
+            }
 
     scene = FakeScene()
     renderer = FakeRenderer()
@@ -156,12 +169,13 @@ def test_opengl_cache_inputs_and_per_play_policy(monkeypatch):
     scene.renderer = renderer
     manager = Manager(scene)
     manager._file_writer = renderer.file_writer
+    manager._play_internal = Mock()
 
-    with tempconfig({"disable_caching": False}):
-        manager._play_opengl()
+    with tempconfig({"disable_caching": False, "frame_rate": 60}):
+        manager._play()
         with tempconfig({"disable_caching": True}):
-            manager._play_opengl()
-        manager._play_opengl()
+            manager._play()
+        manager._play()
 
     assert fingerprint.call_args_list == [call(encoder), call(encoder)]
     assert hash_play.call_count == 2
@@ -169,10 +183,17 @@ def test_opengl_cache_inputs_and_per_play_policy(monkeypatch):
         "backend": "opengl",
         "encoder_fingerprint": "encoder-token",
         "renderer_state": {
-            "meshes": scene.meshes,
-            "background_color": renderer.background_color,
-            "anti_alias_width": renderer.anti_alias_width,
-            "execution_clock": "sample-v1",
+            "drawing": {
+                "meshes": scene.meshes,
+                "background_color": renderer.background_color,
+                "anti_alias_width": renderer.anti_alias_width,
+            },
+            "execution": {
+                "clock": "sample-v2",
+                "time": 0,
+                "play_index": 2,
+                "frame_rate": 60.0,
+            },
         },
     }
     assert renderer.animations_hashes == [

--- a/tests/module/utils/test_caching.py
+++ b/tests/module/utils/test_caching.py
@@ -172,6 +172,7 @@ def test_opengl_cache_inputs_and_per_play_policy(monkeypatch):
             "meshes": scene.meshes,
             "background_color": renderer.background_color,
             "anti_alias_width": renderer.anti_alias_width,
+            "execution_clock": "sample-v1",
         },
     }
     assert renderer.animations_hashes == [

--- a/tests/module/utils/test_caching.py
+++ b/tests/module/utils/test_caching.py
@@ -5,11 +5,12 @@ from unittest.mock import Mock, call
 
 import numpy as np
 
-from manim import tempconfig
+import manim.manager as manager_module
+from manim import Manager, tempconfig
+from manim.renderer._execution import _RendererExecutionView
 from manim.utils import caching
 from manim.utils.caching import (
     clear_segment_cache,
-    handle_caching_play,
     prune_segment_cache,
 )
 
@@ -115,14 +116,20 @@ def test_opengl_cache_inputs_and_per_play_policy(monkeypatch):
     encoder = object()
     fingerprint = Mock(return_value="encoder-token")
     hash_play = Mock(return_value="cache-key")
-    monkeypatch.setattr(caching, "video_encoder_fingerprint", fingerprint)
-    monkeypatch.setattr(caching, "get_hash_from_play_call", hash_play)
+    monkeypatch.setattr(manager_module, "video_encoder_fingerprint", fingerprint)
+    monkeypatch.setattr(manager_module, "get_hash_from_play_call", hash_play)
 
     class FakeScene:
         def __init__(self):
             self.mobjects = [object()]
             self.meshes = [object()]
-            self.session_spec = Mock(video_encoder=encoder)
+            self.session_spec = Mock(video_encoder=encoder, output=Mock(is_still=False))
+            self.manager = None
+            self.duration = 1
+            self.compile_animation_data = Mock()
+            self.begin_animations = Mock()
+            self.play_internal = Mock()
+            self.is_current_animation_frozen_frame = Mock(return_value=False)
 
         def compile_animations(self, *args, **kwargs):
             return []
@@ -130,33 +137,31 @@ def test_opengl_cache_inputs_and_per_play_policy(monkeypatch):
         def add_mobjects_from_animations(self, animations):
             pass
 
-    class FakeRenderer:
-        _original_skipping_status = False
-        skip_animations = False
-        num_plays = 0
-        animations_hashes = []
+    class FakeRenderer(_RendererExecutionView):
+        def __init__(self):
+            self._initialize_execution(False)
+
         camera = object()
         background_color = np.array([0.1, 0.2, 0.3, 1.0])
         anti_alias_width = 1.5
-        file_writer = Mock()
-
-        def update_skipping_status(self):
-            pass
-
-        @handle_caching_play
-        def play(self, scene, *args, **kwargs):
-            self.num_plays += 1
+        file_writer = Mock(
+            sections=[Mock(skip_animations=False)], output_spec=Mock(is_still=False)
+        )
+        open = Mock()
 
     scene = FakeScene()
     renderer = FakeRenderer()
     renderer.animations_hashes = []
     renderer.file_writer.is_already_cached.side_effect = [False, True]
+    scene.renderer = renderer
+    manager = Manager(scene)
+    manager._file_writer = renderer.file_writer
 
     with tempconfig({"disable_caching": False}):
-        renderer.play(scene)
+        manager._play_opengl()
         with tempconfig({"disable_caching": True}):
-            renderer.play(scene)
-        renderer.play(scene)
+            manager._play_opengl()
+        manager._play_opengl()
 
     assert fingerprint.call_args_list == [call(encoder), call(encoder)]
     assert hash_play.call_count == 2

--- a/tests/module/utils/test_caching.py
+++ b/tests/module/utils/test_caching.py
@@ -153,7 +153,6 @@ def test_opengl_cache_inputs_and_per_play_policy(monkeypatch):
         _closed = False
         _start_animation = Mock()
         _prepare_animation = Mock()
-        _is_bound_to = Mock(return_value=True)
 
         def _animation_cache_identity(self, scene):
             return "opengl", {

--- a/tests/test_scene_rendering/test_cairo_renderer.py
+++ b/tests/test_scene_rendering/test_cairo_renderer.py
@@ -16,9 +16,7 @@ def test_render(using_temp_config, disabling_caching):
     renderer.update_frame = Mock(wraps=renderer.update_frame)
     writer = scene._get_manager().file_writer
     writer.write_frame = Mock(wraps=writer.write_frame)
-    renderer.add_frame = Mock(side_effect=AssertionError("backend advanced execution"))
     scene.render()
-    renderer.add_frame.assert_not_called()
     assert writer.write_frame.call_count == config["frame_rate"]
     assert renderer.update_frame.call_count == config["frame_rate"]
     assert_file_exists(renderer.file_writer.final_file_path)

--- a/tests/test_scene_rendering/test_cairo_renderer.py
+++ b/tests/test_scene_rendering/test_cairo_renderer.py
@@ -14,9 +14,12 @@ def test_render(using_temp_config, disabling_caching):
     scene = SquareToCircle()
     renderer = scene.renderer
     renderer.update_frame = Mock(wraps=renderer.update_frame)
-    renderer.add_frame = Mock(wraps=renderer.add_frame)
+    writer = scene._get_manager().file_writer
+    writer.write_frame = Mock(wraps=writer.write_frame)
+    renderer.add_frame = Mock(side_effect=AssertionError("backend advanced execution"))
     scene.render()
-    assert renderer.add_frame.call_count == config["frame_rate"]
+    renderer.add_frame.assert_not_called()
+    assert writer.write_frame.call_count == config["frame_rate"]
     assert renderer.update_frame.call_count == config["frame_rate"]
     assert_file_exists(renderer.file_writer.final_file_path)
     assert config.output_file == ""
@@ -88,7 +91,7 @@ def test_hash_logic_is_not_called_when_caching_is_disabled(
     using_temp_config,
     disabling_caching,
 ):
-    with patch("manim.renderer.cairo.renderer.get_hash_from_play_call") as mocked:
+    with patch("manim.manager.get_hash_from_play_call") as mocked:
         scene = SquareToCircle()
         scene.render()
         mocked.assert_not_called()
@@ -96,10 +99,10 @@ def test_hash_logic_is_not_called_when_caching_is_disabled(
 
 
 def test_hash_logic_is_called_when_caching_is_enabled(using_temp_config):
-    from manim.renderer.cairo.renderer import get_hash_from_play_call
+    from manim.manager import get_hash_from_play_call
 
     with patch(
-        "manim.renderer.cairo.renderer.get_hash_from_play_call",
+        "manim.manager.get_hash_from_play_call",
         wraps=get_hash_from_play_call,
     ) as mocked:
         scene = SquareToCircle()

--- a/tests/test_scene_rendering/test_manager_cache_clock.py
+++ b/tests/test_scene_rendering/test_manager_cache_clock.py
@@ -1,0 +1,133 @@
+"""Real segment reuse must preserve the engine time visible to user code."""
+
+from unittest.mock import Mock
+
+import av
+import numpy as np
+import pytest
+
+from manim import Animation, Scene, Square, tempconfig
+
+
+class TimeDriven(Animation):
+    def __init__(self, mobject, scene):
+        self.scene = scene
+        super().__init__(mobject, run_time=0.3)
+
+    def interpolate_mobject(self, alpha):
+        self.mobject.set_x(self.scene.time)
+
+
+class TimeDrivenScene(Scene):
+    def construct(self):
+        for _ in range(4):
+            square = Square(side_length=0.5)
+            self.add(square)
+            self.play(TimeDriven(square, self))
+            self.remove(square)
+
+
+def decoded_frames(path):
+    with av.open(str(path)) as video:
+        return [frame.to_ndarray(format="rgba") for frame in video.decode(video=0)]
+
+
+@pytest.mark.parametrize("backend", ["cairo", "opengl"])
+def test_time_dependent_cache_and_fractional_downstream_epochs(tmp_path, backend):
+    with tempconfig(
+        {
+            "renderer": backend,
+            "format": "mp4",
+            "media_dir": str(tmp_path),
+            "frame_rate": 4,
+            "pixel_width": 64,
+            "pixel_height": 32,
+            "live_preview": False,
+            "disable_caching": False,
+            "progress_bar": "none",
+        }
+    ):
+        cold = TimeDrivenScene()
+        cold.render()
+        reference = decoded_frames(cold.manager.file_writer.final_file_path)
+        assert cold.time == 2
+        assert len(set(cold.renderer.animations_hashes)) == 4
+        assert len(reference) == 8
+        assert not np.array_equal(reference[4], reference[6])
+
+        warm = TimeDrivenScene()
+        writer = warm._get_manager().file_writer
+        hits = []
+        lookup = writer.is_already_cached
+
+        def cached(key):
+            result = lookup(key)
+            hits.append(result)
+            return result
+
+        writer.is_already_cached = cached
+        warm.render()
+        assert any(hits)
+        assert warm.time == cold.time
+        actual = decoded_frames(writer.final_file_path)
+        np.testing.assert_array_equal(actual, reference)
+
+        with tempconfig({"disable_caching": True}):
+            uncached = TimeDrivenScene()
+            uncached.render()
+        assert uncached.time == cold.time
+        np.testing.assert_array_equal(
+            decoded_frames(uncached.manager.file_writer.final_file_path), reference
+        )
+
+
+@pytest.mark.parametrize("backend", ["cairo", "opengl"])
+def test_rate_change_cannot_publish_mismatched_video(tmp_path, backend):
+    with tempconfig(
+        {
+            "renderer": backend,
+            "format": "mp4",
+            "media_dir": str(tmp_path),
+            "frame_rate": 4,
+            "pixel_width": 64,
+            "pixel_height": 32,
+            "live_preview": False,
+        }
+    ):
+        scene = TimeDrivenScene()
+        manager = scene._get_manager()
+        try:
+            with (
+                tempconfig({"frame_rate": 8}),
+                pytest.raises(ValueError, match="frame_rate changed"),
+            ):
+                scene.render()
+            assert manager._file_writer is None
+            assert not list(tmp_path.rglob("*.mp4"))
+        finally:
+            manager.close()
+
+
+@pytest.mark.parametrize("backend", ["cairo", "opengl"])
+def test_stopped_events_do_not_reuse_an_unknown_cached_span(backend, monkeypatch):
+    with tempconfig(
+        {
+            "renderer": backend,
+            "format": "none",
+            "frame_rate": 4,
+            "pixel_width": 32,
+            "pixel_height": 16,
+            "live_preview": False,
+            "disable_caching": False,
+            "progress_bar": "none",
+        }
+    ):
+        scene = Scene()
+        with scene._get_manager() as manager:
+            lookup = Mock(
+                side_effect=AssertionError("stop span is not in cache metadata")
+            )
+            monkeypatch.setattr(manager.file_writer, "is_already_cached", lookup)
+            scene.wait(1, stop_condition=lambda: scene.time >= 0.5)
+            assert scene.time == 0.5
+            lookup.assert_not_called()

--- a/tests/test_scene_rendering/test_parallel_encoding.py
+++ b/tests/test_scene_rendering/test_parallel_encoding.py
@@ -130,9 +130,9 @@ def test_parallel_encoding_cache_behavior(tmp_path):
     scene_file = tmp_path / "parallel_encoding_scenes.py"
     scene_file.write_text(_SCENE_SOURCE)
 
-    # Equal geometry at different execution epochs no longer implies equal
-    # pixels. Reuse is checked on a second render of the same timeline below;
-    # the writer's in-flight lookup is covered separately at the writer boundary.
+    # Identical geometry can produce different pixels at different scene times.
+    # Check cache reuse by rendering the same scene again below. Separate writer
+    # tests cover cache lookups while a matching segment is still being encoded.
     media_dir = tmp_path / "media"
     quality_directory, partial_directory = _render_scene(media_dir, scene_file)
     partial_movies = sorted(partial_directory.glob("*.mp4"))
@@ -188,7 +188,7 @@ def test_disable_caching_is_evaluated_per_play(config, tmp_path):
     assert restored_hash is not None
     assert cached_hash is not None
     assert not cached_hash.startswith("uncached_")
-    assert cached_hash != restored_hash  # Different execution epoch, caching enabled.
+    assert cached_hash != restored_hash  # Different play index; caching is enabled.
 
 
 @pytest.mark.slow

--- a/tests/test_scene_rendering/test_parallel_encoding.py
+++ b/tests/test_scene_rendering/test_parallel_encoding.py
@@ -130,13 +130,13 @@ def test_parallel_encoding_cache_behavior(tmp_path):
     scene_file = tmp_path / "parallel_encoding_scenes.py"
     scene_file.write_text(_SCENE_SOURCE)
 
-    # The duplicate tail play must cache-hit within the run (one file fewer
-    # than the number of plays); that hit exercises the writer's in-flight
-    # lookup while the first tail file may still be encoding.
+    # Equal geometry at different execution epochs no longer implies equal
+    # pixels. Reuse is checked on a second render of the same timeline below;
+    # the writer's in-flight lookup is covered separately at the writer boundary.
     media_dir = tmp_path / "media"
     quality_directory, partial_directory = _render_scene(media_dir, scene_file)
     partial_movies = sorted(partial_directory.glob("*.mp4"))
-    assert len(partial_movies) == _TOTAL_PLAYS - 1
+    assert len(partial_movies) == _TOTAL_PLAYS
     assert (quality_directory / f"{_SCENE_NAME}.mp4").exists()
     for partial_movie in partial_movies:
         with av.open(partial_movie) as container:
@@ -186,7 +186,9 @@ def test_disable_caching_is_evaluated_per_play(config, tmp_path):
     assert initial_hash is not None
     assert uncached_hash == "uncached_00001"
     assert restored_hash is not None
-    assert cached_hash == restored_hash
+    assert cached_hash is not None
+    assert not cached_hash.startswith("uncached_")
+    assert cached_hash != restored_hash  # Different execution epoch, caching enabled.
 
 
 @pytest.mark.slow
@@ -668,7 +670,7 @@ def test_abort_encode_jobs_noop_on_dry_run_writer(config):
 
 
 def test_keyboard_interrupt_aborts_encode_jobs_and_reraises(config):
-    scene = Scene(renderer=Mock())
+    scene = Scene(renderer=Mock(_closed=False, _retiring=False))
     writer = scene._get_manager().file_writer
 
     def construct():
@@ -688,7 +690,7 @@ def test_rerun_propagates_encoder_failure(config, tmp_path):
     failing_inflight = Mock(path=tmp_path / "inflight.mp4")
     failing_inflight.join.side_effect = expected_exception
     _add_inflight_job(writer, failing_inflight)
-    scene = Scene(renderer=Mock())
+    scene = Scene(renderer=Mock(_closed=False, _retiring=False))
     scene._get_manager()._file_writer = writer
 
     def construct():
@@ -718,7 +720,7 @@ def test_rerun_propagates_failed_current_job(config, tmp_path):
             break
         time.sleep(0.01)
 
-    scene = Scene(renderer=Mock())
+    scene = Scene(renderer=Mock(_closed=False, _retiring=False))
     scene._get_manager()._file_writer = writer
 
     def construct():


### PR DESCRIPTION
## Overview: What does this pull request change?

Stacked on #5002.

This PR moves animation playback and the animation clock into `Manager`, using one play loop for Cairo and OpenGL. `Scene` prepares animations and updates mobjects; renderers draw frames and display the live preview; the manager decides what to play, advances time, and sends frames to the writer.

- Compile each play call once, with shared cache checks, skip handling, interpolation, updater calls, stop checks, and animation cleanup.
- Advance animation time independently of drawing, reading pixels, or writing frames. Interactive redraws continue to display frames without advancing the animation clock.
- Keep renderer properties such as `time`, `num_plays`, and `skip_animations` working by forwarding them to the manager's state, including values set before the manager was attached.
- Remove `Scene.play_internal` and the separate OpenGL caching decorator. The renderer `play()` methods delegate to the manager rather than implementing another scheduler.

## Motivation and Explanation: Why and how do your changes improve the library?

Previously, playback was split between the scene and two renderer implementations, and the backends advanced time differently. In Cairo, advancing time depended on frame output; OpenGL generally exposed the play call's start time until the animation ended. A common loop lets updaters and stop conditions use the same clock on either backend and separates animation progress from producing pixels.

### Timing and compatibility changes

- During normal playback, interpolation and updaters see the start of each frame interval. The manager advances the clock before writing the frame and checking the stop condition. Finish and cleanup see the time reached by the processed frames, including an early-stopped wait.
- Whole-frame rounding remains explicit: at 4 fps, a non-frozen 0.3-second animation takes two steps and advances 0.5 seconds; a frozen wait of the same duration repeats one frame and advances 0.25 seconds. OpenGL now follows the same sampled clock as Cairo.
- Cache hits advance by the frame-rounded duration of normal playback. Explicit skips retain nominal-duration fast-forwarding. Neither shortcut guarantees the same Python state as running every updater step.
- Segment cache keys include start time, play index, and frame rate. Earlier keys change, and identical geometry at different scene times no longer shares a segment. Repeated renders can still reuse matching segments. Waits with stop conditions are evaluated instead of reused from cache.
- Changing the frame rate after scene construction raises an error before playback. Create and render the scene inside the intended configuration context so sampling and encoding agree.

`Scene.play()` remains the normal entry point. Integrations that override `Scene.play_internal` or rely on the renderer's `play()` being called by the scene need updating. Direct renderer drawing no longer writes movie frames or advances animation time.

This is preparation for evaluation without rendering, not that evaluation API itself. No no-raster mode, timeline export, or targeted-frame API is added here.

## Links to added or changed documentation pages

- Updated the play-call and render-loop walkthrough in `docs/source/guides/deep_dive.rst`, including a frame-timing table and configuration example.
- Updated the Manager, Scene, and renderer API descriptions.