### PR TITLE
fix: use dynamic class name in CurvesAsSubmobjects errors

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -2856,8 +2856,9 @@ class CurvesAsSubmobjects(VGroup):
     def _throw_error_if_no_submobjects(self):
         if len(self.submobjects) == 0:
             caller_name = sys._getframe(1).f_code.co_name
+            class_name = type(self).__name__
             raise Exception(
-                f"Cannot call CurvesAsSubmobjects. {caller_name} for a CurvesAsSubmobject with no submobjects"
+                f"Cannot call {class_name}. {caller_name} for a {class_name} with no submobjects"
             )
 
     def _get_submobjects_with_points(self):
@@ -2866,8 +2867,9 @@ class CurvesAsSubmobjects(VGroup):
         )
         if len(submobjs_with_pts) == 0:
             caller_name = sys._getframe(1).f_code.co_name
+            class_name = type(self).__name__
             raise Exception(
-                f"Cannot call CurvesAsSubmobjects. {caller_name} for a CurvesAsSubmobject whose submobjects have no points"
+                f"Cannot call {class_name}. {caller_name} for a {class_name} whose submobjects have no points"
             )
         return submobjs_with_pts
 

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -171,7 +171,6 @@ def test_curves_as_submobjects_point_from_proportion():
     obj.add(VMobject())
     with pytest.raises(Exception, match="have no points"):
         obj.point_from_proportion(0)
-
     # submobject[0] is a line of length 4
     obj.submobjects[0].set_points_as_corners(
         [
@@ -190,6 +189,25 @@ def test_curves_as_submobjects_point_from_proportion():
 
     # point at proportion 0.5 should be at length 3, point [3, 0, 0]
     np.testing.assert_array_equal(obj.point_from_proportion(0.5), np.array([3, 0, 0]))
+
+
+def test_curves_as_submobjects_errors_use_dynamic_class_name():
+    class MyCurves(CurvesAsSubmobjects):
+        pass
+
+    obj = MyCurves(VGroup())
+    with pytest.raises(
+        Exception,
+        match=r"Cannot call MyCurves\. point_from_proportion for a MyCurves with no submobjects",
+    ):
+        obj.point_from_proportion(0)
+
+    obj.add(VMobject())
+    with pytest.raises(
+        Exception,
+        match=r"Cannot call MyCurves\. point_from_proportion for a MyCurves whose submobjects have no points",
+    ):
+        obj.point_from_proportion(0)
 
 
 def test_vgroup_init():


### PR DESCRIPTION
## Summary

`CurvesAsSubmobjects._throw_error_if_no_submobjects()` and `_get_submobjects_with_points()` raised errors with the hardcoded string `CurvesAsSubmobjects`, so error messages stayed wrong for subclasses or future renames.

Changes in `manim/mobject/types/vectorized_mobject.py`:

- Both messages now use `type(self).__name__`, so they report the actual class of the object that raised them (e.g. `Cannot call MyCurves. point_from_proportion for a MyCurves with no submobjects`).
- Message wording is otherwise unchanged.

## Tests

Added `test_curves_as_submobjects_errors_use_dynamic_class_name` in `tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py`, covering a `CurvesAsSubmobjects` subclass for both error paths and asserting the raised message contains the subclass name.

## Verification

```bash
pytest tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py -q   # 43 passed
ruff check manim/mobject/types/vectorized_mobject.py tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py   # clean
ruff format --check ...                                                               # clean
```

Fixes #4983.