### PR TITLE
Use dynamic class name in CurvesAsSubmobjects error messages

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -2856,8 +2856,9 @@ class CurvesAsSubmobjects(VGroup):
     def _throw_error_if_no_submobjects(self):
         if len(self.submobjects) == 0:
             caller_name = sys._getframe(1).f_code.co_name
+            cls = type(self).__name__
             raise Exception(
-                f"Cannot call CurvesAsSubmobjects. {caller_name} for a CurvesAsSubmobject with no submobjects"
+                f"Cannot call {cls}. {caller_name} for a CurvesAsSubmobject with no submobjects"
             )
 
     def _get_submobjects_with_points(self):
@@ -2866,8 +2867,9 @@ class CurvesAsSubmobjects(VGroup):
         )
         if len(submobjs_with_pts) == 0:
             caller_name = sys._getframe(1).f_code.co_name
+            cls = type(self).__name__
             raise Exception(
-                f"Cannot call CurvesAsSubmobjects. {caller_name} for a CurvesAsSubmobject whose submobjects have no points"
+                f"Cannot call {cls}. {caller_name} for a CurvesAsSubmobject whose submobjects have no points"
             )
         return submobjs_with_pts
 

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -192,6 +192,25 @@ def test_curves_as_submobjects_point_from_proportion():
     np.testing.assert_array_equal(obj.point_from_proportion(0.5), np.array([3, 0, 0]))
 
 
+def test_curves_as_submobjects_error_message_uses_dynamic_class_name():
+    """The error messages should reference the actual class name, not a
+    hardcoded "CurvesAsSubmobjects" string, so that subclasses are reported
+    correctly."""
+
+    class CustomCurves(CurvesAsSubmobjects):
+        pass
+
+    obj = CustomCurves(VGroup())
+    with pytest.raises(Exception, match="Cannot call CustomCurves") as error:
+        obj.point_from_proportion(0)
+    assert "CurvesAsSubmobjects" not in str(error.value)
+
+    obj.add(VMobject())
+    with pytest.raises(Exception, match="Cannot call CustomCurves") as error:
+        obj.point_from_proportion(0)
+    assert "CurvesAsSubmobjects" not in str(error.value)
+
+
 def test_vgroup_init():
     """Test the VGroup instantiation."""
     VGroup()

--- a/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
+++ b/tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py
@@ -195,7 +195,8 @@ def test_curves_as_submobjects_point_from_proportion():
 def test_curves_as_submobjects_error_message_uses_dynamic_class_name():
     """The error messages should reference the actual class name, not a
     hardcoded "CurvesAsSubmobjects" string, so that subclasses are reported
-    correctly."""
+    correctly.
+    """
 
     class CustomCurves(CurvesAsSubmobjects):
         pass


### PR DESCRIPTION
## Summary

Fixes #4983.

The two error messages in `_throw_error_if_no_submobjects` and `_get_submobjects_with_points` hardcoded the string `"CurvesAsSubmobjects"`. This PR uses `type(self).__name__` so the message automatically reflects any subclass and stays correct if the class is ever renamed (matching the existing pattern in `Mobject.throw_error_if_no_points`).

## Changes

- `manim/mobject/types/vectorized_mobject.py`: replace the hardcoded class name with `cls = type(self).__name__` in both error messages.
- `tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py`: added `test_curves_as_submobjects_error_message_uses_dynamic_class_name`, which subclasses `CurvesAsSubmobjects` and asserts the error reports the subclass name and no longer contains the hardcoded string.

## Test

```
pytest tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py::test_curves_as_submobjects_point_from_proportion tests/module/mobject/types/vectorized_mobject/test_vectorized_mobject.py::test_curves_as_submobjects_error_message_uses_dynamic_class_name
```
2 passed.