### PR TITLE
Add missing typst mobject module reference

### DIFF
--- a/docs/source/guides/using_text.rst
+++ b/docs/source/guides/using_text.rst
@@ -19,7 +19,7 @@ information.
 Typst support is available via :class:`~.Typst` and
 :class:`~.MathTypst`. It offers both general markup and mathematical
 typesetting through the Typst compiler without requiring a TeX
-distribution. See :ref:`typst-mobjects` for more information.
+distribution. See :mod:`~.typst_mobject` for more information.
 
 .. _using-text-objects:
 
@@ -344,7 +344,7 @@ or via Manim's ``{{ ... }}`` shorthand in :class:`~.MathTypst`:
     eq.select("lhs").set_color(BLUE)
     eq.select(0).set_color(YELLOW)
 
-See :ref:`typst-mobjects` for more details and additional examples.
+See :mod:`~.typst_mobject` for more details and additional examples.
 
 .. _rendering-with-latex:
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -76,6 +76,7 @@ Mobjects
    manim.mobject.text.numbers
    manim.mobject.text.tex_mobject
    manim.mobject.text.text_mobject
+   manim.mobject.text.typst_mobject
    manim.mobject.types.image_mobject
    manim.mobject.types.point_cloud_mobject
    manim.mobject.types.vectorized_mobject


### PR DESCRIPTION
See title: we apparently forgot to include the typst module in the reference manual.